### PR TITLE
Adding embedded mongo and postgres

### DIFF
--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -237,6 +237,18 @@
 			<artifactId>systems-common</artifactId>
 			<version>2.0</version>
 		</dependency>
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<version>4.18.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.zonky.test</groupId>
+			<artifactId>embedded-database-spring-test</artifactId>
+			<version>2.5.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/ConflictApiApplication.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/ConflictApiApplication.java
@@ -1,13 +1,9 @@
 package us.dot.its.jpo.ode.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-
-import us.dot.its.jpo.ode.api.asn1.DecoderManager;
-import us.dot.its.jpo.ode.api.services.PostgresService;
 
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
@@ -18,12 +14,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @ComponentScan(basePackages = { "us.dot.its.jpo.ode.api", "us.dot.its.jpo.geojsonconverter.validator" })
 public class ConflictApiApplication extends SpringBootServletInitializer {
-
-    @Autowired
-    DecoderManager manager;
-
-    @Autowired
-    PostgresService service;
 
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/AssessmentTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/AssessmentTests.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -19,6 +20,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
@@ -34,6 +36,8 @@ import us.dot.its.jpo.ode.mockdata.MockAssessmentGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class AssessmentTests {
 
     @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
@@ -10,21 +10,25 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepository;
 import us.dot.its.jpo.ode.api.controllers.BsmController;
 import us.dot.its.jpo.ode.api.models.postgres.derived.UserOrgRole;
 import us.dot.its.jpo.ode.api.services.PostgresService;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
-
-@SpringBootTest
 @RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class BsmTest {
 
   @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/EmailSettingsTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/EmailSettingsTest.java
@@ -7,12 +7,17 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.models.EmailSettings;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class EmailSettingsTest {
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/EventTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/EventTests.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenceAlignmentEvent;
@@ -51,6 +53,8 @@ import us.dot.its.jpo.ode.mockdata.MockEventGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class EventTests {
 
     @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/MapTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/MapTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.ode.api.accessors.map.ProcessedMapRepository;
@@ -28,6 +30,8 @@ import us.dot.its.jpo.ode.mockdata.MockMapGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class MapTest {
 
   @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/NotificationTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/NotificationTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.ConnectionOfTravelNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.IntersectionReferenceAlignmentNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.LaneDirectionOfTravelNotification;
@@ -40,6 +42,8 @@ import us.dot.its.jpo.ode.mockdata.MockNotificationGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class NotificationTest {
 
     @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/SpatTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/SpatTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 import us.dot.its.jpo.ode.api.accessors.spat.ProcessedSpatRepository;
 import us.dot.its.jpo.ode.api.controllers.SpatController;
@@ -27,6 +29,8 @@ import us.dot.its.jpo.ode.mockdata.MockSpatGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SpatTest {
 
   @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/UserCreationTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/UserCreationTests.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.accessors.users.UserRepository;
 import us.dot.its.jpo.ode.api.controllers.UserController;
 import us.dot.its.jpo.ode.api.models.UserCreationRequest;
@@ -24,6 +26,8 @@ import us.dot.its.jpo.ode.mockdata.MockUserCreationRequestGenerator;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class UserCreationTests {
 
     @MockBean

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
@@ -16,15 +16,18 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.ode.api.accessors.assessments.ConnectionOfTravelAssessment.ConnectionOfTravelAssessmentRepositoryImpl;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ConnectionOfTravelAssessmentRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
@@ -16,15 +16,18 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
 import us.dot.its.jpo.ode.api.accessors.assessments.LaneDirectionOfTravelAssessment.LaneDirectionOfTravelAssessmentRepositoryImpl;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/SignalStateEventAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/SignalStateEventAssessmentRepositoryImplTest.java
@@ -16,15 +16,18 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
 import us.dot.its.jpo.ode.api.accessors.assessments.SignalStateEventAssessment.SignalStateEventAssessmentRepositoryImpl;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalStateEventAssessmentRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
@@ -17,16 +17,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.SignalStateAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
 import us.dot.its.jpo.ode.api.accessors.assessments.SignalStateAssessment.StopLineStopAssessmentRepositoryImpl;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class StopLineStopAssessmentRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -18,12 +18,17 @@ import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepositoryImpl;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class OdeBsmJsonRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
@@ -22,12 +22,17 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
 import us.dot.its.jpo.ode.api.accessors.events.BsmEvent.BsmEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class BsmEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
@@ -23,12 +23,17 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEv
 import us.dot.its.jpo.ode.api.accessors.events.ConnectionOfTravelEvent.ConnectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ConnectionOfTravelEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
@@ -23,12 +23,17 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenc
 import us.dot.its.jpo.ode.api.accessors.events.IntersectionReferenceAlignmentEvent.IntersectionReferenceAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class IntersectionReferenceAlignmentEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
@@ -23,12 +23,17 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTrave
 import us.dot.its.jpo.ode.api.accessors.events.LaneDirectionOfTravelEvent.LaneDirectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class LaneDirectionOfTravelEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
@@ -21,15 +21,19 @@ import org.bson.Document;
 
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
 import us.dot.its.jpo.ode.api.accessors.events.MapBroadcastRateEvents.MapBroadcastRateEventRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class MapBroadcastRateEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
@@ -21,8 +21,11 @@ import org.bson.Document;
 
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMinimumDataEvent;
 import us.dot.its.jpo.ode.api.accessors.events.MapMinimumDataEvent.MapMinimumDataEventRepositoryImpl;
 
@@ -30,6 +33,8 @@ import us.dot.its.jpo.ode.api.accessors.events.MapMinimumDataEvent.MapMinimumDat
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class MapMinimumDataEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
@@ -22,14 +22,18 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.events.SignalGroupAlignmentEvent.SignalGroupAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalGroupAlignmentEvent;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalGroupAlignmentEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
@@ -22,14 +22,18 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.events.SignalStateConflictEvent.SignalStateConflictEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalStateConflictEvent;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalStateConflictEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateEventRepositoryImplTest.java
@@ -23,13 +23,18 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent
 import us.dot.its.jpo.ode.api.accessors.events.SignalStateEvent.SignalStateEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalStateEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateStopEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateStopEventRepositoryImplTest.java
@@ -22,14 +22,18 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.events.SignalStateStopEvent.SignalStateStopEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLineStopEvent;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalStateStopEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
@@ -23,14 +23,19 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatB
 import us.dot.its.jpo.ode.api.accessors.events.SpatBroadcastRateEvent.SpatBroadcastRateEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SpatBroadcastRateRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
@@ -24,14 +24,19 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMin
 import us.dot.its.jpo.ode.api.accessors.events.SpatMinimumDataEvent.SpatMinimumDataEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SpatMinimumDataEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
@@ -22,14 +22,18 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.events.TimeChangeDetailsEvent.TimeChangeDetailsEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.TimeChangeDetailsEvent;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class TimeChangeDetailsEventRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
@@ -19,14 +19,17 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.map.OdeMapDataRepositoryImpl;
 import us.dot.its.jpo.ode.model.OdeMapData;
 
-
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class OdeMapDataRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
@@ -23,13 +23,16 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.ode.api.accessors.map.ProcessedMapRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
-
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ProcessedMapRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
@@ -14,14 +14,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.Notification;
 import us.dot.its.jpo.ode.api.accessors.notifications.ActiveNotification.ActiveNotificationRepositoryImpl;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ActiveNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
@@ -20,12 +20,17 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.notifications.ConnectionOfTravelNotification.ConnectionOfTravelNotificationRepositoryImpl;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.ConnectionOfTravelNotification;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ConnectionOfTravelNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
@@ -20,12 +20,17 @@ import org.bson.Document;
 import us.dot.its.jpo.ode.api.accessors.notifications.IntersectionReferenceAlignmentNotification.IntersectionReferenceAlignmentNotificationRepositoryImpl;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.IntersectionReferenceAlignmentNotification;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
@@ -20,12 +20,17 @@ import org.bson.Document;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.LaneDirectionOfTravelNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.LaneDirectionOfTravelNotificationRepo.LaneDirectionOfTravelNotificationRepositoryImpl;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class LaneDirectionOfTravelNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
@@ -17,14 +17,18 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.accessors.notifications.MapBroadcastRateNotification.MapBroadcastRateNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class MapBroadcastRateNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAlignmentNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.SignalGroupAlignmentNotificationRepo.SignalGroupAlignmentNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalGroupAlignmentNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.SignalStateConflictNotification.SignalStateConflictNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SignalStateConflictNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.SpatBroadcastRateNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.SpatBroadcastRateNotification.SpatBroadcastRateNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SpatBroadcastRateNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLinePassageNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.StopLinePassageNotification.StopLinePassageNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class StopLinePassageNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLineStopNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.StopLineStopNotification.StopLineStopNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class StopLineStopNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
@@ -16,16 +16,19 @@ import java.util.Date;
 import java.util.List;
 
 import org.bson.Document;
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
 import us.dot.its.jpo.ode.api.accessors.notifications.TimeChangeDetailsNotification.TimeChangeDetailsNotificationRepositoryImpl;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class TimeChangeDetailsNotificationRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
@@ -17,12 +17,17 @@ import org.bson.Document;
 
 import us.dot.its.jpo.ode.api.accessors.spat.OdeSpatDataRepositoryImpl;
 
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class OdeSpatDataRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
@@ -22,12 +22,16 @@ import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.spat.ProcessedSpatRepositoryImpl;
 
-
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class ProcessedSpatRepositoryImplTest {
 
     @Mock

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/BsmDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/BsmDecoderTests.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.BsmDecoder;
 import us.dot.its.jpo.ode.api.models.messages.BsmDecodedMessage;
 import us.dot.its.jpo.ode.mockdata.MockDecodedMessageGenerator;
@@ -20,6 +22,8 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class BsmDecoderTests {
     
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/MapDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/MapDecoderTests.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.MapDecoder;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
@@ -22,6 +24,8 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class MapDecoderTests {
     
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SpatDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SpatDecoderTests.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.SpatDecoder;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 import us.dot.its.jpo.ode.api.models.messages.SpatDecodedMessage;
@@ -21,6 +23,8 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SpatDecoderTests {
     
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SrmDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SrmDecoderTests.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.SrmDecoder;
 import us.dot.its.jpo.ode.api.models.messages.SrmDecodedMessage;
 import us.dot.its.jpo.ode.mockdata.MockDecodedMessageGenerator;
@@ -21,6 +23,8 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SrmDecoderTests {
     
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SsmDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/SsmDecoderTests.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.SsmDecoder;
 import us.dot.its.jpo.ode.api.models.messages.SsmDecodedMessage;
 import us.dot.its.jpo.ode.mockdata.MockDecodedMessageGenerator;
@@ -19,6 +21,8 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class SsmDecoderTests {
 
     @Autowired

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/TimDecoderTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/decoderTests/TimDecoderTests.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.ode.api.asn1.TimDecoder;
 import us.dot.its.jpo.ode.api.models.messages.TimDecodedMessage;
 import us.dot.its.jpo.ode.mockdata.MockDecodedMessageGenerator;
@@ -16,6 +18,8 @@ import us.dot.its.jpo.ode.model.OdeMsgMetadata;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@AutoConfigureDataMongo
+@AutoConfigureEmbeddedDatabase
 public class TimDecoderTests {
 
     @Autowired


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

This PR adds in embedded mongoDB and postgres instances. These instances allow for unit tests to be run without throwing errors about missing mongo or postgres instances. In the future, the embedded databases will also allow for improved testing by allowing mocked database queries.

<!--- Describe your changes in detail -->

## How Has This Been Tested?

To verify these changes, run mvn test. All unit tests will pass, and no additional error messages will be generated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
