### PR TITLE
Change the tx flag to on for TIM message forwarding

### DIFF
--- a/services/common/rsufwdsnmpset.py
+++ b/services/common/rsufwdsnmpset.py
@@ -493,7 +493,7 @@ def config_init(
                 "47900",
                 index,
                 "8003",
-                raw=True
+                raw=True,
             )
         else:
             return (
@@ -502,6 +502,7 @@ def config_init(
             )
     elif snmp_version == "1218":
         # Based on message type, choose the right port
+        # rsu_ip, snmp_creds, dest_ip, udp_port, rsu_index, psid, tx
         if msg_type.lower() == "bsm":
             return config_txrxmsg(
                 rsu_ip, snmp_creds, dest_ip, "46800", index, "20", False
@@ -524,7 +525,7 @@ def config_init(
             )
         if msg_type.lower() == "tim":
             return config_txrxmsg(
-                rsu_ip, snmp_creds, dest_ip, "47900", index, "8003", False
+                rsu_ip, snmp_creds, dest_ip, "47900", index, "8003", True
             )
         else:
             return (


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

TIM message forwarding was not being correctly configured over SNMP for NTCIP 1218 commands. Previously, the TIM configurations would be added to the RX table. This is incorrect since we do not want to forward TIM messages when they are received by a RSU. We want to forward these when they are transmitted by a RSU. This change is luckily very simple and ensures TIM messages are properly configured.

## How Has This Been Tested?

This has been tested in CDOT's RSU deployment environment. The TIM message forwarding is successfully added to the proper TX table. The SNMP delete command has also been tested to work with this expected functionality.

Unit tests still pass without any changes needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
