### PR TITLE
Fix failing firmware manager tests

### DIFF
--- a/services/addons/tests/firmware_manager/test_firmware_manager.py
+++ b/services/addons/tests/firmware_manager/test_firmware_manager.py
@@ -452,11 +452,11 @@ def test_list_active_upgrades():
 
 @patch(
     "addons.images.firmware_manager.firmware_manager.active_upgrades",
-    {"8.8.8.8": fmv.upgrade_info},
+    {},
 )
 @patch(
     "addons.images.firmware_manager.firmware_manager.get_rsu_upgrade_data",
-    MagicMock(return_value=fmv.multi_rsu_info),
+    MagicMock(return_value=fmv.single_rsu_info),
 )
 @patch("addons.images.firmware_manager.firmware_manager.logging")
 @patch(
@@ -485,7 +485,7 @@ def test_check_for_upgrades_exception(mock_popen, mock_logging):
 
 @patch(
     "addons.images.firmware_manager.firmware_manager.active_upgrades",
-    {"8.8.8.8": fmv.upgrade_info},
+    {},
 )
 @patch(
     "addons.images.firmware_manager.firmware_manager.get_rsu_upgrade_data",
@@ -500,7 +500,7 @@ def test_check_for_upgrades(mock_stfq, mock_logging):
     mock_stfq.assert_called_once_with()
 
     # Assert the process reference is successfully tracked in the active_upgrades dictionary
-    assert firmware_manager.upgrade_queue[0] == "9.9.9.9"
+    assert firmware_manager.upgrade_queue[1] == "9.9.9.9"
     mock_logging.info.assert_called_with(
         "Firmware upgrade successfully started for '9.9.9.9'"
     )

--- a/services/addons/tests/firmware_manager/test_firmware_manager_values.py
+++ b/services/addons/tests/firmware_manager/test_firmware_manager_values.py
@@ -65,6 +65,19 @@ multi_rsu_info = [
     },
 ]
 
+single_rsu_info = [
+    {
+        "ipv4_address": "9.9.9.9",
+        "manufacturer": "Commsignia",
+        "model": "ITS-RS4-M",
+        "ssh_username": "user",
+        "ssh_password": "psw",
+        "target_firmware_id": 2,
+        "target_firmware_version": "y20.39.0",
+        "install_package": "install_package.tar",
+    },
+]
+
 upgrade_info = {
     "process": MagicMock(),
     "manufacturer": "Commsignia",


### PR DESCRIPTION
# PR Details
This PR fixes two failing firmware manager unit tests.

## Description

After the firmware manager ACTIVE_UPGRADE_LIMIT was set to 1 by default two unit tests are no longer passing. This update fixes those failing tests.

## How Has This Been Tested?

These updates have been verified to work using pytest.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ X ] My changes require updates and/or additions to the unit tests:
  - [ X ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
