### PR TITLE
Firmware Manager Fix

### DIFF
--- a/services/addons/images/firmware_manager/firmware_manager.py
+++ b/services/addons/images/firmware_manager/firmware_manager.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 log_level = os.environ.get("LOGGING_LEVEL", "INFO")
 logging.basicConfig(format="%(levelname)s:%(message)s", level=log_level)
 
-ACTIVE_UPGRADE_LIMIT = os.environ.get("ACTIVE_UPGRADE_LIMIT", 20)
+ACTIVE_UPGRADE_LIMIT = int(os.environ.get("ACTIVE_UPGRADE_LIMIT", "1"))
 
 manufacturer_upgrade_scripts = {
     "Commsignia": "commsignia_upgrader.py",


### PR DESCRIPTION


<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Modifies the firmware manager to expect the ACTIVE_UPGRADE_LIMIT environment variable as a string instead of immediately an integer. This was an oversight when initially implemented because environment variables are always strings initially.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested through the environment variables.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
