### PR TITLE
Fixed Mongo Timeout during long running tests

### DIFF
--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -255,6 +255,12 @@
 			<version>17.2.0</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<version>4.18.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -253,7 +253,13 @@
 			<groupId>io.zonky.test.postgres</groupId>
 			<artifactId>embedded-postgres-binaries-darwin-amd64</artifactId>
 			<version>17.2.0</version>
-			<scope>runtime</scope>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.zonky.test.postgres</groupId>
+			<artifactId>embedded-postgres-binaries-darwin-arm64v8</artifactId>
+			<version>17.2.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>

--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -24,6 +24,17 @@
 		<!-- Allow override of github organization when publishing artifacts to github -->
     	<github_organization>usdot-jpo-ode</github_organization>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.zonky.test.postgres</groupId>
+				<artifactId>embedded-postgres-binaries-bom</artifactId>
+				<version>16.4.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>

--- a/services/intersection-api/api/src/main/resources/application.properties
+++ b/services/intersection-api/api/src/main/resources/application.properties
@@ -62,3 +62,4 @@ postmark.api.secretKey=${CM_POSTMARK_SECRET_KEY:""}
 
 ### Emulation Settings
 zonky.test.database.provider=zonky
+zonky.test.database.type=postgres

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/AssessmentTests.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/AssessmentTests.java
@@ -16,8 +16,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -26,7 +25,7 @@ import us.dot.its.jpo.ode.api.services.PostgresService;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest
 @AutoConfigureDataMongo
 @AutoConfigureEmbeddedDatabase
 public class BsmTest {
@@ -44,6 +43,7 @@ public class BsmTest {
 
   @Test
   public void testBsmJson() {
+
 
     MockKeyCloakAuth.setSecurityContextHolder("cm_user@cimms.com", Set.of("USER"));
 


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This PR adds a missing dependency for mongo DB emulation to prevent mongo errors from being generated in long running tests.

## How Has This Been Tested?

mvn clean test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
