### PR TITLE
Update admin edit pages to populate values correctly

### DIFF
--- a/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
+++ b/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
@@ -123,14 +123,15 @@ const AdminEditRsu = () => {
   }, [dispatch, rsuIp, rsuTableData])
 
   useEffect(() => {
-    if (apiData && Object.keys(apiData).length !== 0) {
-      setValue('orig_ip', apiData.rsu_data.ip)
-      setValue('ip', apiData.rsu_data.ip)
-      setValue('geo_position.latitude', apiData.rsu_data.geo_position.latitude.toString())
-      setValue('geo_position.longitude', apiData.rsu_data.geo_position.longitude.toString())
-      setValue('milepost', String(apiData.rsu_data.milepost))
-      setValue('serial_number', apiData.rsu_data.serial_number)
-      setValue('scms_id', apiData.rsu_data.scms_id)
+    const currRsu = (rsuTableData ?? []).find((rsu: AdminRsu) => rsu.ip === rsuIp)
+    if (currRsu) {
+      setValue('orig_ip', currRsu.ip)
+      setValue('ip', currRsu.ip)
+      setValue('geo_position.latitude', currRsu.geo_position.latitude.toString())
+      setValue('geo_position.longitude', currRsu.geo_position.longitude.toString())
+      setValue('milepost', String(currRsu.milepost))
+      setValue('serial_number', currRsu.serial_number)
+      setValue('scms_id', currRsu.scms_id)
     }
   }, [apiData, setValue])
 

--- a/webapp/src/features/adminEditUser/AdminEditUser.tsx
+++ b/webapp/src/features/adminEditUser/AdminEditUser.tsx
@@ -90,13 +90,14 @@ const AdminEditUser = () => {
   }, [dispatch])
 
   useEffect(() => {
-    if (apiData && Object.keys(apiData).length !== 0) {
-      setValue('orig_email', apiData.user_data.email)
-      setValue('email', apiData.user_data.email)
-      setValue('first_name', apiData.user_data.first_name)
-      setValue('last_name', apiData.user_data.last_name)
-      setValue('super_user', apiData.user_data.super_user.toString())
-      setValue('receive_error_emails', apiData.user_data.receive_error_emails.toString())
+    const currUser = (userTableData ?? []).find((user: AdminUserWithId) => user.email === email)
+    if (currUser) {
+      setValue('orig_email', currUser.email)
+      setValue('email', currUser.email)
+      setValue('first_name', currUser.first_name)
+      setValue('last_name', currUser.last_name)
+      setValue('super_user', currUser.super_user.toString())
+      setValue('receive_error_emails', currUser.receive_error_emails.toString())
     }
     console.log('useEffect apiData', email, userTableData, apiData)
   }, [apiData, setValue])


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a bug where RSU/User data only populates correctly for one RSU or User in the admin menu. 

## How Has This Been Tested?

This has been tested locally using docker-compose. 

## Types of changes

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [ x ] All existing tests pass.
