### PR TITLE
WCAG color contrast

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -53,10 +53,11 @@ header {
 .tab-list-active {
   font-family: Arial, Helvetica, sans-serif;
   font-weight: 550;
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: white;
-  border: solid #d16d15;
+  border: solid #b55e12;
   border-width: 1px 1px 0 1px;
+  border-top: 0.5px solid #ffffff;
 }
 
 #content-grid {

--- a/webapp/src/components/AdminTable.tsx
+++ b/webapp/src/components/AdminTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import MaterialTable, { Action, Column } from '@material-table/core'
 import { ThemeProvider } from '@mui/material'
-import { theme } from '../styles'
+import { tableTheme } from '../styles'
 
 import '../features/adminRsuTab/Admin.css'
 
@@ -16,7 +16,7 @@ interface AdminTableProps {
 const AdminTable = (props: AdminTableProps) => {
   return (
     <div>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={tableTheme}>
         <MaterialTable
           actions={props.actions}
           columns={props.columns}

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -76,7 +76,7 @@ const SnmpwalkMenu = () => {
                 dispatch(refreshSnmpFwdConfig([rsuIp]))
               }}
             >
-              <RefreshIcon />
+              <RefreshIcon htmlColor="#b55e12" />
             </IconButton>
           </Tooltip>
         </div>

--- a/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`should take a snapshot 1`] = `
         <svg
           aria-hidden="true"
           class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-mocked-MuiSvgIcon-root"
+          color="#b55e12"
           data-testid="RefreshIcon"
           focusable="false"
           viewBox="0 0 24 24"

--- a/webapp/src/components/css/ConfigureItem.css
+++ b/webapp/src/components/css/ConfigureItem.css
@@ -42,5 +42,5 @@
 }
 
 strong {
-  color: #d16d15;
+  color: #e37616;
 }

--- a/webapp/src/components/css/Header.css
+++ b/webapp/src/components/css/Header.css
@@ -45,7 +45,7 @@
 }
 
 .keycloak-button {
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: #fff;
   padding: 10px 20px;
   border: none;
@@ -118,7 +118,6 @@
   font-weight: bold;
   font-size: 16px;
   text-align: right;
-  color: #d16d15;
+  color: #e98125;
   background-color: #333;
 }
-

--- a/webapp/src/components/css/Help.css
+++ b/webapp/src/components/css/Help.css
@@ -32,4 +32,5 @@
   width: 40%;
   margin-top: 4em;
   margin-bottom: 4em;
+  border: 0.5px solid white;
 }

--- a/webapp/src/components/css/SnmpItem.css
+++ b/webapp/src/components/css/SnmpItem.css
@@ -33,5 +33,5 @@
 }
 
 strong {
-  color: #d16d15;
+  color: #e37616;
 }

--- a/webapp/src/components/css/SnmpwalkMenu.css
+++ b/webapp/src/components/css/SnmpwalkMenu.css
@@ -8,6 +8,7 @@
   padding-bottom: 30px;
   padding-left: 30px;
   vertical-align: top;
+  border: 1px solid white;
 }
 
 #updatediv {
@@ -68,7 +69,7 @@
 #refreshbtn {
   font-family: Arial, Helvetica, sans-serif;
   font-weight: 550;
-  background-color: #d16d15;
+  background-color: #b55e12;
   border: none;
   color: white;
   padding: 8px 10px;
@@ -153,10 +154,12 @@
 }
 
 #warningtext {
+  background-color: #fff;
   font-family: Arial, Helvetica, sans-serif;
-  color: red;
+  color: #d10000;
   margin-top: 10px;
   font-weight: 550;
+  padding: 4px;
 }
 
 #msgfwddiv {
@@ -183,5 +186,5 @@
 
 #firmwarenoticetext {
   font-family: Arial, Helvetica, sans-serif;
-  color: #d16d15;
+  color: #e98125;
 }

--- a/webapp/src/features/adminRsuTab/Admin.css
+++ b/webapp/src/features/adminRsuTab/Admin.css
@@ -14,7 +14,7 @@
 
 .errorMsg {
   max-width: 350px;
-  color: #f21e08;
+  color: #f83a25;
   padding: 2px 0;
   margin-top: 2px;
   font-size: 14px;
@@ -109,7 +109,7 @@
 .admin-button {
   font-family: Arial, Helvetica, sans-serif;
   font-weight: 550;
-  background-color: #d16d15;
+  background-color: #b55e12;
   border: none;
   color: white;
   padding: 8px 10px;
@@ -126,7 +126,7 @@
   margin-top: -4px;
   margin-right: 10px;
   padding: 6px 6px;
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: white;
   border: none;
   border-radius: 10px;
@@ -181,7 +181,7 @@
 }
 
 .expand {
-  color: #d16d15;
+  color: #e98125;
 }
 
 .success-msg {
@@ -189,7 +189,7 @@
 }
 
 .error-msg {
-  color: rgb(255, 0, 0);
+  color: #f83a25;
   margin-bottom: 10px;
   background-color: #1c1d1f;
 }
@@ -234,7 +234,7 @@
   margin-right: 10px;
   float: right;
   padding: 6px 6px;
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: white;
   border: none;
   border-radius: 10px;
@@ -250,7 +250,7 @@
   margin-left: 10px;
   float: left;
   padding: 6px 6px;
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: white;
   border: none;
   border-radius: 10px;

--- a/webapp/src/features/menu/Menu.css
+++ b/webapp/src/features/menu/Menu.css
@@ -75,7 +75,7 @@
   z-index: 100;
   margin-top: 10px;
   right: 10px;
-  background-color: #d16d15;
+  background-color: #b55e12;
   color: white;
 }
 #toggle_config {
@@ -142,8 +142,9 @@
   display: flex;
   justify-content: center;
   color: white;
-  background-color: red;
+  background-color: #eb0000;
   margin: 1em;
+  padding: 1em;
 }
 .selectContainer {
   width: 90%;

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -687,6 +687,7 @@ function MapPage(props: MapPageProps) {
                     <Button
                       variant="contained"
                       className="contained-button"
+                      sx={{ backgroundColor: '#B55e12' }}
                       disabled={!(configCoordinates.length > 2 && addConfigPoint)}
                       onClick={() => {
                         dispatch(geoRsuQuery())

--- a/webapp/src/pages/css/BsmMap.css
+++ b/webapp/src/pages/css/BsmMap.css
@@ -36,7 +36,7 @@
   width: fit-content;
   padding: 5px;
   font-size: 1em;
-  background: #d16d15;
+  background: #b55e12;
   border-radius: 10px;
   border-color: white;
   cursor: pointer;
@@ -90,7 +90,7 @@
   width: fit-content;
   padding: 5px;
   font-size: 1em;
-  background: #d16d15;
+  background: #b55e12;
   border-radius: 10px;
   border-color: white;
   cursor: pointer;

--- a/webapp/src/pages/css/Map.css
+++ b/webapp/src/pages/css/Map.css
@@ -35,7 +35,7 @@
 
 .legend-input {
   margin-right: 10px;
-  accent-color: #d16d15;
+  accent-color: #b55e12;
 }
 
 .legend-grid {
@@ -63,7 +63,7 @@
 
 .rsu-status-input {
   margin-right: 10px;
-  accent-color: #d16d15;
+  accent-color: #b55e12;
 }
 
 .map-button {

--- a/webapp/src/styles/index.ts
+++ b/webapp/src/styles/index.ts
@@ -59,3 +59,121 @@ export const theme = createTheme({
     color: '#11ff00',
   },
 })
+
+export const tableTheme = createTheme({
+  palette: {
+    common: {
+      black: '#000000',
+      white: '#ffffff',
+    },
+    primary: {
+      main: '#ffffff',
+      light: '#0e2052',
+      contrastTextColor: '#0e2052',
+    },
+    secondary: {
+      main: '#333333',
+      light: '#0e2052',
+      contrastTextColor: '#0e2052',
+    },
+    text: {
+      primary: '#ffffff',
+      secondary: '#ffffff',
+      disabled: '#ffffff',
+      hint: '#ffffff',
+    },
+    divider: '#333',
+    background: {
+      paper: '#333',
+      default: '#1c1d1f',
+    },
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          border: '1.5px solid #ffffff',
+        },
+      },
+    },
+    MuiIcon: {
+      styleOverrides: {
+        root: {
+          color: '#333333',
+          backgroundColor: '#dadde5',
+          borderRadius: '50%',
+          padding: '2px',
+        },
+      },
+    },
+    MuiInputAdornment: {
+      styleOverrides: {
+        positionStart: {
+          color: '#333333',
+        },
+        positionEnd: {
+          color: '#333333',
+        },
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#dadde5',
+          color: '#333333',
+        },
+      },
+    },
+    MuiButtonBase: {
+      styleOverrides: {
+        root: {
+          color: '#ffffff',
+        },
+      },
+    },
+    MuiCheckbox: {
+      styleOverrides: {
+        root: {
+          color: '#ffffff',
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          color: '#ffffff',
+        },
+      },
+    },
+    MuiToolbar: {
+      styleOverrides: {
+        root: {
+          color: '#333333',
+          backgroundColor: '#dadde5',
+        },
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        colorInherit: {
+          color: '#333333',
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        footer: {
+          backgroundColor: '#dadde5',
+          borderBottom: 'None',
+        },
+      },
+    },
+    MuiTablePagination: {
+      styleOverrides: {
+        root: {
+          color: '#333333',
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
Includes CSS color updates so that there is enough color contrast between elements. The following are necessary to conform to WCAG AA:
  
  - Text has a contrast ratio of at least 4.5:1
  - Icons have a contrast ratio of at least 3:1
  - UI components have a contrast ratio of at least 3:1 against adjacent colors
  - Graphical objects have a contrast ratio of at least 3:1 against adjacent colors
 
The following website was used to verify that these color changes meet these standards: https://webaim.org/resources/contrastchecker/