### PR TITLE
Switching Zonky to use internal postgres instead of docker version

### DIFF
--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -238,16 +238,22 @@
 			<version>2.0</version>
 		</dependency>
 		<dependency>
-			<groupId>de.flapdoodle.embed</groupId>
-			<artifactId>de.flapdoodle.embed.mongo</artifactId>
-			<version>4.18.1</version>
+			<groupId>io.zonky.test</groupId>
+			<artifactId>embedded-database-spring-test</artifactId>
+			<version>2.5.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.zonky.test</groupId>
-			<artifactId>embedded-database-spring-test</artifactId>
-			<version>2.5.0</version>
+			<artifactId>embedded-postgres</artifactId>
+			<version>2.0.7</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.zonky.test.postgres</groupId>
+			<artifactId>embedded-postgres-binaries-darwin-amd64</artifactId>
+			<version>17.2.0</version>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/services/intersection-api/api/src/main/resources/application.properties
+++ b/services/intersection-api/api/src/main/resources/application.properties
@@ -17,7 +17,7 @@ spring.data.mongodb.uri=${CM_MONGO_URI:null}
 spring.datasource.url=${POSTGRES_SERVER_URL:jdbc:postgresql://localhost:5432}/postgres
 spring.datasource.username=${PG_DB_USER:postgres}
 spring.datasource.password=${PG_DB_PASS:postgres}
-spring.datasource.driver-class-name: org.postgresql.Driver
+spring.datasource.driver-class-name= org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 # spring.jpa.hibernate.ddl-auto = update
 
@@ -58,3 +58,7 @@ sendgrid.password=${CM_SENDGRID_PASSWORD:""}
 
 ### Postmark Email Settings
 postmark.api.secretKey=${CM_POSTMARK_SECRET_KEY:""}
+
+
+### Emulation Settings
+zonky.test.database.provider=zonky


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Removes Zonky dependency on docker to properly embed postgres database.

## How Has This Been Tested?

make sure docker is not running and run mvn test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
