### PR TITLE
Geo-Msg-Query Bug Fix

### DIFF
--- a/services/addons/images/geo_msg_query/geo_msg_query.py
+++ b/services/addons/images/geo_msg_query/geo_msg_query.py
@@ -28,6 +28,8 @@ def create_message(original_message, msg_type):
             latitude = original_message["payload"]["data"]["position"]["latitude"]
         if latitude and longitude:
             timestamp_str = original_message["metadata"]["odeReceivedAt"]
+            # checking if the timestamp is using nanoseconds and then truncating
+            # to milliseconds to avoid exceptions when creating the datetime object.
             if len(timestamp_str) > 26:
                 timestamp_str = timestamp_str[:26] + "Z"
             new_message = {
@@ -150,7 +152,6 @@ def run():
     logging.basicConfig(format="%(levelname)s:%(message)s", level=log_level)
 
     logging.debug("Starting the service with environment variables: ")
-    logging.debug(f"MONGO_DB_URI: {MONGO_DB_URI}")
     logging.debug(f"MONGO_DB: {MONGO_DB}")
     logging.debug(f"MONGO_INPUT_COLLECTIONS: {MONGO_INPUT_COLLECTIONS}")
     logging.debug(f"MONGO_GEO_OUTPUT_COLLECTION: {MONGO_GEO_OUTPUT_COLLECTION}")

--- a/services/addons/tests/geo_msg_query/test_geo_query.py
+++ b/services/addons/tests/geo_msg_query/test_geo_query.py
@@ -40,6 +40,33 @@ def test_create_message_bsm():
     assert create_message(original_message, msg_type) == expected_message
 
 
+def test_create_message_bsm_millis():
+    original_message = {
+        "payload": {
+            "data": {"coreData": {"position": {"longitude": 123.456, "latitude": 78.9}}}
+        },
+        "metadata": {
+            "odeReceivedAt": "2022-01-01T12:34:56.789Z",
+            "originIp": "127.0.0.1",
+        },
+    }
+    msg_type = "Bsm"
+
+    expected_message = {
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [123.456, 78.9]},
+        "properties": {
+            "id": "127.0.0.1",
+            "timestamp": datetime.strptime(
+                "2022-01-01T12:34:56.789Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+            ),
+            "msg_type": "Bsm",
+        },
+    }
+
+    assert create_message(original_message, msg_type) == expected_message
+
+
 def test_create_message_psm():
     original_message = {
         "payload": {"data": {"position": {"longitude": 12.34, "latitude": 56.78}}},

--- a/services/addons/tests/geo_msg_query/test_geo_query.py
+++ b/services/addons/tests/geo_msg_query/test_geo_query.py
@@ -13,7 +13,7 @@ from addons.images.geo_msg_query.geo_msg_query import (
 
 
 # create_message unit tests
-def test_create_message_bsm():
+def test_create_message_bsm_nanoseconds():
     original_message = {
         "payload": {
             "data": {"coreData": {"position": {"longitude": 123.456, "latitude": 78.9}}}
@@ -40,7 +40,7 @@ def test_create_message_bsm():
     assert create_message(original_message, msg_type) == expected_message
 
 
-def test_create_message_bsm_millis():
+def test_create_message_bsm_milliseconds():
     original_message = {
         "payload": {
             "data": {"coreData": {"position": {"longitude": 123.456, "latitude": 78.9}}}


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Found a bug with the geo_msg_query add-on failing in dev, with the "odeReceivedAt" being in milliseconds rather than nanoseconds. This change updates the addon to handle both milliseconds and nanoseconds.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a unit test for each and improved logging in case of other failures.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ x ] My changes require updates and/or additions to the unit tests:
  - [ x ] I have modified/added tests to cover my changes.
- [ x ] All existing tests pass.
