### PR TITLE
Fix Purger Corner Cases

### DIFF
--- a/services/addons/images/rsu_status_check/purger.py
+++ b/services/addons/images/rsu_status_check/purger.py
@@ -1,13 +1,25 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import logging
 import common.pgquery as pgquery
 
 
-def get_last_online_rsu_records():
-    result = []
+def get_all_rsus():
+    query = "SELECT to_jsonb(row) FROM (SELECT rsu_id FROM public.rsus) AS row ORDER BY rsu_id"
+    data = pgquery.query_db(query)
 
+    rsu_obj = {}
+    for row in data:
+        row = dict(row[0])
+        rsu_obj[row["rsu_id"]] = None
+
+    return rsu_obj
+
+
+def get_last_online_rsu_records(rsu_dict):
     query = (
+        "SELECT to_jsonb(row) "
+        "FROM ("
         "SELECT a.ping_id, a.rsu_id, a.timestamp "
         "FROM ("
         "SELECT pd.ping_id, pd.rsu_id, pd.timestamp, ROW_NUMBER() OVER (PARTITION BY pd.rsu_id order by pd.timestamp DESC) AS row_id "
@@ -15,39 +27,54 @@ def get_last_online_rsu_records():
         "WHERE pd.result = '1'"
         ") AS a "
         "WHERE a.row_id <= 1 ORDER BY rsu_id"
+        ") as row"
     )
     data = pgquery.query_db(query)
 
     # Create list of RSU last online ping records
     # Tuple in the format of (ping_id, rsu_id, timestamp (UTC))
-    result = [value for value in data]
+    for row in data:
+        row = dict(row[0])
 
-    return result
+        if row["rsu_id"] not in rsu_dict:
+            # If there is ping data for a RSU not in the PostgreSQL 'rsus' table, it is most likely old and no longer tracked
+            # This will allow for all of the stale ping data to be removed
+            rsu_dict[row["rsu_id"]] = None
+        else:
+            rsu_dict[row["rsu_id"]] = {
+                "ping_id": row["ping_id"],
+                "timestamp": datetime.strptime(row["timestamp"], "%Y-%m-%dT%H:%M:%S"),
+            }
+    return rsu_dict
 
 
 def purge_ping_data(stale_period):
-    last_online_list = get_last_online_rsu_records()
+    rsu_dict = get_all_rsus()
+    online_rsu_dict = get_last_online_rsu_records(rsu_dict)
 
-    stale_point = datetime.utcnow() - timedelta(hours=stale_period)
-    stale_point_str = stale_point.strftime("%Y/%m/%dT%H:%M:%S")
+    stale_point = datetime.now() - timedelta(hours=stale_period)
+    stale_point_str = stale_point.strftime("%Y-%m-%dT%H:%M:%S")
 
-    for record in last_online_list:
-        logging.debug(f"Cleaning up rsu_id: {str(record[1])}")
-        # Check if the RSU has been offline longer than the stale period
-        if record[2] < stale_point:
-            logging.debug(
-                f"Latest record of rsu_id {str(record[1])} is a stale RSU ping record (ping_id: {str(record[0])})"
-            )
-            # Create query to delete all records of the stale ping data besides the latest record
-            purge_query = (
-                "DELETE FROM public.ping "
-                f"WHERE rsu_id = {str(record[1])} AND ping_id != {str(record[0])}"
-            )
-        else:
+    logging.info(f"Purging all ping data before {stale_point_str}")
+
+    for key, value in online_rsu_dict.items():
+        logging.debug(f"Cleaning up rsu_id: {str(key)}")
+
+        purge_query = ""
+        if value is not None:
+            if value["timestamp"] < stale_point:
+                # Create query to delete all records of the stale ping data besides the latest record
+                purge_query = (
+                    "DELETE FROM public.ping "
+                    f"WHERE rsu_id = {str(key)} AND ping_id != {str(value["ping_id"])}"
+                )
+
+        # If the RSU is no longer tracked or the last ping was within the last 24 hours, purge all data beyond the stale point
+        if purge_query == "":
             # Create query to delete all records before the stale_point
             purge_query = (
                 "DELETE FROM public.ping "
-                f"WHERE rsu_id = {str(record[1])} AND timestamp < '{stale_point_str}'::timestamp"
+                f"WHERE rsu_id = {str(key)} AND timestamp < '{stale_point_str}'::timestamp"
             )
 
         pgquery.write_db(purge_query)

--- a/services/addons/tests/rsu_status_check/test_purger.py
+++ b/services/addons/tests/rsu_status_check/test_purger.py
@@ -4,34 +4,54 @@ from addons.images.rsu_status_check import purger
 from freezegun import freeze_time
 
 
-@freeze_time("2023-07-06")
+@patch("addons.images.rsu_status_check.purger.pgquery.query_db")
+def test_get_all_rsus(mock_query_db):
+    # mock
+    mock_query_db.return_value = [
+        ({"rsu_id": 1},),
+        ({"rsu_id": 2},),
+        ({"rsu_id": 3},),
+        ({"rsu_id": 4},),
+    ]
+
+    # call
+    result = purger.get_all_rsus()
+
+    # check
+    assert 1 in result and result[1] is None
+    assert 2 in result and result[2] is None
+    assert 3 in result and result[3] is None
+    assert 4 in result and result[4] is None
+    assert 5 not in result
+
+
 @patch("addons.images.rsu_status_check.purger.pgquery.query_db")
 def test_get_last_online_rsu_records(mock_query_db):
     # mock
-    mock_query_db.return_value = [(1, 1, datetime.now())]
+    mock_query_db.return_value = [
+        ({"ping_id": 1, "rsu_id": 1, "timestamp": "2023-07-06T00:00:00"},),
+    ]
+    rsu_dict = {1: None}
 
     # call
-    result = purger.get_last_online_rsu_records()
+    result = purger.get_last_online_rsu_records(rsu_dict)
 
     # check
     assert len(result) == 1
-    assert result[0][0] == 1
-    assert result[0][1] == 1
-    assert result[0][2].strftime("%Y/%m/%d") == "2023/07/06"
+    assert result[1]["ping_id"] == 1
+    assert result[1]["timestamp"].strftime("%Y/%m/%d") == "2023/07/06"
 
 
 @freeze_time("2023-07-06")
+@patch("addons.images.rsu_status_check.purger.get_all_rsus", MagicMock())
+@patch("addons.images.rsu_status_check.purger.get_last_online_rsu_records")
 @patch("addons.images.rsu_status_check.purger.pgquery.write_db")
-def test_purge_ping_data(mock_write_db):
+def test_purge_ping_data(mock_write_db, mock_glorr):
     now_dt = datetime.now()
-    purger.get_last_online_rsu_records = MagicMock(
-        return_value=[
-            [0, 0, now_dt - timedelta(hours=10)],
-            [1, 1, now_dt - timedelta(days=3)],
-        ]
-    )
-    purger.logging.info = MagicMock()
-    purger.logging.debug = MagicMock()
+    mock_glorr.return_value = {
+        1: {"ping_id": 1, "timestamp": now_dt - timedelta(hours=10)},
+        2: {"ping_id": 2, "timestamp": now_dt - timedelta(days=3)},
+    }
 
     purger.purge_ping_data(24)
 
@@ -39,24 +59,21 @@ def test_purge_ping_data(mock_write_db):
     mock_write_db.assert_has_calls(
         [
             call(
-                "DELETE FROM public.ping WHERE rsu_id = 0 AND timestamp < '2023/07/05T00:00:00'::timestamp"
+                "DELETE FROM public.ping WHERE rsu_id = 1 AND timestamp < '2023-07-05T00:00:00'::timestamp"
             ),
-            call("DELETE FROM public.ping WHERE rsu_id = 1 AND ping_id != 1"),
+            call("DELETE FROM public.ping WHERE rsu_id = 2 AND ping_id != 2"),
         ]
     )
-    purger.logging.info.assert_called_once()
 
 
 @freeze_time("2023-07-06")
+@patch("addons.images.rsu_status_check.purger.get_all_rsus", MagicMock())
+@patch("addons.images.rsu_status_check.purger.get_last_online_rsu_records")
 @patch("addons.images.rsu_status_check.purger.pgquery.write_db")
-def test_purge_ping_data_none(mock_write_db):
-    now_dt = datetime.now()
-    purger.get_last_online_rsu_records = MagicMock(return_value=[])
-    purger.logging.info = MagicMock()
-    purger.logging.debug = MagicMock()
+def test_purge_ping_data_none(mock_write_db, mock_glorr):
+    mock_glorr.return_value = {}
 
     purger.purge_ping_data(24)
 
     purger.get_last_online_rsu_records.assert_called_once()
     mock_write_db.assert_not_called()
-    purger.logging.info.assert_called_once()


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This fix resolves corner cases that have shown to be present within the purger script in the rsu_status_check addon. These issues have been identified through observing the CDOT deployment of the rsu_status_check service.

- Currently RSUs that have only offline records are ignored by the purger. This update ensures the removal of all stale ping data for every RSU tracked in the PostgreSQL 'rsus' table regardless of it having an online record at any point or not.
- RSUs that have been removed from the CV Manager after online data has been collected from them were previously not removed by the purger. The purger will now properly remove all untracked RSU data older than the stale period.
- Update queries to better support the latest version of Python sqlalchemy. This is not a new library update. The purger function was not properly updated last year when the library was actually upgraded.

## How Has This Been Tested?

Through unit tests and deployment in CDOT GCP K8s dev environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
