### PR TITLE
Fix Orphan RSUs/Users Bug on Organization Delete

### DIFF
--- a/services/api/src/admin_org.py
+++ b/services/api/src/admin_org.py
@@ -246,23 +246,27 @@ def delete_org(org_name):
 
 def check_orphan_rsus(org):
     rsu_query = (
-        "SELECT rsu_id, count(organization_id) FROM rsu_organization WHERE rsu_id IN (SELECT rsu_id FROM rsu_organization WHERE organization_id = "
-        f"(SELECT organization_id FROM organizations WHERE name = '{org}')) GROUP BY rsu_id"
+        "SELECT to_jsonb(row) "
+        "FROM (SELECT rsu_id, count(organization_id) count FROM rsu_organization WHERE rsu_id IN (SELECT rsu_id FROM rsu_organization WHERE organization_id = "
+        f"(SELECT organization_id FROM organizations WHERE name = '{org}')) GROUP BY rsu_id) as row"
     )
     rsu_count = pgquery.query_db(rsu_query)
-    for rsu in rsu_count:
-        if rsu[1] == 1: 
+    for row in rsu_count:
+        rsu = dict(row[0])
+        if rsu["count"] == 1: 
             return True
     return False
 
 def check_orphan_users(org):
     user_query = (
-        "SELECT user_id, count(organization_id) FROM user_organization WHERE user_id IN (SELECT user_id FROM user_organization WHERE organization_id = "
-        f"(SELECT organization_id FROM organizations WHERE name = '{org}')) GROUP BY user_id"
+        "SELECT to_jsonb(row) "
+        "FROM (SELECT user_id, count(organization_id) count FROM user_organization WHERE user_id IN (SELECT user_id FROM user_organization WHERE organization_id = "
+        f"(SELECT organization_id FROM organizations WHERE name = '{org}')) GROUP BY user_id) as row"
         )
     user_count = pgquery.query_db(user_query)
-    for user in user_count:
-        if user[1] == 1:
+    for row in user_count:
+        user = dict(row[0])
+        if user["count"] == 1:
             return True
     return False
 

--- a/services/api/src/admin_org.py
+++ b/services/api/src/admin_org.py
@@ -217,6 +217,25 @@ def modify_org(org_spec):
 
 
 def delete_org(org_name):
+    # Check to make sure there aren't any RSUs or users associated with just this organization
+    rsu_query = (
+        "SELECT rsu_id, count(organization_id) FROM rsu_organization WHERE rsu_id IN (SELECT rsu_id FROM rsu_organization WHERE organization_id = "
+        f"(SELECT organization_id FROM organizations WHERE name = '{org_name}')) GROUP BY rsu_id"
+        )
+    rsu_count = pgquery.query_db(rsu_query)
+    for rsu in rsu_count:
+        if rsu[1] == 1: 
+            return {"message": "Cannot delete organization that has one or more RSUs only associated with this organization"}, 400
+        
+    user_query = (
+        "SELECT user_id, count(organization_id) FROM user_organization WHERE user_id IN (SELECT user_id FROM user_organization WHERE organization_id = "
+        f"(SELECT organization_id FROM organizations WHERE name = '{org_name}')) GROUP BY user_id"
+        )
+    user_count = pgquery.query_db(user_query)
+    for user in user_count:
+        if user[1] == 1:
+            return {"message": "Cannot delete organization that has one or more users only associated with this organization"}, 400
+    
     # Delete user-to-organization relationships
     user_org_remove_query = (
         "DELETE FROM public.user_organization WHERE "
@@ -235,7 +254,7 @@ def delete_org(org_name):
     org_remove_query = "DELETE FROM public.organizations WHERE " f"name = '{org_name}'"
     pgquery.write_db(org_remove_query)
 
-    return {"message": "Organization successfully deleted"}
+    return {"message": "Organization successfully deleted"}, 200
 
 
 # REST endpoint resource class
@@ -313,4 +332,5 @@ class AdminOrg(Resource):
             abort(400, errors)
 
         org_name = urllib.request.unquote(request.args["org_name"])
-        return (delete_org(org_name), 200, self.headers)
+        message, code = delete_org(org_name)
+        return (message, code, self.headers)

--- a/services/api/tests/src/test_admin_org.py
+++ b/services/api/tests/src/test_admin_org.py
@@ -284,7 +284,7 @@ def test_delete_org(mock_query_db, mock_write_db):
 
 @patch("api.src.admin_org.pgquery.query_db")
 def test_delete_org_failure_orphan_rsu(mock_query_db):
-    mock_query_db.return_value = [[1, 2], [2, 1]]
+    mock_query_db.return_value = [[{"user_id": 1, "count": 2}], [{"user_id": 2, "count": 1}]]
     expected_result = {"message": "Cannot delete organization that has one or more RSUs only associated with this organization"}, 400
     actual_result = admin_org.delete_org("test org")
 
@@ -294,7 +294,7 @@ def test_delete_org_failure_orphan_rsu(mock_query_db):
 @patch("api.src.admin_org.check_orphan_rsus")
 def test_delete_org_failure_orphan_user(mock_orphan_rsus, mock_query_db):
     mock_orphan_rsus.return_value = False
-    mock_query_db.return_value = [[1, 2], [2, 1]]
+    mock_query_db.return_value = [[{"user_id": 1, "count": 2}], [{"user_id": 2, "count": 1}]]
     expected_result = {"message": "Cannot delete organization that has one or more users only associated with this organization"}, 400
     actual_result = admin_org.delete_org("test org")
 

--- a/services/api/tests/src/test_admin_org.py
+++ b/services/api/tests/src/test_admin_org.py
@@ -281,3 +281,21 @@ def test_delete_org(mock_query_db, mock_write_db):
     ]
     mock_write_db.assert_has_calls(calls)
     assert actual_result == expected_result
+
+@patch("api.src.admin_org.pgquery.query_db")
+def test_delete_org_failure_orphan_rsu(mock_query_db):
+    mock_query_db.return_value = [[1, 2], [2, 1]]
+    expected_result = {"message": "Cannot delete organization that has one or more RSUs only associated with this organization"}, 400
+    actual_result = admin_org.delete_org("test org")
+
+    assert actual_result == expected_result
+
+@patch("api.src.admin_org.pgquery.query_db")
+@patch("api.src.admin_org.check_orphan_rsus")
+def test_delete_org_failure_orphan_user(mock_orphan_rsus, mock_query_db):
+    mock_orphan_rsus.return_value = False
+    mock_query_db.return_value = [[1, 2], [2, 1]]
+    expected_result = {"message": "Cannot delete organization that has one or more users only associated with this organization"}, 400
+    actual_result = admin_org.delete_org("test org")
+
+    assert actual_result == expected_result

--- a/services/api/tests/src/test_admin_org.py
+++ b/services/api/tests/src/test_admin_org.py
@@ -87,7 +87,7 @@ def test_entry_delete_user(mock_delete_org):
     req = MagicMock()
     req.environ = admin_org_data.request_environ
     req.args = admin_org_data.request_args_good
-    mock_delete_org.return_value = {}
+    mock_delete_org.return_value = {"message": "Organization successfully deleted"}, 200
     with patch("api.src.admin_org.request", req):
         status = admin_org.AdminOrg()
         (body, code, headers) = status.delete()
@@ -97,7 +97,7 @@ def test_entry_delete_user(mock_delete_org):
         )
         assert code == 200
         assert headers["Access-Control-Allow-Origin"] == "test.com"
-        assert body == {}
+        assert body == {"message": "Organization successfully deleted"}
 
 
 def test_entry_delete_schema():
@@ -268,8 +268,10 @@ def test_modify_org_sql_exception(mock_pgquery, mock_check_safe_input):
 
 
 @patch("api.src.admin_org.pgquery.write_db")
-def test_delete_org(mock_write_db):
-    expected_result = {"message": "Organization successfully deleted"}
+@patch("api.src.admin_org.pgquery.query_db")
+def test_delete_org(mock_query_db, mock_write_db):
+    mock_query_db.return_value = []
+    expected_result = {"message": "Organization successfully deleted"}, 200
     actual_result = admin_org.delete_org("test org")
 
     calls = [

--- a/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
+++ b/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
@@ -116,7 +116,7 @@ const AdminOrganizationTab = () => {
 
       {errorState && (
         <p className="error-msg" role="alert">
-          Failed to obtain data due to error: {errorMsg}
+          Failed to perform action due to error: {errorMsg}
         </p>
       )}
 

--- a/webapp/src/features/adminOrganizationTab/adminOrganizationTabSlice.tsx
+++ b/webapp/src/features/adminOrganizationTab/adminOrganizationTabSlice.tsx
@@ -105,10 +105,9 @@ export const deleteOrg = createAsyncThunk(
       case 200:
         console.debug('Successfully deleted Organization: ' + org)
         dispatch(getOrgData({ orgName: 'all', all: true }))
-        return
+        return { success: true, message: '' }
       default:
-        console.error(data)
-        return
+        return { success: false, message: data.message }
     }
   },
   { condition: (_, { getState }) => selectToken(getState() as RootState) != undefined }
@@ -233,6 +232,17 @@ export const adminOrganizationTabSlice = createSlice({
       })
       .addCase(editOrg.rejected, (state) => {
         state.loading = false
+      })
+      .addCase(deleteOrg.fulfilled, (state, action) => {
+        state.loading = false
+        if (action.payload.success) {
+          state.value.errorMsg = ''
+          state.value.errorState = false
+        } else {
+          console.log(action)
+          state.value.errorMsg = action.payload.message
+          state.value.errorState = true
+        }
       })
   },
 })


### PR DESCRIPTION
# PR Details
## Description

Currently, users are prevented from deleting an RSU/User organization assignment if the RSU/User is only tied to one organization. This PR adds a check before deleting an organization to make sure there aren't any RSUs or Users that will be orphaned after the organization is deleted. 

## How Has This Been Tested?

This was tested locally using docker-compose.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ X ] My changes require updates and/or additions to the unit tests:
  - [ X ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
