### PR TITLE
Add cloning of submodules to services azure pipeline

### DIFF
--- a/services/api/src/middleware.py
+++ b/services/api/src/middleware.py
@@ -87,6 +87,7 @@ organization_required = {
 # String: Feature required
 # Dictionary: Method specific feature required (e.g. {"GET": "rsu", "POST": "intersection"})
 feature_tags = {
+    "/": None,
     "/user-auth": None,
     "/rsuinfo": "rsu",
     "/rsu-online-status": "rsu",

--- a/services/azure-pipelines.yml
+++ b/services/azure-pipelines.yml
@@ -12,6 +12,11 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
+  # Update and initialize nested submodules
+  - script: |
+      git submodule update --init --recursive
+    displayName: 'Update and initialize submodules'
+    
   - task: CopyFiles@2
     inputs:
       SourceFolder: 'services'

--- a/services/intersection-api/Dockerfile
+++ b/services/intersection-api/Dockerfile
@@ -15,16 +15,9 @@ RUN yum install -y librdkafka-devel
 ADD ./asn1_codec/pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
 
-# Build and install asn1c submodule
+# Build and install asn1c submodule. Ensure all scripts have the correct permissions - required for azure release pipeline
 ADD ./asn1_codec/usdot-asn1c /asn1_codec/asn1c
-
-# Ensure all scripts have the correct permissions
 RUN find /asn1_codec/asn1c -type f -name '*.pl' -exec chmod +x {} \;
-
-# Verify permissions and file integrity
-RUN find /asn1_codec/asn1c -type f -name '*.pl' -exec ls -l {} \; && \
-    find /asn1_codec/asn1c -type f -name '*.pl' -exec file {} \;
-
 RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example

--- a/services/intersection-api/Dockerfile
+++ b/services/intersection-api/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && 
 
 # Build and install asn1c submodule
 ADD ./asn1_codec/usdot-asn1c /asn1_codec/asn1c
-RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
+RUN cd asn1c && chmod +x ./crfc2asn1.pl && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/services/intersection-api/Dockerfile
+++ b/services/intersection-api/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && 
 
 # Build and install asn1c submodule
 ADD ./asn1_codec/usdot-asn1c /asn1_codec/asn1c
-RUN cd asn1c && chmod +x ./crfc2asn1.pl && test -f configure || autoreconf -iv && ./configure && make && make install
+RUN cd asn1c && find . -name 'crfc2asn1.pl' -exec chmod +x {} \; && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/services/intersection-api/Dockerfile
+++ b/services/intersection-api/Dockerfile
@@ -17,7 +17,15 @@ RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && 
 
 # Build and install asn1c submodule
 ADD ./asn1_codec/usdot-asn1c /asn1_codec/asn1c
-RUN cd asn1c && find . -name 'crfc2asn1.pl' -exec chmod +x {} \; && test -f configure || autoreconf -iv && ./configure && make && make install
+
+# Ensure all scripts have the correct permissions
+RUN find /asn1_codec/asn1c -type f -name '*.pl' -exec chmod +x {} \;
+
+# Verify permissions and file integrity
+RUN find /asn1_codec/asn1c -type f -name '*.pl' -exec ls -l {} \; && \
+    find /asn1_codec/asn1c -type f -name '*.pl' -exec file {} \;
+
+RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This PR makes necessary changes to the intersection-api to build in an azure pipeline and updating services azure pipeline to clone/initialize submodules when building azure artifact. This also includes a bug fix in the cvmanager-api (python) to reduce unnecessary warnings sent on health endpoint hits. 

## How Has This Been Tested?

These changes have been tested in the CVManager intersection api release pipeline: https://dev.azure.com/SOC-OIT/CDOT/_releaseProgress?_a=release-pipeline-progress&releaseId=10372

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.