### PR TITLE
Allowing Consecutive WebSocket Reconnects

### DIFF
--- a/webapp/src/features/intersections/map/map-slice.tsx
+++ b/webapp/src/features/intersections/map/map-slice.tsx
@@ -821,13 +821,25 @@ export const initializeLiveStreaming = createAsyncThunk(
           numRestartsLocal = 0
         }
         console.debug('Attempting to reconnect to STOMP endpoint (numRestarts: ' + numRestartsLocal + ')')
-        dispatch(
-          setLiveDataRestartTimeoutId(
-            setTimeout(() => {
-              dispatch(setLiveDataRestart(numRestartsLocal + 1))
-            }, numRestartsLocal * 2000)
+
+        if (numRestartsLocal == 0) {
+          dispatch(
+            initializeLiveStreaming({
+              token,
+              roadRegulatorId,
+              intersectionId,
+              numRestarts: 0,
+            })
           )
-        )
+        } else {
+          dispatch(
+            setLiveDataRestartTimeoutId(
+              setTimeout(() => {
+                dispatch(setLiveDataRestart(numRestartsLocal + 1))
+              }, numRestartsLocal * 2000)
+            )
+          )
+        }
       } else {
         cleanUpLiveStreaming()
       }
@@ -853,13 +865,25 @@ export const initializeLiveStreaming = createAsyncThunk(
           numRestartsLocal = 0
         }
         console.debug('Attempting to reconnect to STOMP endpoint (numRestarts: ' + numRestartsLocal + ')')
-        dispatch(
-          setLiveDataRestartTimeoutId(
-            setTimeout(() => {
-              dispatch(setLiveDataRestart(numRestartsLocal + 1))
-            }, numRestartsLocal * 2000)
+
+        if (numRestartsLocal == 0) {
+          dispatch(
+            initializeLiveStreaming({
+              token,
+              roadRegulatorId,
+              intersectionId,
+              numRestarts: 0,
+            })
           )
-        )
+        } else {
+          dispatch(
+            setLiveDataRestartTimeoutId(
+              setTimeout(() => {
+                dispatch(setLiveDataRestart(numRestartsLocal + 1))
+              }, numRestartsLocal * 2000)
+            )
+          )
+        }
       } else {
         dispatch(cleanUpLiveStreaming())
       }


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Fixing a bug causing consecutive long-interval live intersection (STOMP websocket) reconnects to fail. The live intersection STOMP websocket handler is set to re-connect after onDisconnect and onClose. This is limited to 5 re-connects if the re-connects happen in quick succession (<10 seconds), and unlimited for longer re-connects (CDOT commonly re-connects after 30 seconds). This was causing a bug where the second 30-second re-connect would not be triggered correctly. This has been resolved. 

## How Has This Been Tested?

This has been tested locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
