### PR TITLE
Fix snmpset toast notification bug

### DIFF
--- a/webapp/src/components/SnmpsetMenu.tsx
+++ b/webapp/src/components/SnmpsetMenu.tsx
@@ -59,11 +59,11 @@ const SnmpsetMenu = (props: SnmpsetMenu) => {
       <button
         id="refreshbtn"
         onClick={() =>
-          dispatch(submitSnmpSet(rsuIpList)).then((data: any) =>
-            data.changeSuccess
+          dispatch(submitSnmpSet(rsuIpList)).then((data: any) => {
+            data.payload.changeSuccess
               ? toast.success('Forwarding Changes Applied Successfully')
               : toast.error('Failed to add forwarding: ', data.errorState)
-          )
+          })
         }
       >
         Add Forwarding


### PR DESCRIPTION
# PR Details

## Description

This PR fixes a bug where an SNMP set command doesn't show a successful toast notification even if the API returns a 200 status code. 

## How Has This Been Tested?

This has been tested locally using docker-compose.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
