### PR TITLE
Firmware Manager Post Update Script Support

### DIFF
--- a/services/addons/images/firmware_manager/README.md
+++ b/services/addons/images/firmware_manager/README.md
@@ -66,6 +66,8 @@ GCP Required environment variables:
 
 Each upgrade requires just one firmware file. Upload target firmware to a cloud storage bucket or alternative hosting service according to the `vendor/rsu-model/firmware-version/install_package` directory path format.
 
+The Firmware Manager is also able to run a bash script on Commsignia RSUs after the firmware update has been completed. If uploading a script to a cloud storage bucket or alternative hosting service do so at the directory path `vendor/rsu-model/firmware-version/post_upgrade.sh`. Additionally, the post_upgrade.sh script will need to output "ALL OK" to stdout to notify the Firmware Manager that it has completed successfully.
+
 ### Yunex
 
 Each upgrade requires 4 total files tarred up into a single TAR file:

--- a/services/addons/images/firmware_manager/commsignia_upgrader.py
+++ b/services/addons/images/firmware_manager/commsignia_upgrader.py
@@ -54,7 +54,7 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             ssh.exec_command("reboot")
             ssh.close()
 
-            # In here check to see if post_upgrade is present
+            # If post_upgrade script exists execute it
             if (self.download_blob(self.post_upgrade_blob_name, self.post_upgrade_file_name)):
                 self.post_upgrade()
 
@@ -86,13 +86,13 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
                 allow_agent=False,
             )
 
-            # Make SCP client to copy over the post upgrade script s to the /tmp/ directory on the remote device
+            # Make SCP client to copy over the post upgrade script to the /tmp/ directory on the remote device
             logging.info("Copying post upgrade script to the device...")
             scp = SCPClient(ssh.get_transport())
             scp.put(self.post_upgrade_file_name, remote_path="/tmp/")
             scp.close()
 
-            # Run post upgrade
+            # Change permissions and execute post upgrade script
             logging.info("Running post upgrade script...")
             ssh.exec_command(
                 f"chmod +x /tmp/post_upgrade.sh"

--- a/services/addons/images/firmware_manager/commsignia_upgrader.py
+++ b/services/addons/images/firmware_manager/commsignia_upgrader.py
@@ -110,20 +110,6 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             logging.info(f"Post upgrade script executed successfully for rsu: {self.rsu_ip}.")
         except Exception as err:
             logging.error(f"Failed to execute post upgrade script for rsu {self.rsu_ip}: {err}")
-            
-    def wait_until_online(self):
-        iter = 0
-        # Ping once every second for 3 minutes until online
-        while iter < 180:
-            time.sleep(1)
-            code = subprocess.run(
-                ["ping", "-n", "-c1", self.rsu_ip], capture_output=True
-            ).returncode
-            if code == 0:
-                return 0
-            iter += 1
-        # 3 minutes pass with no response
-        return -1
 
 # sys.argv[1] - JSON string with the following key-values:
 # - ipv4_address

--- a/services/addons/images/firmware_manager/commsignia_upgrader.py
+++ b/services/addons/images/firmware_manager/commsignia_upgrader.py
@@ -1,3 +1,5 @@
+import subprocess
+import time
 from paramiko import SSHClient, WarningPolicy
 from scp import SCPClient
 import upgrader
@@ -9,6 +11,9 @@ import sys
 
 class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
     def __init__(self, upgrade_info):
+        # set file/blob location for post_upgrade script
+        self.post_upgrade_file_name = f"/home/{upgrade_info['ipv4_address']}/post_upgrade.sh"
+        self.post_upgrade_blob_name = f"{upgrade_info['manufacturer']}/{upgrade_info['model']}/{upgrade_info['target_firmware_version']}/post_upgrade.sh"
         super().__init__(upgrade_info)
 
     def upgrade(self):
@@ -34,9 +39,6 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             scp.put(self.local_file_name, remote_path="/tmp/")
             scp.close()
 
-            # Delete local installation package and its parent directory so it doesn't take up storage space
-            self.cleanup()
-
             # Run firmware upgrade and reboot
             logging.info("Running firmware upgrade...")
             _stdin, _stdout, _stderr = ssh.exec_command(
@@ -52,6 +54,13 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             ssh.exec_command("reboot")
             ssh.close()
 
+            # In here check to see if post_upgrade is present
+            if (self.download_blob(self.post_upgrade_blob_name, self.post_upgrade_file_name)):
+                self.post_upgrade()
+
+            # Delete local installation package and its parent directory so it doesn't take up storage space
+            self.cleanup()
+
             # Notify Firmware Manager of successful firmware upgrade completion
             self.notify_firmware_manager(success=True)
         except Exception as err:
@@ -60,6 +69,61 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             self.cleanup()
             self.notify_firmware_manager(success=False)
 
+    def post_upgrade(self):
+        if self.wait_until_online() == -1:
+            raise Exception("RSU offline for too long after firmware upgrade")
+        try:
+            time.sleep(60)
+            # Make connection with the target device
+            logging.info("Making SSH connection with the device...")
+            ssh = SSHClient()
+            ssh.set_missing_host_key_policy(WarningPolicy)
+            ssh.connect(
+                self.rsu_ip,
+                username=self.ssh_username,
+                password=self.ssh_password,
+                look_for_keys=False,
+                allow_agent=False,
+            )
+
+            # Make SCP client to copy over the post upgrade script s to the /tmp/ directory on the remote device
+            logging.info("Copying post upgrade script to the device...")
+            scp = SCPClient(ssh.get_transport())
+            scp.put(self.post_upgrade_file_name, remote_path="/tmp/")
+            scp.close()
+
+            # Run post upgrade
+            logging.info("Running post upgrade script...")
+            ssh.exec_command(
+                f"chmod +x /tmp/post_upgrade.sh"
+            )
+            _stdin, _stdout, _stderr = ssh.exec_command(
+                f"/tmp/post_upgrade.sh"
+            )
+            decoded_stdout = _stdout.read().decode()
+            logging.info(decoded_stdout)
+            if "ALL OK" not in decoded_stdout:
+                ssh.close()
+                logging.error(f"Failed to execute post upgrade script for rsu {self.rsu_ip}: {decoded_stdout}")
+                return
+            ssh.close()
+            logging.info(f"Post upgrade script executed successfully for rsu: {self.rsu_ip}.")
+        except Exception as err:
+            logging.error(f"Failed to execute post upgrade script for rsu {self.rsu_ip}: {err}")
+            
+    def wait_until_online(self):
+        iter = 0
+        # Ping once every second for 3 minutes until online
+        while iter < 180:
+            time.sleep(1)
+            code = subprocess.run(
+                ["ping", "-n", "-c1", self.rsu_ip], capture_output=True
+            ).returncode
+            if code == 0:
+                return 0
+            iter += 1
+        # 3 minutes pass with no response
+        return -1
 
 # sys.argv[1] - JSON string with the following key-values:
 # - ipv4_address

--- a/services/addons/images/firmware_manager/download_blob.py
+++ b/services/addons/images/firmware_manager/download_blob.py
@@ -10,7 +10,10 @@ def download_gcp_blob(blob_name, destination_file_name):
     storage_client = storage.Client(gcp_project)
     bucket = storage_client.get_bucket(bucket_name)
     blob = bucket.blob(blob_name)
-    blob.download_to_filename(destination_file_name)
-    logging.info(
-        f"Downloaded storage object {blob_name} from bucket {bucket_name} to local file {destination_file_name}."
-    )
+    if blob.exists():
+        blob.download_to_filename(destination_file_name)
+        logging.info(
+            f"Downloaded storage object {blob_name} from bucket {bucket_name} to local file {destination_file_name}."
+        )
+        return True
+    return False

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -27,7 +27,7 @@ class UpgraderAbstractClass(abc.ABC):
                 shutil.rmtree(path)
 
     # Downloads firmware install package blob to /home/rsu_ip/
-    def download_blob(self):
+    def download_blob(self, blob_name=None, local_file_name=None):
         # Create parent rsu_ip directory
         path = self.local_file_name[: self.local_file_name.rfind("/")]
         Path(path).mkdir(exist_ok=True)
@@ -35,7 +35,9 @@ class UpgraderAbstractClass(abc.ABC):
         # Download blob, defaults to GCP blob storage
         bsp = os.environ.get("BLOB_STORAGE_PROVIDER", "GCP")
         if bsp == "GCP":
-            download_blob.download_gcp_blob(self.blob_name, self.local_file_name)
+            blob_name = self.blob_name if blob_name is None else blob_name
+            local_file_name = self.local_file_name if local_file_name is None else local_file_name
+            return download_blob.download_gcp_blob(blob_name, local_file_name)
         else:
             logging.error("Unsupported blob storage provider")
 

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import abc
+import subprocess
+import time
 import download_blob
 import logging
 import os
@@ -55,6 +57,20 @@ class UpgraderAbstractClass(abc.ABC):
             logging.error(
                 f"Failed to connect to the Firmware Manager API for '{self.rsu_ip}': {err}"
             )
+
+    def wait_until_online(self):
+        iter = 0
+        # Ping once every second for 3 minutes until online
+        while iter < 180:
+            time.sleep(1)
+            code = subprocess.run(
+                ["ping", "-n", "-c1", self.rsu_ip], capture_output=True
+            ).returncode
+            if code == 0:
+                return 0
+            iter += 1
+        # 3 minutes pass with no response
+        return -1
 
     # This needs to be defined for each implementation
     @abc.abstractclassmethod

--- a/services/addons/images/firmware_manager/yunex_upgrader.py
+++ b/services/addons/images/firmware_manager/yunex_upgrader.py
@@ -41,20 +41,6 @@ class YunexUpgrader(upgrader.UpgraderAbstractClass):
         # If everything goes as expected, the XFER upgrade was complete
         return 0
 
-    def wait_until_online(self):
-        iter = 0
-        # Ping once every second for 3 minutes until online
-        while iter < 180:
-            time.sleep(1)
-            code = subprocess.run(
-                ["ping", "-n", "-c1", self.rsu_ip], capture_output=True
-            ).returncode
-            if code == 0:
-                return 0
-            iter += 1
-        # 3 minutes pass with no response
-        return -1
-
     def upgrade(self):
         try:
             # Download firmware installation package TAR file

--- a/services/addons/tests/firmware_manager/test_commsignia_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_commsignia_upgrader.py
@@ -33,7 +33,7 @@ def test_commsignia_upgrader_init():
 
 @patch("addons.images.firmware_manager.commsignia_upgrader.SCPClient")
 @patch("addons.images.firmware_manager.commsignia_upgrader.SSHClient")
-def test_commsignia_upgrader_upgrade_success(mock_sshclient, mock_scpclient):
+def test_commsignia_upgrader_upgrade_success_no_post_update(mock_sshclient, mock_scpclient):
     # Mock SSH Client and successful firmware upgrade return value
     sshclient_obj = mock_sshclient.return_value
     _stdout = MagicMock()
@@ -44,7 +44,7 @@ def test_commsignia_upgrader_upgrade_success(mock_sshclient, mock_scpclient):
     scpclient_obj = mock_scpclient.return_value
 
     test_commsignia_upgrader = CommsigniaUpgrader(test_upgrade_info)
-    test_commsignia_upgrader.download_blob = MagicMock()
+    test_commsignia_upgrader.download_blob = MagicMock(return_value=False)
     test_commsignia_upgrader.cleanup = MagicMock()
     notify = MagicMock()
     test_commsignia_upgrader.notify_firmware_manager = notify
@@ -77,6 +77,61 @@ def test_commsignia_upgrader_upgrade_success(mock_sshclient, mock_scpclient):
     # Assert notified success value
     notify.assert_called_with(success=True)
 
+@patch("addons.images.firmware_manager.commsignia_upgrader.SCPClient")
+@patch("addons.images.firmware_manager.commsignia_upgrader.SSHClient")
+@patch("addons.images.firmware_manager.commsignia_upgrader.time")
+def test_commsignia_upgrader_upgrade_success_post_update(mock_time, mock_sshclient, mock_scpclient):
+    # Mock SSH Client and successful firmware upgrade return value
+    sshclient_obj = mock_sshclient.return_value
+    _stdout = MagicMock()
+    sshclient_obj.exec_command.return_value = MagicMock(), _stdout, MagicMock()
+    _stdout.read.return_value.decode.return_value = "ALL OK"
+
+    # Mock SCP Client
+    scpclient_obj = mock_scpclient.return_value
+
+    test_commsignia_upgrader = CommsigniaUpgrader(test_upgrade_info)
+    test_commsignia_upgrader.download_blob = MagicMock(return_value=True)
+    test_commsignia_upgrader.cleanup = MagicMock()
+    notify = MagicMock()
+    test_commsignia_upgrader.notify_firmware_manager = notify
+    test_commsignia_upgrader.wait_until_online = MagicMock(return_value=0)
+
+    # Mock time.sleep to avoid waiting during test
+    mock_time.sleep = MagicMock(return_value=None)
+
+    test_commsignia_upgrader.upgrade()
+
+    # Assert initial SSH connection
+    sshclient_obj.set_missing_host_key_policy.assert_called_with(WarningPolicy)
+    sshclient_obj.connect.assert_called_with(
+        "8.8.8.8",
+        username="test-user",
+        password="test-psw",
+        look_for_keys=False,
+        allow_agent=False,
+    )
+
+    # Assert SCP file transfer
+    mock_scpclient.assert_called_with(sshclient_obj.get_transport())
+    scpclient_obj.put.assert_called_with(
+        "/home/8.8.8.8/post_upgrade.sh", remote_path="/tmp/"
+    )
+    scpclient_obj.close.assert_called_with()
+
+    # Assert SSH firmware upgrade run
+    sshclient_obj.exec_command.assert_has_calls(
+        [
+            call("signedUpgrade.sh /tmp/firmware_package.tar"), 
+            call("reboot"),
+            call("chmod +x /tmp/post_upgrade.sh"),
+            call("/tmp/post_upgrade.sh"),
+        ]
+    )
+    sshclient_obj.close.assert_called_with()
+
+    # Assert notified success value
+    notify.assert_called_with(success=True)
 
 @patch("addons.images.firmware_manager.commsignia_upgrader.SCPClient")
 @patch("addons.images.firmware_manager.commsignia_upgrader.SSHClient")

--- a/services/addons/tests/firmware_manager/test_yunex_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_yunex_upgrader.py
@@ -60,7 +60,7 @@ def test_yunex_upgrader_run_xfer_upgrade_fail_code(mock_subprocess):
 
     test_yunex_upgrader = YunexUpgrader(test_upgrade_info)
     code = test_yunex_upgrader.run_xfer_upgrade("core-file-name")
-
+ 
     assert code == -1
 
 
@@ -78,34 +78,6 @@ def test_yunex_upgrader_run_xfer_upgrade_fail_output(mock_subprocess):
     code = test_yunex_upgrader.run_xfer_upgrade("core-file-name")
 
     assert code == -1
-
-
-@patch("addons.images.firmware_manager.yunex_upgrader.time")
-@patch("addons.images.firmware_manager.yunex_upgrader.subprocess")
-def test_yunex_upgrader_wait_until_online_success(mock_subprocess, mock_time):
-    run_response_obj = MagicMock()
-    run_response_obj.returncode = 0
-    mock_subprocess.run.return_value = run_response_obj
-
-    test_yunex_upgrader = YunexUpgrader(test_upgrade_info)
-    code = test_yunex_upgrader.wait_until_online()
-
-    assert code == 0
-    assert mock_time.sleep.call_count == 1
-
-
-@patch("addons.images.firmware_manager.yunex_upgrader.time")
-@patch("addons.images.firmware_manager.yunex_upgrader.subprocess")
-def test_yunex_upgrader_wait_until_online_timeout(mock_subprocess, mock_time):
-    run_response_obj = MagicMock()
-    run_response_obj.returncode = 1
-    mock_subprocess.run.return_value = run_response_obj
-
-    test_yunex_upgrader = YunexUpgrader(test_upgrade_info)
-    code = test_yunex_upgrader.wait_until_online()
-
-    assert code == -1
-    assert mock_time.sleep.call_count == 180
 
 
 @patch("addons.images.firmware_manager.yunex_upgrader.time")


### PR DESCRIPTION
## Description

This update allows for a post_upgrade.sh script to be run (if present) after a firmware upgrade is complete on Commsignia RSUs.

## How Has This Been Tested?

This has been tested by deploying in the CDOT Dev environment and running an example post_upgrade.sh script on a Commsignia unit. Additionally, these changes have been verified to work correctly when no post_upgrade.sh script is present.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ X ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ X ] My changes require updates to the documentation:
  - [ X ] I have updated the documentation accordingly.
- [ X ] My changes require updates and/or additions to the unit tests:
  - [ X ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
