### PR TITLE
Firmware Manager bug fixes

### DIFF
--- a/services/addons/images/firmware_manager/commsignia_upgrader.py
+++ b/services/addons/images/firmware_manager/commsignia_upgrader.py
@@ -13,7 +13,7 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
         # set file/blob location for post_upgrade script
         self.post_upgrade_file_name = f"/home/{upgrade_info['ipv4_address']}/post_upgrade.sh"
         self.post_upgrade_blob_name = f"{upgrade_info['manufacturer']}/{upgrade_info['model']}/{upgrade_info['target_firmware_version']}/post_upgrade.sh"
-        super().__init__(upgrade_info)
+        super().__init__(upgrade_info, firmware_extension=".tar.sig")
 
     def upgrade(self):
         try:
@@ -54,7 +54,7 @@ class CommsigniaUpgrader(upgrader.UpgraderAbstractClass):
             ssh.close()
 
             # If post_upgrade script exists execute it
-            if (self.download_blob(self.post_upgrade_blob_name, self.post_upgrade_file_name)):
+            if (self.download_blob(self.post_upgrade_blob_name, self.post_upgrade_file_name, ".sh")):
                 self.post_upgrade()
 
             # Delete local installation package and its parent directory so it doesn't take up storage space

--- a/services/addons/images/firmware_manager/requirements.txt
+++ b/services/addons/images/firmware_manager/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.10.4
 google-cloud-storage==2.14.0
 flask==3.0.0
-paramiko==3.3.1
+paramiko==3.5.0
 pg8000==1.30.2
 requests==2.31.0
 scp==0.14.5

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -13,7 +13,7 @@ import download_blob
 
 
 class UpgraderAbstractClass(abc.ABC):
-    def __init__(self, upgrade_info):
+    def __init__(self, upgrade_info, firmware_extension):
         self.install_package = upgrade_info["install_package"]
         self.root_path = f"/home/{upgrade_info['ipv4_address']}"
         self.blob_name = f"{upgrade_info['manufacturer']}/{upgrade_info['model']}/{upgrade_info['target_firmware_version']}/{upgrade_info['install_package']}"
@@ -23,6 +23,7 @@ class UpgraderAbstractClass(abc.ABC):
         self.rsu_ip = upgrade_info["ipv4_address"]
         self.ssh_username = upgrade_info["ssh_username"]
         self.ssh_password = upgrade_info["ssh_password"]
+        self.firmware_extension = firmware_extension
 
     # Deletes the parent directory along with the firmware file
     def cleanup(self):
@@ -32,7 +33,7 @@ class UpgraderAbstractClass(abc.ABC):
                 shutil.rmtree(path)
 
     # Downloads firmware install package blob to /home/rsu_ip/
-    def download_blob(self, blob_name=None, local_file_name=None):
+    def download_blob(self, blob_name=None, local_file_name=None, firmware_extension=None):
         # Create parent rsu_ip directory
         path = self.local_file_name[: self.local_file_name.rfind("/")]
         Path(path).mkdir(exist_ok=True)
@@ -46,7 +47,7 @@ class UpgraderAbstractClass(abc.ABC):
             "BLOB_STORAGE_PROVIDER", "DOCKER"
         ).casefold()
         if bspCaseInsensitive == "gcp":
-            return gcs_utils.download_gcp_blob(blob_name, local_file_name)
+            return gcs_utils.download_gcp_blob(blob_name, local_file_name, self.firmware_extension) if firmware_extension is None else gcs_utils.download_gcp_blob(blob_name, local_file_name, firmware_extension)
         elif bspCaseInsensitive == "docker":
             return download_blob.download_docker_blob(blob_name, local_file_name)
         else:

--- a/services/addons/images/firmware_manager/yunex_upgrader.py
+++ b/services/addons/images/firmware_manager/yunex_upgrader.py
@@ -10,7 +10,7 @@ import time
 
 class YunexUpgrader(upgrader.UpgraderAbstractClass):
     def __init__(self, upgrade_info):
-        super().__init__(upgrade_info)
+        super().__init__(upgrade_info, firmware_extension=".tar")
 
     def run_xfer_upgrade(self, file_name):
         xfer_command = [

--- a/services/addons/images/firmware_manager/yunex_upgrader.py
+++ b/services/addons/images/firmware_manager/yunex_upgrader.py
@@ -42,65 +42,64 @@ class YunexUpgrader(upgrader.UpgraderAbstractClass):
         return 0
 
     def upgrade(self):
-        if (self.check_online()):
-            try:
-                # Download firmware installation package TAR file
-                self.download_blob()
+        try:
+            # Download firmware installation package TAR file
+            self.download_blob()
 
-                # Unpack TAR file which must contain the following:
-                # - Core upgrade file
-                # - SDK upgrade file
-                # - Application provision file
-                # - upgrade_info.json which defines the files as a single JSON object
-                logging.info("Unpacking TAR file prior to upgrading " + self.rsu_ip + "...")
-                with tarfile.open(self.local_file_name, "r") as tar:
-                    tar.extractall(self.root_path)
+            # Unpack TAR file which must contain the following:
+            # - Core upgrade file
+            # - SDK upgrade file
+            # - Application provision file
+            # - upgrade_info.json which defines the files as a single JSON object
+            logging.info("Unpacking TAR file prior to upgrading " + self.rsu_ip + "...")
+            with tarfile.open(self.local_file_name, "r") as tar:
+                tar.extractall(self.root_path)
 
-                # Obtain upgrade info in the following format:
-                # { "core": "core-file-name", "sdk": "sdk-file-name", "provision": "provision-file-name"}
-                with open(f"{self.root_path}/upgrade_info.json") as json_file:
-                    upgrade_info = json.load(json_file)
+            # Obtain upgrade info in the following format:
+            # { "core": "core-file-name", "sdk": "sdk-file-name", "provision": "provision-file-name"}
+            with open(f"{self.root_path}/upgrade_info.json") as json_file:
+                upgrade_info = json.load(json_file)
 
-                # Run Core upgrade
-                logging.info("Running Core firmware upgrade for " + self.rsu_ip + "...")
-                code = self.run_xfer_upgrade(f"{self.root_path}/{upgrade_info['core']}")
-                if code == -1:
-                    raise Exception("Yunex RSU Core upgrade failed")
-                if self.wait_until_online() == -1:
-                    raise Exception("RSU offline for too long after Core upgrade")
-                # Wait an additional 60 seconds after the Yunex RSU is online - needs time to initialize
-                time.sleep(60)
+            # Run Core upgrade
+            logging.info("Running Core firmware upgrade for " + self.rsu_ip + "...")
+            code = self.run_xfer_upgrade(f"{self.root_path}/{upgrade_info['core']}")
+            if code == -1:
+                raise Exception("Yunex RSU Core upgrade failed")
+            if self.wait_until_online() == -1:
+                raise Exception("RSU offline for too long after Core upgrade")
+            # Wait an additional 60 seconds after the Yunex RSU is online - needs time to initialize
+            time.sleep(60)
 
-                # Run SDK upgrade
-                logging.info("Running SDK firmware upgrade for " + self.rsu_ip + "...")
-                code = self.run_xfer_upgrade(f"{self.root_path}/{upgrade_info['sdk']}")
-                if code == -1:
-                    raise Exception("Yunex RSU SDK upgrade failed")
-                if self.wait_until_online() == -1:
-                    raise Exception("RSU offline for too long after SDK upgrade")
-                # Wait an additional 60 seconds after the Yunex RSU is online - needs time to initialize
-                time.sleep(60)
+            # Run SDK upgrade
+            logging.info("Running SDK firmware upgrade for " + self.rsu_ip + "...")
+            code = self.run_xfer_upgrade(f"{self.root_path}/{upgrade_info['sdk']}")
+            if code == -1:
+                raise Exception("Yunex RSU SDK upgrade failed")
+            if self.wait_until_online() == -1:
+                raise Exception("RSU offline for too long after SDK upgrade")
+            # Wait an additional 60 seconds after the Yunex RSU is online - needs time to initialize
+            time.sleep(60)
 
-                # Run application provision image
-                logging.info("Running application provisioning for " + self.rsu_ip + "...")
-                code = self.run_xfer_upgrade(
-                    f"{self.root_path}/{upgrade_info['provision']}"
-                )
-                if code == -1:
-                    raise Exception("Yunex RSU application provisioning upgrade failed")
+            # Run application provision image
+            logging.info("Running application provisioning for " + self.rsu_ip + "...")
+            code = self.run_xfer_upgrade(
+                f"{self.root_path}/{upgrade_info['provision']}"
+            )
+            if code == -1:
+                raise Exception("Yunex RSU application provisioning upgrade failed")
 
-                # Notify Firmware Manager of successful firmware upgrade completion
-                self.cleanup()
-                self.notify_firmware_manager(success=True)
-            except Exception as err:
-                # If something goes wrong, cleanup anything left and report failure if possible.
-                # Yunex RSUs can handle having the same firmware upgraded over again.
-                # There is no issue with starting from the beginning even with a partially complete upgrade.
-                logging.error(f"Failed to perform firmware upgrade for {self.rsu_ip}: {err}")
-                self.cleanup()
-                self.notify_firmware_manager(success=False)
-                # send email to support team with the rsu and error
-                self.send_error_email("Firmware Upgrader", err)
+            # Notify Firmware Manager of successful firmware upgrade completion
+            self.cleanup()
+            self.notify_firmware_manager(success=True)
+        except Exception as err:
+            # If something goes wrong, cleanup anything left and report failure if possible.
+            # Yunex RSUs can handle having the same firmware upgraded over again.
+            # There is no issue with starting from the beginning even with a partially complete upgrade.
+            logging.error(f"Failed to perform firmware upgrade for {self.rsu_ip}: {err}")
+            self.cleanup()
+            self.notify_firmware_manager(success=False)
+            # send email to support team with the rsu and error
+            self.send_error_email("Firmware Upgrader", err)
 
 
 # sys.argv[1] - JSON string with the following key-values:
@@ -118,4 +117,8 @@ if __name__ == "__main__":
     # Trimming outer single quotes from the json.loads
     upgrade_info = json.loads(sys.argv[1][1:-1])
     yunex_upgrader = YunexUpgrader(upgrade_info)
-    yunex_upgrader.upgrade()
+    if (yunex_upgrader.check_online()):
+        yunex_upgrader.upgrade()
+    else:
+        logging.error(f"RSU {upgrade_info['ipv4_address']} is offline")
+        yunex_upgrader.notify_firmware_manager(success=False)

--- a/services/addons/tests/firmware_manager/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_upgrader.py
@@ -12,7 +12,7 @@ class TestUpgrader(upgrader.UpgraderAbstractClass):
     __test__ = False
 
     def __init__(self, upgrade_info):
-        super().__init__(upgrade_info)
+        super().__init__(upgrade_info, "")
 
     def upgrade(self):
         super().upgrade()
@@ -84,7 +84,7 @@ def test_download_blob_gcp(mock_Path, mock_download_gcp_blob):
     mock_path_obj.mkdir.assert_called_with(exist_ok=True)
     mock_download_gcp_blob.assert_called_with(
         "test-manufacturer/test-model/1.0.0/firmware_package.tar",
-        "/home/8.8.8.8/firmware_package.tar",
+        "/home/8.8.8.8/firmware_package.tar", ''
     )
 
 @patch.dict(os.environ, {"BLOB_STORAGE_PROVIDER": "DOCKER"})

--- a/services/common/gcs_utils.py
+++ b/services/common/gcs_utils.py
@@ -4,16 +4,19 @@ import logging
 import os
 
 
-def download_gcp_blob(blob_name, destination_file_name):
+def download_gcp_blob(blob_name, destination_file_name, file_extension=None):
     """Download a file from a GCP Bucket Storage bucket to a local file.
 
     Args:
         blob_name (str): The name of the file in the bucket.
         destination_file_name (str): The name of the local file to download the bucket file to.
     """
-
-    if not validate_file_type(blob_name):
-        return False
+    if file_extension is None:
+        if not validate_file_type(blob_name):
+            return False
+    else:
+        if not validate_file_type(blob_name, file_extension):
+            return False
 
     gcp_project = os.environ.get("GCP_PROJECT")
     bucket_name = os.environ.get("BLOB_STORAGE_BUCKET")

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -26,7 +26,7 @@ uuid==1.30
 multidict==6.0.5
 python-keycloak==2.16.2
 fabric==3.2.2
-paramiko==3.3.1
+paramiko==3.5.0
 scp==0.14.5
 waitress==2.1.2
 fastapi==0.110.0


### PR DESCRIPTION
# PR Details
## Description

This PR fixes an issue where the firmware manager marks files ending in something other than '.tar' as unsupported and another issue where the firmware manager doesn't mark an RSU upgrade as failed if the RSU is offline.

## How Has This Been Tested?

This has been deployed in dev and was verified to work correctly with both online and offline RSUs.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ X ] My changes require updates and/or additions to the unit tests:
  - [ X ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
