### PR TITLE
Add RSU Vendor Filter

### DIFF
--- a/services/api/tests/data/rsu_geo_query_data.py
+++ b/services/api/tests/data/rsu_geo_query_data.py
@@ -44,5 +44,14 @@ point_list = [
     [-105.34460908203145, 39.724583197251334],
 ]
 
+point_list_vendor = [
+    [-105.34460908203145, 39.724583197251334],
+    [-105.34666901855489, 39.670180083300174],
+    [-105.25122529296911, 39.679162192647944],
+    [-105.2539718750002, 39.72088725644132],
+    [-105.34460908203145, 39.724583197251334],
+]
 
 rsu_devices_query = "SELECT to_jsonb(row) FROM (SELECT ipv4_address as ip, ST_X(geography::geometry) AS long, ST_Y(geography::geometry) AS lat FROM rsus WHERE ipv4_address = ANY('{10.11.81.12}'::inet[]) AND ST_Contains(ST_SetSRID(ST_GeomFromText('POLYGON((-105.34460908203145 39.724583197251334,-105.34666901855489 39.670180083300174,-105.25122529296911 39.679162192647944,-105.2539718750002 39.72088725644132,-105.34460908203145 39.724583197251334))'), 4326), rsus.geography::geometry)) as row"
+
+rsu_devices_query_vendor = "SELECT to_jsonb(row) FROM (SELECT ipv4_address as ip, ST_X(geography::geometry) AS long, ST_Y(geography::geometry) AS lat FROM rsus WHERE ipv4_address = ANY('{10.11.81.12}'::inet[])  AND ipv4_address IN (SELECT rd.ipv4_address FROM public.rsus as rd JOIN public.rsu_models as rm ON rm.rsu_model_id = rd.model JOIN public.manufacturers as man on man.manufacturer_id = rm.manufacturer WHERE man.name = 'Test') AND ST_Contains(ST_SetSRID(ST_GeomFromText('POLYGON((-105.34460908203145 39.724583197251334,-105.34666901855489 39.670180083300174,-105.25122529296911 39.679162192647944,-105.2539718750002 39.72088725644132,-105.34460908203145 39.724583197251334))'), 4326), rsus.geography::geometry)) as row"

--- a/services/api/tests/src/test_rsu_geo_query.py
+++ b/services/api/tests/src/test_rsu_geo_query.py
@@ -99,7 +99,6 @@ def test_query_rsu_devices_with_vendor(mock_query_db):
     mock_query_db.return_value = [
         ({"ip": "10.11.81.12"},),
     ]
-    print(rsu_geo_query_data.point_list)
     actual_result, code = rsu_geo_query.query_rsu_devices(
         {"10.11.81.12"},
         rsu_geo_query_data.point_list_vendor,

--- a/services/api/tests/src/test_rsu_geo_query.py
+++ b/services/api/tests/src/test_rsu_geo_query.py
@@ -93,3 +93,19 @@ def test_query_rsu_devices(mock_query_db):
 
     assert actual_result == ["10.11.81.12"]
     assert code == 200
+
+@patch("api.src.rsu_commands.pgquery.query_db")
+def test_query_rsu_devices_with_vendor(mock_query_db):
+    mock_query_db.return_value = [
+        ({"ip": "10.11.81.12"},),
+    ]
+    print(rsu_geo_query_data.point_list)
+    actual_result, code = rsu_geo_query.query_rsu_devices(
+        {"10.11.81.12"},
+        rsu_geo_query_data.point_list_vendor,
+        vendor="Test"
+    )
+    mock_query_db.assert_called_with(rsu_geo_query_data.rsu_devices_query_vendor)
+
+    assert actual_result == ["10.11.81.12"]
+    assert code == 200

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -190,7 +190,7 @@ export const startFirmwareUpgrade = createAsyncThunk(
 
 export const geoRsuQuery = createAsyncThunk(
   'config/geoRsuQuery',
-  async (_, { getState }) => {
+  async (vendor: string, { getState }) => {
     const currentState = getState() as RootState
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)
@@ -202,6 +202,7 @@ export const geoRsuQuery = createAsyncThunk(
       organization,
       JSON.stringify({
         geometry: configCoordinates,
+        vendor: vendor,
       }),
       ''
     )

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -11,6 +11,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
 import Slider from 'rc-slider'
 import Select from 'react-select'
+import { DropdownList } from 'react-widgets'
 import {
   selectRsuOnlineStatus,
   selectMapList,
@@ -174,6 +175,13 @@ function MapPage(props: MapPageProps) {
   const [pageOpen, setPageOpen] = useState(true)
 
   const [activeLayers, setActiveLayers] = useState(['rsu-layer'])
+
+  // Vendor filter local state variable
+  const [selectedVendor, setSelectedVendor] = useState('Select Vendor')
+  const vendorArray: string[] = ['Select Vendor', 'Commsignia', 'Yunex', 'Kapsch']
+  const setVendor = (newVal) => {
+    setSelectedVendor(newVal)
+  }
 
   // useEffects for Mapbox
   useEffect(() => {
@@ -689,7 +697,7 @@ function MapPage(props: MapPageProps) {
                       className="contained-button"
                       disabled={!(configCoordinates.length > 2 && addConfigPoint)}
                       onClick={() => {
-                        dispatch(geoRsuQuery())
+                        dispatch(geoRsuQuery(selectedVendor))
                       }}
                     >
                       Configure RSUs
@@ -712,6 +720,22 @@ function MapPage(props: MapPageProps) {
           >
             Show Intersection
           </button>
+        ) : null}
+        {activeLayers.includes('rsu-layer') ? (
+          <div className="vendor-filter-div">
+            <h2>Filter RSUs</h2>
+            <h4>Vendor</h4>
+            <DropdownList
+              className="form-dropdown"
+              dataKey="id"
+              textField="name"
+              data={vendorArray}
+              value={selectedVendor}
+              onChange={(value) => {
+                setVendor(value)
+              }}
+            />
+          </div>
         ) : null}
       </Grid>
       <Container
@@ -748,7 +772,8 @@ function MapPage(props: MapPageProps) {
           )}
           {rsuData?.map(
             (rsu) =>
-              activeLayers.includes('rsu-layer') && [
+              activeLayers.includes('rsu-layer') &&
+              (selectedVendor === 'Select Vendor' || rsu['properties']['manufacturer_name'] === selectedVendor) && [
                 <Marker
                   // className="rsu-marker"
                   key={rsu.id}

--- a/webapp/src/pages/__snapshots__/Map.test.tsx.snap
+++ b/webapp/src/pages/__snapshots__/Map.test.tsx.snap
@@ -353,6 +353,74 @@ exports[`snapshot bsmData clicked 1`] = `
           SCMS Status
         </label>
       </div>
+      <div
+        class="vendor-filter-div"
+      >
+        <h2>
+          Filter RSUs
+        </h2>
+        <h4>
+          Vendor
+        </h4>
+        <div
+          aria-autocomplete="list"
+          aria-busy="false"
+          aria-controls="rw_5_listbox"
+          aria-disabled="false"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-owns="rw_5_listbox"
+          aria-readonly="false"
+          class="form-dropdown rw-dropdown-list rw-widget"
+          data-intent="mouse"
+          id="rw_4_input"
+          role="combobox"
+          tabindex="-1"
+        >
+          <div
+            class="rw-widget-input rw-widget-picker rw-widget-container"
+            tabindex="-1"
+          >
+            <div
+              class="rw-dropdown-list-input"
+            >
+              <input
+                aria-hidden="true"
+                class="rw-detect-autofill rw-sr"
+                tabindex="-1"
+                value="Select Vendor"
+              />
+              <input
+                autocomplete="off"
+                class="rw-dropdownlist-search"
+                size="2"
+                value=""
+              />
+              <span
+                class="rw-dropdown-list-value"
+              >
+                Select Vendor
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="rw-btn rw-picker-caret"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentcolor"
+                height="1em"
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
     <div
       class="container-fluid"

--- a/webapp/src/pages/css/Map.css
+++ b/webapp/src/pages/css/Map.css
@@ -50,6 +50,44 @@
   margin-top: 10px;
 }
 
+.vendor-filter-div {
+  z-index: 90;
+  background: #0e2052;
+  border-radius: 15px;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-evenly;
+  width: fit-content;
+  height: fit-content;
+  padding: 5px 20px;
+  margin-left: 10px;
+  font-family: Arial, Helvetica, sans-serif;
+  color: #ffffff;
+}
+
+.vendor-filter-div h2 {
+  margin-bottom: 10px;
+}
+
+.vendor-filter-div h4 {
+  font-weight: normal;
+  margin-bottom: 4px;
+}
+
+.form-dropdown {
+  width: 100%;
+}
+
+.rw-dropdown-list-value {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.rw-list-option {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
 .rsu-status-label {
   display: block;
   font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Adds an additional menu to the map to allow users to filter displayed RSUs by vendor. Additionally, updates the geospatial multi-rsu select functionality to only include RSUs with the chosen vendor.

Unit tests for the webapp and API have been updated to pass with these changes. 