### PR TITLE
Improved ability to identify RSUs associated with firmware manager logs

### DIFF
--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -56,7 +56,7 @@ class UpgraderAbstractClass(abc.ABC):
     # success is a boolean
     def notify_firmware_manager(self, success):
         status = "success" if success else "fail"
-        logging.info(f"Firmware upgrade script completed with status: {status}")
+        logging.info(f"Firmware upgrade script completed for {self.rsu_ip} with status: {status}")
 
         url = "http://127.0.0.1:8080/firmware_upgrade_completed"
         body = {"rsu_ip": self.rsu_ip, "status": status}

--- a/services/addons/tests/firmware_manager/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_upgrader.py
@@ -129,8 +129,9 @@ def test_notify_firmware_manager_success(mock_requests, mock_logging):
     expected_url = "http://127.0.0.1:8080/firmware_upgrade_completed"
     expected_body = {"rsu_ip": "8.8.8.8", "status": "success"}
     mock_logging.info.assert_called_with(
-        "Firmware upgrade script completed with status: success"
+        "Firmware upgrade script completed for 8.8.8.8 with status: success"
     )
+    mock_logging.error.assert_not_called()
     mock_requests.post.assert_called_with(expected_url, json=expected_body)
 
 
@@ -144,8 +145,9 @@ def test_notify_firmware_manager_fail(mock_requests, mock_logging):
     expected_url = "http://127.0.0.1:8080/firmware_upgrade_completed"
     expected_body = {"rsu_ip": "8.8.8.8", "status": "fail"}
     mock_logging.info.assert_called_with(
-        "Firmware upgrade script completed with status: fail"
+        "Firmware upgrade script completed for 8.8.8.8 with status: fail"
     )
+    mock_logging.error.assert_not_called()
     mock_requests.post.assert_called_with(expected_url, json=expected_body)
 
 


### PR DESCRIPTION
# PR Details
## Description
The logs for the firmware manager have been modified to ensure that developers reading the console will be able to identify which RSUs are associated with a particular log message.

## How Has This Been Tested?
Unit tests were updated to account for the modifications and expanded to include more log assertions.

## Types of changes
- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ x ] My changes require updates and/or additions to the unit tests:
  - [ x ] I have modified/added tests to cover my changes.
- [ x ] All existing tests pass.
