### PR TITLE
SSH Features: Reboot and SNMP Filter

### DIFF
--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-bigquery==3.12.0
 python-dateutil==2.8.2
 pytz==2023.3.post1
 Werkzeug==3.0.0
+fabric==3.2.2

--- a/services/api/src/ssh_commands.py
+++ b/services/api/src/ssh_commands.py
@@ -1,47 +1,68 @@
 from marshmallow import Schema, fields
-import requests
-import os
+from fabric import Connection, Config
 import logging
 
 def reboot(request):
-  rest_endpoint = os.environ["RSU_REST_ENDPOINT"]
   logging.info(f'Running command, POST reboot')
+  rsu_ip = request["rsu_ip"]
+  username = request["creds"]["username"]
+  password = request["creds"]["password"]
+
+  # Build configurations for ssh and sudo
+  fabric_config = Config(overrides={'sudo': {'password': password}})
+  kwargs = {'password': password}
   try:
-    body = {
-      "rsu_ip": request["rsu_ip"],
-      "username": request["creds"]["username"],
-      "password": request["creds"]["password"]
-    }
-    endpoint = f'http://{rest_endpoint}/reboot'
-    logging.info(f'Hitting the endpoint: {endpoint}')
-    r = requests.post(endpoint, body)
-    return r.json(), r.status_code
+    with Connection(rsu_ip, user=username, config=fabric_config, connect_kwargs=kwargs) as conn:
+      conn.sudo('reboot')
   except Exception as e:
-    logging.exception(f"Encountered an error: {e}")
-    return "Encountered an error with the command reboot", 500
+    # When rebooting, the connection will be dropped from the RSU's end
+    # Ignore the error when this happens
+    if e != '__enter__':
+      logging.error(f"Encountered an error: {e}")
+      return "failed", 500
+  
+  logging.info(f"Reboot successful")
+  return "succeeded", 200
 
 # Command to modify SNMP Message Forwarding configuration files on Commsignia RSUs
-# Forwards the work to the K8s RSU Automation API to perform modifications over SSH
 def snmpfilter(request):
-  rest_endpoint = os.environ["RSU_REST_ENDPOINT"]
   logging.info(f'Running command, POST snmpfilter')
-  try:
-    if request["manufacturer"] != "Commsignia":
-      logging.info(f'snmpfilter is not supported for RSUs of type {request["manufacturer"]}')
-      return "Target RSU is not of type Commsignia", 400
 
-    body = {
-      "rsu_ip": request["rsu_ip"],
-      "username": request["creds"]["username"],
-      "password": request["creds"]["password"]
-    }
-    endpoint = f'http://{rest_endpoint}/snmpfilter'
-    logging.info(f'Hitting the endpoint: {endpoint}')
-    r = requests.post(endpoint, body)
-    return r.json(), r.status_code
+  # First check if target RSU is not a Commsignia RSU
+  if request["manufacturer"] != "Commsignia":
+    logging.info(f'snmpfilter is not supported for RSUs of type {request["manufacturer"]}')
+    return "Target RSU is not of type Commsignia", 400
+
+  rsu_ip = request["rsu_ip"]
+  username = request["creds"]["username"]
+  password = request["creds"]["password"]
+
+  kwargs = {'password': password}
+  try:
+    with Connection(rsu_ip, user=username, connect_kwargs=kwargs) as conn:
+      fwd_configs = []
+      # Get all MAP files
+      output = conn.run('grep -rwl /rwdata/etc/data_logger_ftw -e \'"value":3758096407\'', warn=True, hide=True)
+      fwd_configs = fwd_configs + output.stdout.split('\n')[:-1]
+
+      # Get all SPaT files
+      output = conn.run('grep -rwl /rwdata/etc/data_logger_ftw -e \'"value":32770\'', warn=True, hide=True)
+      fwd_configs = fwd_configs + output.stdout.split('\n')[:-1]
+      
+      # Iterate through the data logger configs for MAP and SPaT and apply the filter for outgoing traffic only
+      # The Unix command, sed, is used for inline text editing. It substitutes strings in place
+      for config in fwd_configs:
+        logging.info('Applying filter to ' + config)
+        output = conn.run('sed -i \'s/"direction":"both"/"direction":"out"/g\' ' + config, hide=True)
+      
+      # Only if files were edited, reboot to force the RSU to apply the changes
+      if len(fwd_configs) != 0:
+        conn.run('reboot')
   except Exception as e:
-    logging.exception(f"Encountered an error: {e}")
-    return "Encountered an error with the command snmpfilter", 500
+    logging.error(f"Encountered an error: {e}")
+    return "filter failed to be applied", 500
+  
+  return "filter applied successfully", 200
 
 class OSUpdate(Schema):
   manufacturer = fields.Str(required=True)
@@ -54,37 +75,12 @@ class OSUpdate(Schema):
   rescue_bash_script = fields.Str(required=False)
 
 def osupdate(request):
-  rest_endpoint = os.environ["RSU_REST_ENDPOINT"]
   logging.info(f'Running command, POST osupdate')
   # Check if the args match what is needed for the snmpset command
   schema = OSUpdate()
   errors = schema.validate(request["args"])
   if errors:
     return f"The provided args does not match required values: {str(errors)}", 400
-  
-  try:
-    body = {
-      "rsu_ip": request["rsu_ip"],
-      "username": request["creds"]["username"],
-      "password": request["creds"]["password"],
-      "manufacturer": request["args"]["manufacturer"],
-      "model": request["args"]["model"],
-      "update_type": request["args"]["update_type"],
-      "update_name": request["args"]["update_name"],
-      "image_name": request["args"]["image_name"],
-      "bash_script": request["args"]["bash_script"]
-    }
-    if "rescue_name" in request["args"]:
-      body["rescue_name"] = request["args"]["rescue_name"]
-      body["rescue_bash_script"] = request["args"]["rescue_bash_script"]
-    
-    endpoint = f'http://{rest_endpoint}/osupdate'
-    logging.info(f'Hitting the endpoint: {endpoint}')
-    r = requests.post(endpoint, body)
-    return r.json(), r.status_code
-  except Exception as e:
-    logging.exception(f"Encountered an error: {e}")
-    return "Encountered an error with the command osupdate", 500
 
 class FWUpdate(Schema):
   manufacturer = fields.Str(required=True)
@@ -95,31 +91,9 @@ class FWUpdate(Schema):
   bash_script = fields.Str(required=True)
 
 def fwupdate(request):
-  rest_endpoint = os.environ["RSU_REST_ENDPOINT"]
   logging.info(f'Running command, POST fwupdate')
   # Check if the args match what is needed for the snmpset command
   schema = FWUpdate()
   errors = schema.validate(request["args"])
   if errors:
     return f"The provided args does not match required values: {str(errors)}", 400
-  
-  try:
-    body = {
-      "rsu_ip": request["rsu_ip"],
-      "username": request["creds"]["username"],
-      "password": request["creds"]["password"],
-      "manufacturer": request["args"]["manufacturer"],
-      "model": request["args"]["model"],
-      "update_type": request["args"]["update_type"],
-      "update_name": request["args"]["update_name"],
-      "image_name": request["args"]["image_name"],
-      "bash_script": request["args"]["bash_script"]
-    }
-    
-    endpoint = f'http://{rest_endpoint}/fwupdate'
-    logging.info(f'Hitting the endpoint: {endpoint}')
-    r = requests.post(endpoint, body)
-    return r.json(), r.status_code
-  except Exception as e:
-    logging.exception(f"Encountered an error: {e}")
-    return "Encountered an error with the command fwupdate", 500

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -22,3 +22,4 @@ pytz==2023.3.post1
 Werkzeug==3.0.0
 uuid==1.30
 multidict==6.0.4
+fabric==3.2.2


### PR DESCRIPTION
This includes a rework of the SSH based features of the RSU management of the CV Manager API. Previously this required a backend service that was hosted on private CDOT repositories. This has been pulled directly into the CV Manager API using the Python library 'fabric'.

Changes:
- Fully implement reboot and SNMP filtering as all-in-one solutions hosted directly in the CV Manager API.
- Write unit tests for the new functions.
- Update firmware and operating system update functions to no longer make calls to external endpoints. This will be addressed in the future to also be a self contained feature hosted in the API.
- Rework unit tests for fw and os updates to just check schema validation.