### PR TITLE
Update V2x Message Viewer geometry generation from useEffect to useMemo

### DIFF
--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -195,23 +195,6 @@ function MapPage() {
     features: [],
   })
 
-  // BSM layer local state variables
-  const [geoMsgPolygonSource, setGeoMsgPolygonSource] = useState<GeoJSON.Feature<GeoJSON.Geometry>>({
-    type: 'Feature',
-    geometry: {
-      type: 'Polygon',
-      coordinates: [],
-    },
-    properties: {},
-  })
-
-  const [geoMsgPolygonPointSource, setGeoMsgPolygonPointSource] = useState<GeoJSON.FeatureCollection<GeoJSON.Geometry>>(
-    {
-      type: 'FeatureCollection',
-      features: [],
-    }
-  )
-
   const [geoMsgPointSource, setGeoMsgPointSource] = useState<GeoJSON.FeatureCollection<GeoJSON.Geometry>>({
     type: 'FeatureCollection',
     features: [],
@@ -329,13 +312,18 @@ function MapPage() {
   }
 
   // Effect for handling polygon updates msg-viewer-layer
-  useEffect(() => {
-    if (!activeLayers.includes('msg-viewer-layer')) return
 
-    setGeoMsgPolygonPointSource((prevPointSource) => ({
-      ...prevPointSource,
+  const geoMsgPolygonPointSource = useMemo(() => {
+    if (!activeLayers.includes('msg-viewer-layer')) return null
+
+    return {
+      type: 'FeatureCollection',
       features: geoMsgCoordinates.map((point) => createPointFeature(point)),
-    }))
+    } as GeoJSON.FeatureCollection<GeoJSON.Geometry>
+  }, [geoMsgCoordinates, activeLayers])
+
+  const geoMsgPolygonSource = useMemo(() => {
+    if (!activeLayers.includes('msg-viewer-layer')) return null
 
     // Get coordinates including preview point if it exists
     let polygonCoords = [...geoMsgCoordinates]
@@ -360,16 +348,16 @@ function MapPage() {
       polygonCoords.push(polygonCoords[0])
     }
 
-    setGeoMsgPolygonSource(
-      (prevPolygonSource) =>
-        ({
-          ...prevPolygonSource,
-          geometry: {
-            type: polygonCoords.length === 2 ? 'LineString' : 'Polygon', // Use LineString for 2 points
-            coordinates: polygonCoords.length === 2 ? polygonCoords : [polygonCoords],
-          },
-        } as GeoJSON.Feature<GeoJSON.Geometry>)
-    )
+    const polygonSource = {
+      type: 'Feature',
+      geometry: {
+        type: polygonCoords.length === 2 ? 'LineString' : 'Polygon', // Use LineString for 2 points
+        coordinates: polygonCoords.length === 2 ? polygonCoords : [polygonCoords],
+      },
+      properties: {},
+    } as GeoJSON.Feature<GeoJSON.Geometry>
+
+    return polygonSource
   }, [geoMsgCoordinates, activeLayers, addGeoMsgPoint, previewPoint])
 
   const mooveAiPolygonPointSource = useMemo(


### PR DESCRIPTION
# PR Details

This PR swaps the V2x Message Viewer geometry generation from useEffect to useMemo.

## Description

The useEffect hook can cause unwanted re-rendering, which is undesirable in this scenario. This PR fixes this issue by swapping to useMemo, which reduces the number of times that require re-calculation.

## How Has This Been Tested?

These changes were tested locally with Docker.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
