### PR TITLE
Lock In Python 3.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build_api:
     runs-on: ubuntu-latest
     container:
-      image: python:3.9
+      image: python:3.12.2
       options: --user root
     steps:
       - name: Checkout ${{ github.event.repository.name }}
@@ -128,7 +128,7 @@ jobs:
           sonar.projectKey=usdot-jpo-ode_jpo-cvmanager
           sonar.projectName=jpo-cvmanager
           sonar.python.coverage.reportPaths=$GITHUB_WORKSPACE/services/cov.xml
-          sonar.python.version=3.12
+          sonar.python.version=3.12.2
           api.sonar.projectBaseDir=$GITHUB_WORKSPACE/services
           api.sonar.sources=addons/images/bsm_query,addons/images/count_metric,addons/images/firmware_manager,addons/images/iss_health_check,addons/images/rsu_status_check,api/src,common/pgquery.py
           api.sonar.tests=addons/tests,api/tests,common/tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The JPO Connected Vehicle Manager is a web-based application that helps an organ
 
 <b>GUI:</b> ReactJS with Redux Toolkit and Mapbox GL
 
-<b>API:</b> Python
+<b>API:</b> Python 3.12.2
 
 <b>Features:</b>
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,32 @@ The following steps are intended to help get a new user up and running the JPO C
 
 ### Debugging
 
-Note that it is recommended to work with the Python API from a [virtual environment](https://docs.python.org/3/library/venv.html). See [Visual Studio Code](https://code.visualstudio.com/docs/python/environments) documentation for more information on how to set up a virtual environment in VS Code.
+Note that it is recommended to work with the Python API from a [virtual environment](https://docs.python.org/3/library/venv.html). 
 
+#### Setting up a virtual environment from the command line
+1. Verify that you have Python 3.12.2 installed on your machine by running `python3 --version`. If not, download and install it from the [Python website](https://www.python.org/downloads/).
+2. Open a terminal and navigate to the root of the project.
+3. Run the following command to create a virtual environment in the project root:
+
+    ```bash
+    python3 -m venv .venv
+    ```
+4. Activate the virtual environment:
+    ```bash
+    source .venv/bin/activate
+    ```
+    ```cmd
+    .venv\Scripts\activate
+    ```
+5. Install the required packages:
+    ```bash
+    pip install -r services/requirements.txt
+    ```
+
+#### Setting up a virtual environment with VSCode
+See [Visual Studio Code](https://code.visualstudio.com/docs/python/environments) documentation for information on how to set up a virtual environment with VS Code.
+
+#### Debugging Profile
 A debugging profile has been set up for use with VSCode to allow ease of debugging with this application. To use this profile, simply open the project in VSCode and select the "Debug" tab on the left side of the screen. Then, select the "Debug Solution" profile and click the green play button. This will spin up a postgresql instance as well as the keycloak auth solution within docker containers. Once running, this will also start the debugger and attach it to the running API container. You can then set breakpoints and step through the code as needed.
 
 For the "Debug Solution" to run properly on Windows 10/11 using WSL, the following must be configured:

--- a/README.md
+++ b/README.md
@@ -91,12 +91,21 @@ The following steps are intended to help get a new user up and running the JPO C
 Note that it is recommended to work with the Python API from a [virtual environment](https://docs.python.org/3/library/venv.html). 
 
 #### Setting up a virtual environment from the command line
-1. Verify that you have Python 3.12.2 installed on your machine by running `python3 --version`. If not, download and install it from the [Python website](https://www.python.org/downloads/).
+1. Verify that you have Python 3.12.2 installed on your machine by running the following command:
+    ```bash
+    python3.12 --version
+    ```
+    ```cmd
+    python --version
+    ```
+    If you have a different version installed, download and install Python 3.12.2 from the [Python website](https://www.python.org/downloads/).
 2. Open a terminal and navigate to the root of the project.
 3. Run the following command to create a virtual environment in the project root:
-
     ```bash
-    python3 -m venv .venv
+    python3.12 -m venv .venv
+    ```
+    ```cmd
+    python -m venv .venv
     ```
 4. Activate the virtual environment:
     ```bash
@@ -107,6 +116,9 @@ Note that it is recommended to work with the Python API from a [virtual environm
     ```
 5. Install the required packages:
     ```bash
+    pip3.12 install -r services/requirements.txt
+    ```
+    ```cmd
     pip install -r services/requirements.txt
     ```
 

--- a/services/Dockerfile.api
+++ b/services/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM python:3.12.0-slim
+FROM python:3.12.2-slim
 
 # Prepare the SNMP functionality for the image
 RUN apt-get update

--- a/services/Dockerfile.bsm_query
+++ b/services/Dockerfile.bsm_query
@@ -1,4 +1,4 @@
-FROM python:3.12.0-alpine3.18
+FROM python:3.12.2-alpine3.18
 
 WORKDIR /home
 

--- a/services/Dockerfile.count_metric
+++ b/services/Dockerfile.count_metric
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12.2-slim
 
 WORKDIR /home
 

--- a/services/Dockerfile.firmware_manager
+++ b/services/Dockerfile.firmware_manager
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12.2-slim
 
 WORKDIR /home
 

--- a/services/Dockerfile.iss_health_check
+++ b/services/Dockerfile.iss_health_check
@@ -1,4 +1,4 @@
-FROM python:3.12.0-alpine3.18
+FROM python:3.12.2-alpine3.18
 
 WORKDIR /home
 

--- a/services/Dockerfile.rsu_status_check
+++ b/services/Dockerfile.rsu_status_check
@@ -1,4 +1,4 @@
-FROM python:3.12.0-alpine3.18
+FROM python:3.12.2-alpine3.18
 
 # Prepare the SNMP functionality for the image
 RUN apk update

--- a/services/README.md
+++ b/services/README.md
@@ -2,6 +2,9 @@
 
 The CV Manager has multiple backend services that are required to allow the CV Manager to operate at full capacity.
 
+## Python Version
+These services are implemented using Python 3.12.2. It is recommended to use this version when developing, testing, and deploying the services.
+
 ## CV Manager API
 
 The CV Manager API is the backend service for the CV Manager webapp. This API is required to be run in an accessible location for the web application to function. The API is a Python Flask REST service.

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==21.2.0
 pytz==2023.3.post1
 Werkzeug==3.0.0
 uuid==1.30
-multidict==6.0.4
+multidict==6.0.5
 python-keycloak==2.16.2
 fabric==3.2.2
 paramiko==3.3.1


### PR DESCRIPTION
## Problem
The version of python to be used with the project is not locked in. The dockerfiles use 3.12.0, the CI uses 3.9 & the developer may choose to use another version as the documentation does not guide the developer on this.

## Solution
The latest LTS version of Python, v3.12.2, has been locked in via the following:
1. The README now recommends using Python 3.12.2
2. The dockerfiles use Python 3.12.2
3. The CI uses Python 3.12.2
4. Instructions on setting up a virtual environment have been added to the README.

## Testing
- The unit tests have been verified to work with these changes.
- The dockerfiles have been verified to build with these changes.