### PR TITLE
Organization dropdown bug fix

### DIFF
--- a/webapp/src/Dashboard.tsx
+++ b/webapp/src/Dashboard.tsx
@@ -14,7 +14,7 @@ import {
   // Actions
   getRsuData,
 } from './generalSlices/rsuSlice'
-import { selectAuthLoginData, selectLoadingGlobal } from './generalSlices/userSlice'
+import { selectAuthLoginData, selectLoadingGlobal, selectOrganizationName } from './generalSlices/userSlice'
 import { SecureStorageManager } from './managers'
 import { ReactKeycloakProvider } from '@react-keycloak/web'
 import keycloak from './keycloak-config'
@@ -31,6 +31,7 @@ const Dashboard = () => {
   const dispatch: ThunkDispatch<RootState, void, AnyAction> = useDispatch()
   const authLoginData = useSelector(selectAuthLoginData)
   const loadingGlobal = useSelector(selectLoadingGlobal)
+  const organizationName = useSelector(selectOrganizationName)
 
   useEffect(() => {
     keycloak
@@ -53,7 +54,7 @@ const Dashboard = () => {
     dispatch(getRsuData())
   }, [authLoginData, dispatch])
 
-  console.log('Auth Role', SecureStorageManager.getUserRole())
+  useEffect(() => {}, [organizationName])
 
   return (
     <ReactKeycloakProvider

--- a/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
+++ b/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
@@ -66,6 +66,8 @@ const AdminOrganizationTab = () => {
 
   useEffect(() => {
     dispatch(getOrgData({ orgName: 'all', all: true, specifiedOrg: undefined })).then(() => {
+      // on first render set the default organization in the admin
+      // organization tab to the currently selected organization
       if (defaultOrgData) {
         const selectedOrg = (orgData ?? []).find(
           (organization: AdminOrgSummary) => organization?.name === defaultOrgName

--- a/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
+++ b/webapp/src/features/adminOrganizationTab/AdminOrganizationTab.tsx
@@ -23,6 +23,7 @@ import {
   getOrgData,
   updateTitle,
   setSelectedOrg,
+  AdminOrgSummary,
 } from './adminOrganizationTabSlice'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -31,6 +32,7 @@ import { RootState } from '../../store'
 import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { NotFound } from '../../pages/404'
+import { changeOrganization, selectOrganizationName, setOrganizationList } from '../../generalSlices/userSlice'
 
 const getTitle = (activeTab: string) => {
   if (activeTab === undefined) {
@@ -59,8 +61,19 @@ const AdminOrganizationTab = () => {
   const errorState = useSelector(selectErrorState)
   const errorMsg = useSelector(selectErrorMsg)
 
+  const defaultOrgName = useSelector(selectOrganizationName)
+  var defaultOrgData = orgData.find((org) => org.name === defaultOrgName)
+
   useEffect(() => {
-    dispatch(getOrgData({ orgName: 'all', all: true, specifiedOrg: undefined }))
+    dispatch(getOrgData({ orgName: 'all', all: true, specifiedOrg: undefined })).then(() => {
+      if (defaultOrgData) {
+        const selectedOrg = (orgData ?? []).find(
+          (organization: AdminOrgSummary) => organization?.name === defaultOrgName
+        )
+        dispatch(setSelectedOrg(selectedOrg))
+        defaultOrgData = null
+      }
+    })
   }, [dispatch])
 
   const updateTableData = (orgName: string) => {
@@ -77,6 +90,12 @@ const AdminOrganizationTab = () => {
 
   const refresh = () => {
     updateTableData(selectedOrgName)
+  }
+
+  const handleOrgDelete = (orgName) => {
+    dispatch(deleteOrg(orgName))
+    dispatch(setOrganizationList({ value: { name: orgName }, type: 'delete' }))
+    dispatch(changeOrganization(orgData[0].name))
   }
 
   return (
@@ -148,7 +167,7 @@ const AdminOrganizationTab = () => {
                 </Grid>
                 <Grid item xs={0}>
                   <AdminOrganizationDeleteMenu
-                    deleteOrganization={() => dispatch(deleteOrg(selectedOrgName))}
+                    deleteOrganization={() => handleOrgDelete(selectedOrgName)}
                     selectedOrganization={selectedOrgName}
                   />
                 </Grid>

--- a/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
+++ b/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
@@ -25,7 +25,7 @@ import {
   setSelectedUserRole,
   setSelectedUserList,
 } from './adminOrganizationTabUserSlice'
-import { selectLoadingGlobal } from '../../generalSlices/userSlice'
+import { selectAuthLoginData, selectLoadingGlobal, setOrganizationList } from '../../generalSlices/userSlice'
 import { useSelector, useDispatch } from 'react-redux'
 
 import '../adminRsuTab/Admin.css'
@@ -47,6 +47,7 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
   const selectedUserList = useSelector(selectSelectedUserList)
   const availableRoles = useSelector(selectAvailableRoles)
   const loadingGlobal = useSelector(selectLoadingGlobal)
+  const authLoginData = useSelector(selectAuthLoginData)
   const [userColumns] = useState<Column<any>[]>([
     {
       title: 'First Name',
@@ -155,6 +156,9 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
         updateTableData: props.updateTableData,
       })
     )
+    if (row.email === authLoginData?.data?.email) {
+      dispatch(setOrganizationList({ value: { name: props.selectedOrg, role: row.role }, type: 'delete' }))
+    }
   }
 
   const userMultiDelete = async (rows: AdminOrgUser[]) => {
@@ -165,6 +169,11 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
         updateTableData: props.updateTableData,
       })
     )
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i].email === authLoginData?.data?.email) {
+        dispatch(setOrganizationList({ value: { name: props.selectedOrg, role: rows[i].role }, type: 'delete' }))
+      }
+    }
   }
 
   const userMultiAdd = async (userList: AdminOrgUser[]) => {
@@ -175,6 +184,11 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
         updateTableData: props.updateTableData,
       })
     )
+    for (let i = 0; i < userList.length; i++) {
+      if (userList[i].email === authLoginData?.data?.email) {
+        dispatch(setOrganizationList({ value: { name: props.selectedOrg, role: userList[i].role }, type: 'add' }))
+      }
+    }
   }
 
   const userBulkEdit = async (

--- a/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
+++ b/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
@@ -25,7 +25,12 @@ import {
   setSelectedUserRole,
   setSelectedUserList,
 } from './adminOrganizationTabUserSlice'
-import { selectAuthLoginData, selectLoadingGlobal, setOrganizationList } from '../../generalSlices/userSlice'
+import {
+  selectAuthLoginData,
+  selectEmail,
+  selectLoadingGlobal,
+  setOrganizationList,
+} from '../../generalSlices/userSlice'
 import { useSelector, useDispatch } from 'react-redux'
 
 import '../adminRsuTab/Admin.css'
@@ -48,6 +53,7 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
   const availableRoles = useSelector(selectAvailableRoles)
   const loadingGlobal = useSelector(selectLoadingGlobal)
   const authLoginData = useSelector(selectAuthLoginData)
+  const userEmail = useSelector(selectEmail)
   const [userColumns] = useState<Column<any>[]>([
     {
       title: 'First Name',
@@ -203,6 +209,7 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
     dispatch(
       userBulkEditAction({
         json,
+        selectedUser: userEmail,
         selectedOrg: props.selectedOrg,
         updateTableData: props.updateTableData,
       })

--- a/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUserTypes.d.ts
+++ b/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUserTypes.d.ts
@@ -18,5 +18,6 @@ export type AdminOrgUserDeleteMultiple = {
 export type AdminOrgTabUserBulkEdit = {
   json: { [key: string]: { newData: AdminOrgTabUser } }
   selectedOrg: string
+  selectedUser: string
   updateTableData: (org: string) => void
 }

--- a/webapp/src/features/adminOrganizationTabUser/adminOrganizationTabUserSlice.test.ts
+++ b/webapp/src/features/adminOrganizationTabUser/adminOrganizationTabUserSlice.test.ts
@@ -378,10 +378,11 @@ describe('async thunks', () => {
         obj2: { newData: { email: 'test2@gmail.com', role: 'role2' } },
       }
       const selectedOrg = 'selectedOrg'
+      const selectedUser = 'selectedUser'
       const fetchPatchOrganization = jest.fn()
       const updateTableData = jest.fn()
 
-      const action = userBulkEdit({ json, selectedOrg, updateTableData })
+      const action = userBulkEdit({ json, selectedOrg, selectedUser, updateTableData })
 
       await action(dispatch, getState, undefined)
       expect(dispatch).toHaveBeenCalledTimes(2 + 2)

--- a/webapp/src/features/adminOrganizationTabUser/adminOrganizationTabUserSlice.tsx
+++ b/webapp/src/features/adminOrganizationTabUser/adminOrganizationTabUserSlice.tsx
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { selectToken } from '../../generalSlices/userSlice'
+import { selectToken, setOrganizationList } from '../../generalSlices/userSlice'
 import EnvironmentVars from '../../EnvironmentVars'
 import apiHelper from '../../apis/api-helper'
 import { RootState } from '../../store'
@@ -174,19 +174,26 @@ export const userAddMultiple = createAsyncThunk(
 export const userBulkEdit = createAsyncThunk(
   'adminOrganizationTabUser/userBulkEdit',
   async (payload: AdminOrgTabUserBulkEdit, { dispatch }) => {
-    const { json, selectedOrg, updateTableData } = payload
+    const { json, selectedOrg, selectedUser, updateTableData } = payload
 
     const patchJson: adminOrgPatch = {
       name: selectedOrg,
       users_to_modify: [],
     }
     const rows = Object.values(json)
+    var orgUpdateVal = {}
     for (var row of rows) {
+      if (row.newData.email === selectedUser) {
+        orgUpdateVal = { name: selectedOrg, role: row.newData.role }
+      }
       const userRole = { email: row.newData.email, role: row.newData.role }
       patchJson.users_to_modify.push(userRole)
     }
     await dispatch(editOrg(patchJson))
     dispatch(refresh({ selectedOrg, updateTableData }))
+    if (Object.keys(orgUpdateVal).length > 0) {
+      dispatch(setOrganizationList({ value: orgUpdateVal, orgName: selectedOrg, type: 'update' }))
+    }
   },
   { condition: (_, { getState }) => selectToken(getState() as RootState) != undefined }
 )

--- a/webapp/src/generalSlices/userSlice.ts
+++ b/webapp/src/generalSlices/userSlice.ts
@@ -72,7 +72,6 @@ export const userSlice = createSlice({
     },
     setOrganizationList: (state, action) => {
       if (action.payload.type === 'add') {
-        console.debug('payload: ', [...state.value.authLoginData.data.organizations, action.payload])
         state.value.authLoginData.data.organizations = [
           ...state.value.authLoginData.data.organizations,
           action.payload.value,
@@ -84,6 +83,13 @@ export const userSlice = createSlice({
         if (index > -1) {
           var updatedOrgList = state.value.authLoginData.data.organizations
           updatedOrgList.splice(index, 1)
+          state.value.authLoginData.data.organizations = [...updatedOrgList]
+        }
+      } else if (action.payload.type === 'update') {
+        var index = state.value.authLoginData.data.organizations.findIndex((org) => org.name === action.payload.orgName)
+        if (index > -1) {
+          var updatedOrgList = state.value.authLoginData.data.organizations
+          updatedOrgList[index] = action.payload.value
           state.value.authLoginData.data.organizations = [...updatedOrgList]
         }
       }

--- a/webapp/src/generalSlices/userSlice.ts
+++ b/webapp/src/generalSlices/userSlice.ts
@@ -65,8 +65,28 @@ export const userSlice = createSlice({
       SecureStorageManager.removeUserRole()
     },
     changeOrganization: (state, action) => {
-      state.value.organization =
+      var organization =
         UserManager.getOrganization(state.value.authLoginData, action.payload) ?? state.value.organization
+      state.value.organization = organization
+      SecureStorageManager.setUserRole({ name: organization.name, role: organization.role })
+    },
+    setOrganizationList: (state, action) => {
+      if (action.payload.type === 'add') {
+        console.debug('payload: ', [...state.value.authLoginData.data.organizations, action.payload])
+        state.value.authLoginData.data.organizations = [
+          ...state.value.authLoginData.data.organizations,
+          action.payload.value,
+        ]
+      } else if (action.payload.type === 'delete') {
+        var index = state.value.authLoginData.data.organizations.findIndex(
+          (org) => org.name === action.payload.value.name
+        )
+        if (index > -1) {
+          var updatedOrgList = state.value.authLoginData.data.organizations
+          updatedOrgList.splice(index, 1)
+          state.value.authLoginData.data.organizations = [...updatedOrgList]
+        }
+      }
     },
     setLoading: (state, action) => {
       state.loading = action.payload
@@ -102,7 +122,7 @@ export const userSlice = createSlice({
         state.value.authLoginData = action.payload
         state.value.organization = action.payload?.data?.organizations?.[0]
         LocalStorageManager.setAuthData(action.payload)
-        SecureStorageManager.setUserRole(action.payload)
+        SecureStorageManager.setUserRole(action.payload['data']['organizations'][0])
       })
       .addCase(keycloakLogin.rejected, (state, action: PayloadAction<unknown>) => {
         console.debug('keycloakLogin.rejected')
@@ -115,8 +135,15 @@ export const userSlice = createSlice({
   },
 })
 
-export const { logout, changeOrganization, setLoading, setLoginFailure, setKcFailure, setRouteNotFound } =
-  userSlice.actions
+export const {
+  logout,
+  changeOrganization,
+  setOrganizationList,
+  setLoading,
+  setLoginFailure,
+  setKcFailure,
+  setRouteNotFound,
+} = userSlice.actions
 
 export const selectAuthLoginData = (state: RootState) => state.user.value.authLoginData
 export const selectToken = (state: RootState) => state.user.value.authLoginData.token

--- a/webapp/src/managers.tsx
+++ b/webapp/src/managers.tsx
@@ -44,11 +44,8 @@ const SecureStorageManager = {
       return authData['role']
     }
   },
-  setUserRole: (authData) => {
-    return secureLocalStorage.setItem(
-      AUTH_DATA_SECURE_STORAGE_KEY,
-      JSON.stringify(authData['data']['organizations'][0])
-    )
+  setUserRole: (organization) => {
+    return secureLocalStorage.setItem(AUTH_DATA_SECURE_STORAGE_KEY, JSON.stringify(organization))
   },
   removeUserRole: () => {
     return secureLocalStorage.removeItem(AUTH_DATA_SECURE_STORAGE_KEY)

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -35,6 +35,7 @@ import {
 
   // actions
   selectRsu,
+  getRsuData,
   toggleMapDisplay,
   getIssScmsStatus,
   getMapData,
@@ -212,6 +213,7 @@ function MapPage(props: MapPageProps) {
 
   // useEffects for RSU layer
   useEffect(() => {
+    dispatch(getRsuData())
     dispatch(selectRsu(null))
     dispatch(clearFirmware())
   }, [organization, dispatch])


### PR DESCRIPTION
# PR Details
## Description

This PR modifies the organization dropdown menu to update correctly after a user-organization assignment is created, deleted, or edited for the current user. Additionally, the tabs displayed now update correctly after a new organization is selected from the dropdown menu. 

## How Has This Been Tested?

This has been tested locally via docker-compose with user-organization add, edit, and delete. Additionally, organization delete has been tested and the tabs shown to the user have been verified to update correctly after switching organizations.

## Types of changes

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ x ] My changes require updates and/or additions to the unit tests:
  - [ x ] I have modified/added tests to cover my changes.
- [ x ] All existing tests pass.
