### PR TITLE
Fix FM Upgrade Runner Completion Bug

### DIFF
--- a/docker-compose-addons.yml
+++ b/docker-compose-addons.yml
@@ -100,11 +100,11 @@ services:
       PG_DB_PASS: ${PG_DB_PASS}
 
       PROJECT_ID: ${GCP_PROJECT_ID}
-      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS}
+      GOOGLE_APPLICATION_CREDENTIALS: /home/gcp_key.json
 
       LOGGING_LEVEL: ${ISS_LOGGING_LEVEL}
     volumes:
-      - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
+      - ./resources/google/${GOOGLE_ACCESS_KEY_NAME}:/home/gcp_key.json
     logging:
       options:
         max-size: '10m'
@@ -132,7 +132,6 @@ services:
 
       LOGGING_LEVEL: ${FIRMWARE_MANAGER_LOGGING_LEVEL}
     volumes:
-      - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
       - ${HOST_BLOB_STORAGE_DIRECTORY}:/mnt/blob_storage
     logging:
       options:
@@ -158,15 +157,18 @@ services:
       FW_UPGRADE_MAX_RETRY_LIMIT: ${FW_UPGRADE_MAX_RETRY_LIMIT}
 
       GCP_PROJECT: ${GCP_PROJECT_ID}
-      GOOGLE_APPLICATION_CREDENTIALS: '/google/gcp_credentials.json'
+      GOOGLE_APPLICATION_CREDENTIALS: /home/gcp_key.json
 
       SMTP_SERVER_IP: ${SMTP_SERVER_IP}
       SMTP_EMAIL: ${SMTP_EMAIL}
       SMTP_USERNAME: ${SMTP_USERNAME}
       SMTP_PASSWORD: ${SMTP_PASSWORD}
+
+      UPGRADE_SCHEDULER_ENDPOINT: ${FIRMWARE_MANAGER_UPGRADE_SCHEDULER_ENDPOINT}
+
       LOGGING_LEVEL: ${FIRMWARE_MANAGER_LOGGING_LEVEL}
     volumes:
-      - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
+      - ./resources/google/${GOOGLE_ACCESS_KEY_NAME}:/home/gcp_key.json
       - ${HOST_BLOB_STORAGE_DIRECTORY}:/mnt/blob_storage
     logging:
       options:

--- a/sample.env
+++ b/sample.env
@@ -359,9 +359,6 @@ ISS_KEY_TABLE_NAME=
 BLOB_STORAGE_PROVIDER=DOCKER
 BLOB_STORAGE_BUCKET=
 
-# If "BIGQUERY", set the location of the GCP service account key attached as a volume
-GOOGLE_APPLICATION_CREDENTIALS='./resources/google/sample_gcp_service_account.json'
-
 ## Docker volume mount point for BLOB storage (if using Docker)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 

--- a/sample.env
+++ b/sample.env
@@ -368,6 +368,8 @@ HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 ## Maximum retry limit for performing firmware upgrades
 FW_UPGRADE_MAX_RETRY_LIMIT=3
 
+FIRMWARE_MANAGER_UPGRADE_SCHEDULER_ENDPOINT=http://${DOCKER_HOST_IP}:8089
+
 #### ---- firmware_manager_upgrade_scheduler
 
 FIRMWARE_MANAGER_UPGRADE_RUNNER_ENDPOINT=http://${DOCKER_HOST_IP}:8090

--- a/services/addons/images/firmware_manager/upgrade_runner/sample.env
+++ b/services/addons/images/firmware_manager/upgrade_runner/sample.env
@@ -18,3 +18,7 @@ SMTP_SERVER_IP=
 SMTP_EMAIL=
 SMTP_USERNAME=
 SMTP_PASSWORD=
+
+# Must specify this endpoint to wherever the Upgrade Scheduler is hosted
+# Must include 'http://' or 'https://' along with specified port if non-standard
+UPGRADE_SCHEDULER_ENDPOINT="http://"

--- a/services/addons/images/firmware_manager/upgrade_scheduler/sample.env
+++ b/services/addons/images/firmware_manager/upgrade_scheduler/sample.env
@@ -8,5 +8,5 @@ PG_DB_USER=""
 PG_DB_PASS=""
 
 # Must specify this endpoint to wherever the Upgrade Runner is hosted
-# Must include 'http://' or 'https://'
+# Must include 'http://' or 'https://' along with specified port if non-standard
 UPGRADE_RUNNER_ENDPOINT="http://"

--- a/services/addons/tests/firmware_manager/upgrade_runner/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/upgrade_runner/test_upgrader.py
@@ -125,6 +125,7 @@ def test_download_blob_not_supported(mock_Path, mock_download_gcp_blob, mock_log
         mock_logging.error.assert_called_with("Unsupported blob storage provider")
 
 
+@patch.dict("os.environ", {"UPGRADE_SCHEDULER_ENDPOINT": "http://test-endpoint"})
 @patch("addons.images.firmware_manager.upgrade_runner.upgrader.logging")
 @patch("addons.images.firmware_manager.upgrade_runner.upgrader.requests")
 def test_notify_firmware_manager_success(mock_requests, mock_logging):
@@ -132,7 +133,7 @@ def test_notify_firmware_manager_success(mock_requests, mock_logging):
 
     test_upgrader.notify_firmware_manager(success=True)
 
-    expected_url = "http://127.0.0.1:8080/firmware_upgrade_completed"
+    expected_url = "http://test-endpoint/firmware_upgrade_completed"
     expected_body = {"rsu_ip": "8.8.8.8", "status": "success"}
     mock_logging.info.assert_called_with(
         "Firmware upgrade script completed for 8.8.8.8 with status: success"
@@ -141,6 +142,7 @@ def test_notify_firmware_manager_success(mock_requests, mock_logging):
     mock_requests.post.assert_called_with(expected_url, json=expected_body)
 
 
+@patch.dict("os.environ", {"UPGRADE_SCHEDULER_ENDPOINT": "http://test-endpoint"})
 @patch("addons.images.firmware_manager.upgrade_runner.upgrader.logging")
 @patch("addons.images.firmware_manager.upgrade_runner.upgrader.requests")
 def test_notify_firmware_manager_fail(mock_requests, mock_logging):
@@ -148,7 +150,7 @@ def test_notify_firmware_manager_fail(mock_requests, mock_logging):
 
     test_upgrader.notify_firmware_manager(success=False)
 
-    expected_url = "http://127.0.0.1:8080/firmware_upgrade_completed"
+    expected_url = "http://test-endpoint/firmware_upgrade_completed"
     expected_body = {"rsu_ip": "8.8.8.8", "status": "fail"}
     mock_logging.info.assert_called_with(
         "Firmware upgrade script completed for 8.8.8.8 with status: fail"


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Resolves a bug in the Firmware Manager Upgrade Runner (FMUR), where the endpoint for the completion callback to the Firmware Manager Upgrade Scheduler (FMUS) was hard-coded to 'localhost.' This worked as expected during local testing and deployments but fails in more customized deployment scenarios.

A new environment variable was added to resolve this issue, similar to how the FMUS is already implemented to send requests to the FMUR. The docker-compose and .env files have been updated accordingly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in a K8s environment deployed in GCP with live Commsignia RSUs. Unit tests have been updated and pass locally as well.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [x] My changes require new environment variables:
  - [x] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [x] My changes require updates to the documentation:
  - [x] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
