### PR TITLE
Individual profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ The following steps are intended to help get a new user up and running the JPO C
 ### Docker Profiles
 
 Docker compose profiles allow for the customization of services that are run. For more information on how this works, see the [Docker Compose Profiles Documentation](https://docs.docker.com/compose/profiles/).
-Services and profiles are configured using the COMPOSE_PROFILES environment variable. Multiple profiles may be specified, like COMPOSE_PROFILES=basic,webapp,intersectionThis
+Services and profiles are configured using the COMPOSE_PROFILES environment variable. Multiple profiles may be specified, like COMPOSE_PROFILES=basic,webapp,intersection
+
+In addition to the groups defined in the table below, each service may also be activated independently by specifying the service name as a profile. This can be combined with other service names or profile groups to produce unique combinations of services. For example, the entry COMPOSE_PROFILES=kafka,kafka_init,basic would bring up the kafka services and the basic CV-Manager services. To avoid breaking name changes, the conflictmonitor service can be started individually using the "conflictmonitor_only" profile.
 
 #### Profiles and Services
 

--- a/docker-compose-addons.yml
+++ b/docker-compose-addons.yml
@@ -2,6 +2,7 @@ services:
   jpo_count_metric:
     profiles:
       - addons
+      - jpo_count_metric
     build:
       context: ./services
       dockerfile: Dockerfile.count_metric
@@ -42,6 +43,7 @@ services:
   rsu_status_check:
     profiles:
       - addons
+      - rsu_status_check
     build:
       context: ./services
       dockerfile: Dockerfile.rsu_status_check
@@ -72,13 +74,16 @@ services:
   jpo_iss_health_check:
     profiles:
       - addons
+      - jpo_iss_health_check
     build:
       context: ./services
       dockerfile: Dockerfile.iss_health_check
     image: iss_health_check:latest
     restart: on-failure:3
     depends_on:
-      - cvmanager_postgres
+      cvmanager_postgres:
+        condition: service_healthy
+        required: false
     environment:
       STORAGE_TYPE: ${STORAGE_TYPE}
 
@@ -108,6 +113,7 @@ services:
   firmware_manager_upgrade_scheduler:
     profiles:
       - addons
+      - firmware_manager_upgrade_scheduler
     build:
       context: services
       dockerfile: Dockerfile.fmus
@@ -136,6 +142,7 @@ services:
   firmware_manager_upgrade_runner:
     profiles:
       - addons
+      - firmware_manager_upgrade_runner
     build:
       context: services
       dockerfile: Dockerfile.fmur

--- a/docker-compose-conflictmonitor.yml
+++ b/docker-compose-conflictmonitor.yml
@@ -2,6 +2,7 @@ services:
   conflictmonitor:
     profiles:
       - conflictmonitor
+      - conflictmonitor_only
     image: usdotjpoode/jpo-conflictmonitor:latest
     restart: ${RESTART_POLICY}
     ports:
@@ -30,6 +31,7 @@ services:
   ode:
     profiles:
       - conflictmonitor
+      - ode
     image: usdotjpoode/jpo-ode:latest
     restart: ${RESTART_POLICY}
     ports:
@@ -74,6 +76,7 @@ services:
   geojsonconverter:
     profiles:
       - conflictmonitor
+      - geojsonconverter
     image: usdotjpoode/geojsonconverter:latest
     restart: ${RESTART_POLICY}
     deploy:
@@ -97,6 +100,7 @@ services:
   connect:
     profiles:
       - conflictmonitor
+      - connect
     image: cp-kafka-connect:6.1.9
     build:
       context: ./resources/connect_scripts
@@ -108,10 +112,10 @@ services:
     depends_on:
       mongodb_container:
         condition: service_healthy
+        required: false
       kafka:
-        condition: service_started
-      conflictmonitor:
-        condition: service_started
+        condition: service_healthy
+        required: false
     environment:
       DOCKER_HOST_IP: ${DOCKER_HOST_IP}
       DB_HOST_IP: ${DB_HOST_IP}

--- a/docker-compose-intersection.yml
+++ b/docker-compose-intersection.yml
@@ -4,6 +4,7 @@ services:
       - intersection
       - intersection_no_api
       - conflictmonitor
+      - kafka
     image: bitnami/kafka:latest
     hostname: kafka
     ports:
@@ -33,10 +34,12 @@ services:
       - intersection
       - intersection_no_api
       - conflictmonitor
+      - kafka_init
     image: bitnami/kafka:latest
     depends_on:
       kafka:
         condition: service_started
+        required: false
     volumes:
       - ./resources/kafka/kafka_init.sh:/kafka_init.sh
     entrypoint: ['/bin/sh', 'kafka_init.sh']
@@ -44,6 +47,7 @@ services:
   intersection_api:
     profiles:
       - intersection
+      - intersection_api
     image: intersection-api:latest
     build:
       context: ./services/intersection-api
@@ -98,17 +102,21 @@ services:
     depends_on:
       cvmanager_keycloak:
         condition: service_healthy
+        required: false
       mongodb_container:
         condition: service_healthy
+        required: false
       kafka_init:
         condition: service_started
+        required: false
 
   mongodb_container:
     profiles:
       - intersection
       - intersection_no_api
       - conflictmonitor
-    image: mongo:6
+      - mongo
+    image: mongo:8
     container_name: jpo-conflictmonitor-mongodb-container
     restart: always
     environment:

--- a/docker-compose-intersection.yml
+++ b/docker-compose-intersection.yml
@@ -115,7 +115,7 @@ services:
       - intersection
       - intersection_no_api
       - conflictmonitor
-      - mongo
+      - mongodb_container
     image: mongo:8
     container_name: jpo-conflictmonitor-mongodb-container
     restart: always

--- a/docker-compose-obu-ota-server.yml
+++ b/docker-compose-obu-ota-server.yml
@@ -38,7 +38,7 @@ services:
   jpo_ota_nginx:
     profiles:
       - obu_ota
-      - obu_ota_nginx
+      - jpo_ota_nginx
     build:
       context: resources/ota/nginx
     image: obu_ota_nginx:latest

--- a/docker-compose-obu-ota-server.yml
+++ b/docker-compose-obu-ota-server.yml
@@ -3,7 +3,7 @@ services:
   jpo_ota_backend:
     profiles:
       - obu_ota
-      - obu_ota_backend
+      - jpo_ota_backend
     build:
       context: ./services
       dockerfile: Dockerfile.obu_ota_server

--- a/docker-compose-obu-ota-server.yml
+++ b/docker-compose-obu-ota-server.yml
@@ -3,6 +3,7 @@ services:
   jpo_ota_backend:
     profiles:
       - obu_ota
+      - obu_ota_backend
     build:
       context: ./services
       dockerfile: Dockerfile.obu_ota_server
@@ -37,6 +38,7 @@ services:
   jpo_ota_nginx:
     profiles:
       - obu_ota
+      - obu_ota_nginx
     build:
       context: resources/ota/nginx
     image: obu_ota_nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
   cvmanager_api:
     profiles:
       - basic
+      - cvmanager_api
     build:
       context: services
       dockerfile: Dockerfile.api
@@ -71,6 +72,7 @@ services:
   cvmanager_webapp:
     profiles:
       - webapp
+      - cvmanager_webapp
     build:
       context: webapp
       dockerfile: Dockerfile
@@ -101,6 +103,7 @@ services:
     depends_on:
       cvmanager_keycloak:
         condition: service_healthy
+        required: false
     extra_hosts:
       ${WEBAPP_DOMAIN}: ${WEBAPP_HOST_IP}
       ${KEYCLOAK_DOMAIN}: ${KC_HOST_IP}
@@ -113,6 +116,7 @@ services:
   cvmanager_postgres:
     profiles:
       - basic
+      - cvmanager_postgres
     image: postgis/postgis:15-master
     restart: always
     ports:
@@ -130,6 +134,8 @@ services:
   cvmanager_keycloak:
     profiles:
       - basic
+      - keycloak
+      - cvmanager_keycloak
     build:
       context: ./resources/keycloak
       dockerfile: Dockerfile
@@ -138,7 +144,9 @@ services:
     image: jpo_cvmanager_keycloak:latest
     restart: always
     depends_on:
-      - cvmanager_postgres
+      cvmanager_postgres:
+        required: false
+
     extra_hosts:
       ${WEBAPP_DOMAIN}: ${WEBAPP_HOST_IP}
       ${KEYCLOAK_DOMAIN}: ${KC_HOST_IP}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
     depends_on:
       cvmanager_postgres:
         required: false
+        condition: service_started
 
     extra_hosts:
       ${WEBAPP_DOMAIN}: ${WEBAPP_HOST_IP}

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,9 @@
 ######## ---------------------- DOCKER COMPOSE PROFILES ---------------------- ########
 
 # Compose Profiles - see [README](README.md#docker-profiles) and sections below for more information
+# There are a number of profiles available to start up groups of services. 
+# Additionally, each individual service in this project can be started by specifying its service name as a profile.
+# The currently available profile groups are listed below. 
 # basic, webapp, intersection, intersection_no_api, conflictmonitor, addons, obu_ota
 COMPOSE_PROFILES=basic,webapp,intersection
 


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This PR adds a unique profile for every service defined in the CV-Manager docker-compose files. This allows users to individually start up any configuration of services directly from docker-compose. This should allow for additional flexibility when developing and deploying parts of the CV-Manager. For example, if a user only wants to activate Kafka from docker compose they could specify COMPOSE_PROFILEs=KAFKA to bring this service up.

## How Has This Been Tested?

Docker-compose was run with each profile individually to ensure that all services would start. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [x] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [x] My changes require updates to the documentation:
  - [x] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
