### PR TITLE
Update unit testing for timezone independence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build_api
-          path: services/coverage.xml
+          path: services/cov.xml
 
-      - name: Find coverage.xml
+      - name: Find cov.xml
         shell: bash
         run: |
-          find "$GITHUB_WORKSPACE/services" -name "coverage.xml"
+          find "$GITHUB_WORKSPACE/services" -name "cov.xml"
 
   webapp:
     runs-on: ubuntu-latest
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         with:
           name: build_api
-          path: services/coverage.xml
+          path: services/cov.xml
 
       - name: Download Code Coverage Results
         uses: actions/download-artifact@v3
@@ -97,10 +97,10 @@ jobs:
           name: webapp
           path: webapp
 
-      - name: Find coverage.xml
+      - name: Find cov.xml
         shell: bash
         run: |
-          find "$GITHUB_WORKSPACE" -name "coverage.xml"
+          find "$GITHUB_WORKSPACE" -name "cov.xml"
 
       - name: Find lcov.info
         shell: bash
@@ -127,7 +127,7 @@ jobs:
           sonar.projectBaseDir=$GITHUB_WORKSPACE
           sonar.projectKey=usdot-jpo-ode_jpo-cvmanager
           sonar.projectName=jpo-cvmanager
-          sonar.python.coverage.reportPaths=$GITHUB_WORKSPACE/services/coverage.xml
+          sonar.python.coverage.reportPaths=$GITHUB_WORKSPACE/services/cov.xml
           sonar.python.version=3.12
           api.sonar.projectBaseDir=$GITHUB_WORKSPACE/services
           api.sonar.sources=addons/images/bsm_query,addons/images/count_metric,addons/images/firmware_manager,addons/images/iss_health_check,addons/images/rsu_ping,api/src,common/pgquery.py

--- a/services/api/tests/data/rsu_online_status_data.py
+++ b/services/api/tests/data/rsu_online_status_data.py
@@ -1,5 +1,6 @@
 import multidict
 from datetime import datetime
+from pytz import timezone
 
 ##################################### request_data ###########################################
 
@@ -65,7 +66,7 @@ last_online_query_return = [[datetime.strptime('06/14/2022 07:44:09 PM', '%m/%d/
 
 last_online_data_expected = {
         "ip": "10.0.0.1",
-        "last_online": "06/14/2022 07:44:09 PM"
+        "last_online": datetime.strftime(datetime.strptime('06/14/2022 07:44:09 PM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p')
     }
 
 last_online_no_data_expected = {

--- a/services/api/tests/data/rsu_ssm_srm_data.py
+++ b/services/api/tests/data/rsu_ssm_srm_data.py
@@ -1,19 +1,24 @@
 import multidict
 from datetime import datetime
 
-ssm_expected_query = 'SELECT rtdh_timestamp as time, ' \
+from pytz import timezone
+
+start_date = datetime.strftime(datetime.strptime('2022-12-13T07:00:00', '%Y-%m-%dT%H:%M:%S').astimezone(timezone('America/Denver')), '%Y-%m-%dT%H:%M:%S')
+end_date = datetime.strftime(datetime.strptime('2022-12-14T07:00:00', '%Y-%m-%dT%H:%M:%S').astimezone(timezone('America/Denver')), '%Y-%m-%dT%H:%M:%S')
+
+ssm_expected_query = f'SELECT rtdh_timestamp as time, ' \
     f'ssm.metadata.originIp as ip, ssm.payload.data.status.signalStatus[ordinal(1)].sigStatus.signalStatusPackage[ordinal(1)].requester.request, ' \
     f'ssm.payload.data.status.signalStatus[ordinal(1)].sigStatus.signalStatusPackage[ordinal(1)].requester.typeData.role, ' \
     f'ssm.payload.data.status.signalStatus[ordinal(1)].sigStatus.signalStatusPackage[ordinal(1)].status, ' \
-    f'ssm.metadata.recordType as type FROM `Fake_table` WHERE TIMESTAMP(rtdh_timestamp) >= "2022-12-13T07:00:00" ' \
-    f'AND TIMESTAMP(rtdh_timestamp) <= "2022-12-14T07:00:00" ORDER BY rtdh_timestamp ASC'
+    f'ssm.metadata.recordType as type FROM `Fake_table` WHERE TIMESTAMP(rtdh_timestamp) >= "{start_date}" ' \
+    f'AND TIMESTAMP(rtdh_timestamp) <= "{end_date}" ORDER BY rtdh_timestamp ASC'
 
-srm_expected_query = 'SELECT rtdh_timestamp as time, srm.metadata.originIp as ip, ' \
+srm_expected_query = f'SELECT rtdh_timestamp as time, srm.metadata.originIp as ip, ' \
     f'srm.payload.data.requests.signalRequestPackage[ordinal(1)].request.requestID as request, ' \
     f'srm.payload.data.requestor.type.role, srm.payload.data.requestor.position.position.latitude as lat, ' \
     f'srm.payload.data.requestor.position.position.longitude as long, srm.metadata.recordType as type ' \
-    f'FROM `Fake_table` WHERE TIMESTAMP(rtdh_timestamp) >= "2022-12-13T07:00:00" AND ' \
-    f'TIMESTAMP(rtdh_timestamp) <= "2022-12-14T07:00:00" ORDER BY rtdh_timestamp ASC'
+    f'FROM `Fake_table` WHERE TIMESTAMP(rtdh_timestamp) >= "{start_date}" AND ' \
+    f'TIMESTAMP(rtdh_timestamp) <= "{end_date}" ORDER BY rtdh_timestamp ASC'
 
 ssm_record_one = multidict.MultiDict([
         ('time', datetime.strptime('2022/12/13 00:00:00', '%Y/%m/%d %H:%M:%S')), 
@@ -71,7 +76,7 @@ srm_record_three = multidict.MultiDict([
 ])
 
 ssm_single_result_expected = [{
-    'time': '12/13/2022 12:00:00 AM', 
+    'time': datetime.strftime(datetime.strptime('12/13/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'), 
     'ip': '127.0.0.1', 
     'requestId': 13, 
     'role': 'publicTrasport', 
@@ -79,19 +84,19 @@ ssm_single_result_expected = [{
     'type': 'ssmTx'}]
 
 ssm_multiple_result_expected = [
-    {'time': '12/13/2022 12:00:00 AM', 
+    {'time': datetime.strftime(datetime.strptime('12/13/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
     'ip': '127.0.0.1', 
     'requestId': 13, 
     'role': 'publicTrasport', 
     'status': 'granted', 
     'type': 'ssmTx'}, 
-    {'time': '12/14/2022 12:00:00 AM', 
+    {'time': datetime.strftime(datetime.strptime('12/14/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
     'ip': '127.0.0.1', 
     'requestId': 10, 
     'role': 'publicTrasport', 
     'status': 'granted', 
     'type': 'ssmTx'}, 
-    {'time': '12/12/2022 12:00:00 AM', 
+    {'time': datetime.strftime(datetime.strptime('12/12/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'), 
     'ip': '127.0.0.1', 
     'requestId': 17, 
     'role': 'publicTrasport', 
@@ -99,7 +104,7 @@ ssm_multiple_result_expected = [
     'type': 'ssmTx'}]
 
 srm_single_result_expected = [{
-    'time': '12/13/2022 12:00:00 AM', 
+    'time': datetime.strftime(datetime.strptime('12/13/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
     'ip': '127.0.0.1', 
     'requestId': 9, 
     'role': 'publicTrasport', 
@@ -110,7 +115,7 @@ srm_single_result_expected = [{
 
 srm_multiple_result_expected = [
     {
-        'time': '12/13/2022 12:00:00 AM', 
+        'time': datetime.strftime(datetime.strptime('12/13/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
         'ip': '127.0.0.1', 
         'requestId': 9, 
         'role': 'publicTrasport', 
@@ -120,7 +125,7 @@ srm_multiple_result_expected = [
         'status': 'N/A'
     }, 
     {
-        'time': '12/12/2022 12:00:00 AM', 
+        'time': datetime.strftime(datetime.strptime('12/12/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
         'ip': '127.0.0.1', 
         'requestId': 13, 
         'role': 'publicTrasport', 
@@ -130,7 +135,7 @@ srm_multiple_result_expected = [
         'status': 'N/A'
     }, 
     {
-        'time': '12/14/2022 12:00:00 AM', 
+        'time': datetime.strftime(datetime.strptime('12/14/2022 12:00:00 AM', '%m/%d/%Y %I:%M:%S %p').astimezone(timezone('America/Denver')), '%m/%d/%Y %I:%M:%S %p'),
         'ip': '127.0.0.1', 
         'requestId': 17, 
         'role': 'publicTrasport', 

--- a/services/api/tests/src/test_rsu_ssm_srm.py
+++ b/services/api/tests/src/test_rsu_ssm_srm.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, MagicMock
 import api.src.rsu_ssm_srm as rsu_ssm_srm
 import api.tests.data.rsu_ssm_srm_data as ssm_srm_data
 from datetime import datetime
+from pytz import UTC
 
 
 ##################################### Testing Requests ###########################################
@@ -43,7 +44,7 @@ def test_get_request(mock_srm, mock_ssm):
 @patch('api.src.rsu_ssm_srm.datetime')
 def test_query_ssm_data_query(mock_date, mock_bigquery):
     mock_bigquery.Client.return_value.query.return_value = []
-    mock_date.now.return_value = datetime.strptime('2022/12/14 00:00:00', '%Y/%m/%d %H:%M:%S')
+    mock_date.now.return_value = datetime.strptime('2022/12/14 00:00:00', '%Y/%m/%d %H:%M:%S').astimezone(UTC)
     with patch.dict('api.src.rsu_ssm_srm.os.environ', {'SSM_DB_NAME': 'Fake_table'}):
         rsu_ssm_srm.query_ssm_data([])
         mock_bigquery.Client.return_value.query.assert_called_with(ssm_srm_data.ssm_expected_query)
@@ -82,7 +83,7 @@ def test_query_ssm_data_multiple_result(mock_bigquery):
 @patch('api.src.rsu_ssm_srm.datetime')
 def test_query_srm_data_query(mock_date, mock_bigquery):
     mock_bigquery.Client.return_value.query.return_value = []
-    mock_date.now.return_value = datetime.strptime('2022/12/14 00:00:00', '%Y/%m/%d %H:%M:%S')
+    mock_date.now.return_value = datetime.strptime('2022/12/14 00:00:00', '%Y/%m/%d %H:%M:%S').astimezone(UTC)
     with patch.dict('api.src.rsu_ssm_srm.os.environ', {'SRM_DB_NAME': 'Fake_table'}):
         rsu_ssm_srm.query_srm_data([])
         mock_bigquery.Client.return_value.query.assert_called_with(ssm_srm_data.srm_expected_query)

--- a/services/api/tests/src/test_util.py
+++ b/services/api/tests/src/test_util.py
@@ -1,11 +1,14 @@
 import datetime
+
+import pytz
 from api.src import util
 
 
 def test_format_date_utc():
     dt = datetime.datetime(2020, 1, 1, 1, 1, 1)
     datetimeString = dt.strftime("%Y-%m-%dT%H:%M:%S")
-    assert util.format_date_utc(datetimeString) == "2020-01-01T08:01:01"
+    expected_dt = datetime.datetime.strftime(dt.astimezone(pytz.UTC), "%Y-%m-%dT%I:%M:%S")
+    assert util.format_date_utc(datetimeString) == expected_dt
 
 
 def test_format_date_utc_failure():
@@ -17,8 +20,9 @@ def test_format_date_utc_failure():
 
 def test_format_date_denver():
     dt = datetime.datetime(2020, 1, 1, 1, 1, 1)
+    expected_dt = datetime.datetime.strftime(dt.astimezone(pytz.timezone("America/Denver")), "%m/%d/%Y %I:%M:%S %p")
     datetimeString = dt.strftime("%Y-%m-%dT%H:%M:%S")
-    assert util.format_date_denver(datetimeString) == "01/01/2020 01:01:01 AM"
+    assert util.format_date_denver(datetimeString) == expected_dt
 
 
 def test_format_date_denver_failure():


### PR DESCRIPTION
Updates unit tests failing when run in other timezones to pass regardless of timezone. 

Tested in the following timezones: PST, MST, CST, and EST.