### PR TITLE
Reduce ping requirements for a successful ping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,6 @@ services:
 
       TIMEZONE: ${TIMEZONE}
       LOGGING_LEVEL: ${API_LOGGING_LEVEL}
-    volumes:
-      - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
     logging:
       options:
         max-size: '10m'

--- a/services/addons/images/rsu_status_check/rsu_pinger.py
+++ b/services/addons/images/rsu_status_check/rsu_pinger.py
@@ -23,7 +23,7 @@ def ping_rsu_ips(rsu_list):
     for rsu in rsu_list:
         # id: rsu_id
         # key: process pinging the RSU's ipv4_address
-        p[rsu[0]] = Popen(["ping", "-n", "-w5", "-c3", rsu[1]], stdout=DEVNULL)
+        p[rsu[0]] = Popen(["ping", "-n", "-w20", "-c1", rsu[1]], stdout=DEVNULL)
 
     ping_data = {}
     while p:

--- a/services/addons/tests/rsu_status_check/test_rsu_pinger.py
+++ b/services/addons/tests/rsu_status_check/test_rsu_pinger.py
@@ -36,8 +36,8 @@ def test_ping_rsu_ips_online(mock_Popen):
     expected_result = {1: "1", 2: "1"}
     mock_Popen.assert_has_calls(
         [
-            call(["ping", "-n", "-w5", "-c3", "1.1.1.1"], stdout=DEVNULL),
-            call(["ping", "-n", "-w5", "-c3", "2.2.2.2"], stdout=DEVNULL),
+            call(["ping", "-n", "-w20", "-c1", "1.1.1.1"], stdout=DEVNULL),
+            call(["ping", "-n", "-w20", "-c1", "2.2.2.2"], stdout=DEVNULL),
         ]
     )
     assert mock_p.poll.call_count == len(rsu_list)  # 2
@@ -59,8 +59,8 @@ def test_ping_rsu_ips_offline(mock_Popen):
     expected_result = {1: "0", 2: "0"}
     mock_Popen.assert_has_calls(
         [
-            call(["ping", "-n", "-w5", "-c3", "1.1.1.1"], stdout=DEVNULL),
-            call(["ping", "-n", "-w5", "-c3", "2.2.2.2"], stdout=DEVNULL),
+            call(["ping", "-n", "-w20", "-c1", "1.1.1.1"], stdout=DEVNULL),
+            call(["ping", "-n", "-w20", "-c1", "2.2.2.2"], stdout=DEVNULL),
         ]
     )
     assert mock_p.poll.call_count == len(rsu_list)  # 2


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Allows for a longer duration of ping response and only requires one successful response. This has been proven to be more accurate with CDOT's environment. Waiting for 5 seconds would frequently timeout. This may have been caused due to running 100 processes in parallel or potentially a slower network.

* The docker-compose has been modified to remove the GCP service account volume from the CV Manager API since it is no longer used.

## How Has This Been Tested?

This has been tested in GCP K8s with CDOT's RSU deployment. The unit tests have also been updated to pass with the changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
