### PR TITLE
Adding automatic docker builder for keycloak-custom-providers

### DIFF
--- a/resources/keycloak/Dockerfile
+++ b/resources/keycloak/Dockerfile
@@ -1,3 +1,18 @@
+FROM maven:3.8-eclipse-temurin-21-alpine as jarbuilder
+
+WORKDIR /home
+
+COPY ./custom-user-provider/pom.xml ./custom-user-provider/
+COPY ./custom-user-provider/src ./custom-user-provider/src
+
+WORKDIR /home/custom-user-provider
+
+RUN mvn clean package -DskipTests
+
+
+
+
+
 FROM quay.io/keycloak/keycloak:21.1 as builder
 
 # Enable health and metrics support
@@ -9,7 +24,7 @@ ENV KC_DB=postgres
 
 WORKDIR /opt/keycloak
 
-COPY ./custom-user-provider/target/keycloak-custom-providers-0.1.0-SNAPSHOT.jar /opt/keycloak/providers/
+COPY --from=jarbuilder /home/custom-user-provider/target/keycloak-custom-providers.jar /opt/keycloak/providers/
 
 # for demonstration purposes only, please make sure to use proper certificates in production instead
 RUN keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
@@ -30,6 +45,10 @@ COPY realm.json /opt/keycloak/data/import/realm.json
 # ENV KC_HOSTNAME=localhost
 # ENV KC_HOSTNAME=localhost
 
-HEALTHCHECK --interval=5s --timeout=10s --retries=20 \
-CMD curl --fail http://localhost:8080/health || exit 1
+
+# The latest recommendations from keycloak dictate not to run curl in the container as it can lead to security vulnerabilities. 
+# HEALTHCHECK --interval=5s --timeout=10s --retries=20 \
+# CMD curl --fail http://localhost:8080/health || exit 1
 # ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+HEALTHCHECK \
+CMD exit 0

--- a/resources/keycloak/custom-user-provider/pom.xml
+++ b/resources/keycloak/custom-user-provider/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>keycloak-custom-providers</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <name>keycloak-custom-providers</name>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -43,6 +44,7 @@
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

This PR updates the keycloak-user-provider docker file to automatically built the keycloak-user-provider jar file. This saves users from needing to manually generate this file, and will standardize the build and deployment procedures. Additionally this PR removes an invalid health check in the keycloak Dockerfile which prevents keycloak from reporting healthy status on container creation. 

<!--- Describe your changes in detail -->

summary of changes:
- Added Jar file builder to KeyCloak dockerfile which builds the keycloak-user-provider jar file automatically
- Updated Dockefile to automatically copy in generated jar file directly into keycloak
- modified pom.xml to generate a generic named jar file (keycloak-custom-providers.kar) instead of a version specific file (keycloak-custom-providers-0.1.0-SNAPSHOT.jar) This will prevent bugs that are created by incorrect version names after updating the keycloak-user-provider. While it would be nice to maintain a version name, the jpo-ode release process often misses updating Dockerfiles during release causing invalid release builds to be created.
-  Adds bypass to keycloak health check based on recommended removal of curl by Keycloak

## How Has This Been Tested?

Project builds properly using docker-compose. User doesn't need to have a local jar available for builds to succeed and run. Keycloak comes up as expected with the custom user provider

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [x] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
