### PR TITLE
Help screen header fix

### DIFF
--- a/webapp/src/components/css/Help.css
+++ b/webapp/src/components/css/Help.css
@@ -1,8 +1,8 @@
 #help {
   width: '100%';
-  height: fit-content;
-  background-color: #15317e;
+  height: calc(100vh - 215px);
   padding-bottom: 5em;
+  overflow-y: scroll;
 }
 
 .helpHeader {


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Limits the scrolling menu to the div for the help page instead of the entire page. This ensures the Help page behaves properly with a static header at the top of the page.

## How Has This Been Tested?

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
