### PR TITLE
Fixing Q2 Testing Bugs

### DIFF
--- a/webapp/src/components/__snapshots__/Help.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/Help.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="RSU Statuses Shown on Map"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_status.PNG"
       />
       <p>
@@ -29,7 +29,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="RSU Popup with Data"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_popup.PNG"
       />
       <p>
@@ -37,7 +37,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="RSU Menu"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_menu.PNG"
       />
       <p>
@@ -45,7 +45,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="RSU Message Count Table"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_count.PNG"
       />
       <p>
@@ -53,7 +53,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="CV Manager Heat Map"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_heatmap.PNG"
       />
       <p>
@@ -61,7 +61,7 @@ exports[`should take a snapshot 1`] = `
       </p>
       <img
         alt="CV Manager Configuration Page"
-        class="css-1qjvnec"
+        class="css-2ttpiu"
         src="rsu_configure.PNG"
       />
     </div>

--- a/webapp/src/features/intersections/map/control-panel.tsx
+++ b/webapp/src/features/intersections/map/control-panel.tsx
@@ -439,8 +439,8 @@ function ControlPanel() {
                       type="number"
                       sx={{ mt: 1 }}
                       onChange={(e) => {
-                        if (e.target.value === '' || Number.isInteger(Number(e.target.value))) {
-                          setTimeWindowSeconds(parseInt(e.target.value))
+                        if (Number.isInteger(Number(e.target.value))) {
+                          dispatch(setTimeWindowSeconds(parseInt(e.target.value)))
                         }
                       }}
                       slotProps={{

--- a/webapp/src/features/intersections/map/control-panel.tsx
+++ b/webapp/src/features/intersections/map/control-panel.tsx
@@ -62,7 +62,7 @@ import { decoderModeToggled, setAsn1DecoderDialogOpen } from '../decoder/asn1-de
 import toast from 'react-hot-toast'
 import { ExpandMoreOutlined, Pause, PlayArrowOutlined, UploadFile } from '@mui/icons-material'
 
-const getNumber = (value: string | undefined): number | undefined => {
+export const getNumber = (value: string | undefined): number | undefined => {
   if (value == null) return undefined
   const num = parseInt(value)
   if (isNaN(num)) {
@@ -246,20 +246,10 @@ function ControlPanel() {
   }, [timeWindowSeconds])
 
   useEffect(() => {
-    setBsmTrailLengthLocal(bsmTrailLength.toString())
-  }, [bsmTrailLength])
-
-  useEffect(() => {
     if (getNumber(timeWindowSecondsLocal) != null && getNumber(timeWindowSecondsLocal) !== timeWindowSeconds) {
       dispatch(setTimeWindowSeconds(getNumber(timeWindowSecondsLocal)))
     }
   }, [timeWindowSecondsLocal])
-
-  useEffect(() => {
-    if (getNumber(bsmTrailLengthLocal) !== null && getNumber(bsmTrailLengthLocal) !== bsmTrailLength) {
-      dispatch(setBsmTrailLength(getNumber(bsmTrailLengthLocal)!))
-    }
-  }, [bsmTrailLengthLocal])
 
   const timelineTicks = [120, 240, 360, 480, 600, 720, 840, 960, 1080, 1200, 1320]
 

--- a/webapp/src/features/intersections/map/visual-settings.tsx
+++ b/webapp/src/features/intersections/map/visual-settings.tsx
@@ -10,12 +10,14 @@ import {
   setSigGroupLabelsVisible,
   setShowPopupOnHover,
   selectBsmTrailLength,
+  setBsmTrailLength,
 } from './map-slice'
 import { selectSignalStateLayerStyle, setSignalLayerLayout } from './map-layer-style-slice'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import React from 'react'
 import { Close, SettingsOutlined } from '@mui/icons-material'
+import { getNumber } from './control-panel'
 
 type VisualSettingsProps = {
   openPanel: string
@@ -37,6 +39,16 @@ function VisualSettings(props: VisualSettingsProps) {
     props.openPanel === 'visual-settings' ? props.setOpenPanel('') : props.setOpenPanel('visual-settings')
   }
   const [bsmTrailLengthLocal, setBsmTrailLengthLocal] = useState<string | undefined>(bsmTrailLength.toString())
+
+  useEffect(() => {
+    setBsmTrailLengthLocal(bsmTrailLength.toString())
+  }, [bsmTrailLength])
+
+  useEffect(() => {
+    if (getNumber(bsmTrailLengthLocal) !== null && getNumber(bsmTrailLengthLocal) !== bsmTrailLength) {
+      dispatch(setBsmTrailLength(getNumber(bsmTrailLengthLocal)!))
+    }
+  }, [bsmTrailLengthLocal])
 
   return (
     <>

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -1019,15 +1019,11 @@ function MapPage() {
                 </FormGroup>
                 <FormGroup row sx={{ justifyContent: 'center', alignItems: 'center' }}>
                   <Button
-                    variant="outlined"
-                    color="info"
+                    variant="contained"
                     sx={{
-                      '&.Mui-disabled': {
-                        backgroundColor: alpha(theme.palette.primary.light, 0.5),
-                      },
                       width: '100%',
                     }}
-                    disabled={!(configCoordinates.length > 2 && addConfigPoint)}
+                    disabled={!(configCoordinates.length > 2)}
                     onClick={() => {
                       dispatch(geoRsuQuery(selectedVendor))
                     }}

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -1019,8 +1019,12 @@ function MapPage() {
                 </FormGroup>
                 <FormGroup row sx={{ justifyContent: 'center', alignItems: 'center' }}>
                   <Button
-                    variant="contained"
+                    variant="outlined"
+                    color="info"
                     sx={{
+                      '&.Mui-disabled': {
+                        backgroundColor: alpha(theme.palette.primary.light, 0.5),
+                      },
                       width: '100%',
                     }}
                     disabled={!(configCoordinates.length > 2)}

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -120,6 +120,7 @@ import { toast } from 'react-hot-toast'
 import { RoomOutlined } from '@mui/icons-material'
 import MooveAiHardBrakingLegend from '../components/MooveAiHardBrakingLegend'
 import { PrimaryButton } from '../styles/components/PrimaryButton'
+import { ConditionalRenderRsu, evaluateFeatureFlags } from '../feature-flags'
 
 // @ts-ignore: workerClass does not exist in typed mapboxgl
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -751,6 +752,7 @@ function MapPage() {
       id: 'msg-viewer-layer',
       label: 'V2x Message Viewer',
       type: 'symbol',
+      tag: 'rsu',
     },
     {
       id: 'wzdx-layer',
@@ -842,28 +844,30 @@ function MapPage() {
 
     return (
       <FormGroup>
-        {layers.map((layer) => (
-          <div key={layer.id}>
-            <Typography fontSize="small" display="flex" alignItems="center">
-              {layer.control && (
-                <IconButton
-                  onClick={() => toggleExpandLayer(layer.id)}
-                  size="small"
-                  edge="end"
-                  aria-label={expandedLayers.includes(layer.id) ? 'Collapse' : 'Expand'}
-                >
-                  {expandedLayers.includes(layer.id) ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                </IconButton>
-              )}
-              <FormControlLabel
-                onClick={() => toggleLayer(layer.id)}
-                label={<Typography>{layer.label}</Typography>}
-                control={<Checkbox checked={activeLayers.includes(layer.id)} />}
-              />
-            </Typography>
-            {layer.control && <Collapse in={expandedLayers.includes(layer.id)}>{layer.control}</Collapse>}
-          </div>
-        ))}
+        {layers
+          .filter((layer) => evaluateFeatureFlags(layer.tag))
+          .map((layer) => (
+            <div key={layer.id}>
+              <Typography fontSize="small" display="flex" alignItems="center">
+                {layer.control && (
+                  <IconButton
+                    onClick={() => toggleExpandLayer(layer.id)}
+                    size="small"
+                    edge="end"
+                    aria-label={expandedLayers.includes(layer.id) ? 'Collapse' : 'Expand'}
+                  >
+                    {expandedLayers.includes(layer.id) ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  </IconButton>
+                )}
+                <FormControlLabel
+                  onClick={() => toggleLayer(layer.id)}
+                  label={<Typography>{layer.label}</Typography>}
+                  control={<Checkbox checked={activeLayers.includes(layer.id)} />}
+                />
+              </Typography>
+              {layer.control && <Collapse in={expandedLayers.includes(layer.id)}>{layer.control}</Collapse>}
+            </div>
+          ))}
       </FormGroup>
     )
   }
@@ -913,158 +917,167 @@ function MapPage() {
             <Legend />
           </AccordionDetails>
         </Accordion>
-        <Divider />
-        <Accordion
-          style={{ backgroundColor: theme.palette.background.paper }}
-          disableGutters={true}
-          sx={{ '&.accordion': { marginBottom: 0 } }}
-          defaultExpanded
-          elevation={0}
-        >
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon style={{ color: theme.palette.text.primary }} />}
-            aria-controls="panel3-content"
-            id="panel3-header"
+        <ConditionalRenderRsu>
+          <Divider />
+          <Accordion
+            style={{ backgroundColor: theme.palette.background.paper }}
+            disableGutters={true}
+            sx={{ '&.accordion': { marginBottom: 0 } }}
+            defaultExpanded
+            elevation={0}
           >
-            <Typography className="accordion-header museo-slab" color={theme.palette.text.primary}>
-              Filter RSUs
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <FormControl fullWidth>
-              <InputLabel htmlFor="vendor">Vendor</InputLabel>
-              <Select
-                id="vendor"
-                label="Vendor"
-                value={selectedVendor}
-                defaultValue={selectedVendor}
-                onChange={(event) => {
-                  const vendor = event.target.value as string
-                  console.log(vendor)
-                  setVendor(vendor)
-                }}
-              >
-                {vendorArray.map((vendor) => (
-                  <MenuItem key={vendor} value={vendor}>
-                    <Typography>{vendor}</Typography>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <Typography sx={{ marginTop: '12px' }}>RSU Status</Typography>
-            <FormControl sx={{ ml: 2, mt: 1 }}>
-              <RadioGroup value={displayType} onChange={handleRsuDisplayTypeChange}>
-                {[
-                  { key: 'online', label: <Typography>Online Status</Typography> },
-                  { key: 'scms', label: <Typography>SCMS Status</Typography> },
-                ].map((val) => (
-                  <FormControlLabel
-                    value={val.key}
-                    sx={{ mt: -1 }}
-                    control={
-                      <Radio
-                        sx={{
-                          color: theme.palette.text.primary,
-                          '&.Mui-checked': {
-                            color: theme.palette.primary.main,
-                          },
-                        }}
-                      />
-                    }
-                    label={val.label}
-                  />
-                ))}
-              </RadioGroup>
-            </FormControl>
-          </AccordionDetails>
-        </Accordion>
-        {SecureStorageManager.getUserRole() === 'admin' && (
-          <>
-            <Divider />
-            <Accordion
-              style={{ backgroundColor: theme.palette.background.paper }}
-              disableGutters={true}
-              sx={{ '&.accordion': { marginBottom: 0 } }}
-              defaultExpanded
-              elevation={0}
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon style={{ color: theme.palette.text.primary }} />}
+              aria-controls="panel3-content"
+              id="panel3-header"
             >
-              <AccordionSummary
-                expandIcon={<ExpandMoreIcon style={{ color: theme.palette.text.primary }} />}
-                aria-controls="panel3-content"
-                id="panel3-header"
+              <Typography className="accordion-header museo-slab" color={theme.palette.text.primary}>
+                Filter RSUs
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <FormControl fullWidth>
+                <InputLabel htmlFor="vendor">Vendor</InputLabel>
+                <Select
+                  id="vendor"
+                  label="Vendor"
+                  value={selectedVendor}
+                  defaultValue={selectedVendor}
+                  onChange={(event) => {
+                    const vendor = event.target.value as string
+                    console.log(vendor)
+                    setVendor(vendor)
+                  }}
+                >
+                  {vendorArray.map((vendor) => (
+                    <MenuItem key={vendor} value={vendor}>
+                      <Typography>{vendor}</Typography>
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Typography sx={{ marginTop: '12px' }}>RSU Status</Typography>
+              <FormControl sx={{ ml: 2, mt: 1 }}>
+                <RadioGroup value={displayType} onChange={handleRsuDisplayTypeChange}>
+                  {[
+                    { key: 'online', label: <Typography>Online Status</Typography> },
+                    { key: 'scms', label: <Typography>SCMS Status</Typography> },
+                  ].map((val) => (
+                    <FormControlLabel
+                      value={val.key}
+                      sx={{ mt: -1 }}
+                      control={
+                        <Radio
+                          sx={{
+                            color: theme.palette.text.primary,
+                            '&.Mui-checked': {
+                              color: theme.palette.primary.main,
+                            },
+                          }}
+                        />
+                      }
+                      label={val.label}
+                    />
+                  ))}
+                </RadioGroup>
+              </FormControl>
+            </AccordionDetails>
+          </Accordion>
+        </ConditionalRenderRsu>
+
+        <ConditionalRenderRsu>
+          {SecureStorageManager.getUserRole() === 'admin' && (
+            <>
+              <Divider />
+              <Accordion
+                style={{ backgroundColor: theme.palette.background.paper }}
+                disableGutters={true}
+                sx={{ '&.accordion': { marginBottom: 0 } }}
+                defaultExpanded
+                elevation={0}
               >
-                <Typography className="accordion-header museo-slab" color={theme.palette.text.primary}>
-                  RSU Configuration
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <FormGroup row className="form-group-row">
-                  <FormControlLabel
-                    control={<Switch checked={addConfigPoint} />}
-                    label={<Typography>Add Points</Typography>}
-                    onChange={(e) => handleButtonToggle(e, 'config')}
-                    sx={{ ml: 1 }}
-                  />
-                  <Tooltip title="Clear Points">
-                    <IconButton
-                      disabled={configCoordinates.length == 0}
-                      onClick={() => {
-                        dispatch(clearConfig())
+                <AccordionSummary
+                  expandIcon={<ExpandMoreIcon style={{ color: theme.palette.text.primary }} />}
+                  aria-controls="panel3-content"
+                  id="panel3-header"
+                >
+                  <Typography className="accordion-header museo-slab" color={theme.palette.text.primary}>
+                    RSU Configuration
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FormGroup row className="form-group-row">
+                    <FormControlLabel
+                      control={<Switch checked={addConfigPoint} />}
+                      label={<Typography>Add Points</Typography>}
+                      onChange={(e) => handleButtonToggle(e, 'config')}
+                      sx={{ ml: 1 }}
+                    />
+                    <Tooltip title="Clear Points">
+                      <IconButton
+                        disabled={configCoordinates.length == 0}
+                        onClick={() => {
+                          dispatch(clearConfig())
+                        }}
+                        size="large"
+                      >
+                        <ClearIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </FormGroup>
+                  <FormGroup row sx={{ justifyContent: 'center', alignItems: 'center' }}>
+                    <Button
+                      variant="outlined"
+                      color="info"
+                      sx={{
+                        '&.Mui-disabled': {
+                          backgroundColor: alpha(theme.palette.primary.light, 0.5),
+                        },
+                        width: '100%',
                       }}
-                      size="large"
+                      disabled={!(configCoordinates.length > 2)}
+                      onClick={() => {
+                        dispatch(geoRsuQuery(selectedVendor))
+                      }}
+                      className="museo-slab capital-case"
                     >
-                      <ClearIcon />
-                    </IconButton>
-                  </Tooltip>
-                </FormGroup>
-                <FormGroup row sx={{ justifyContent: 'center', alignItems: 'center' }}>
-                  <Button
-                    variant="outlined"
-                    color="info"
-                    sx={{
-                      '&.Mui-disabled': {
-                        backgroundColor: alpha(theme.palette.primary.light, 0.5),
-                      },
-                      width: '100%',
-                    }}
-                    disabled={!(configCoordinates.length > 2)}
-                    onClick={() => {
-                      dispatch(geoRsuQuery(selectedVendor))
-                    }}
-                    className="museo-slab capital-case"
-                  >
-                    Configure RSUs
-                  </Button>
-                </FormGroup>
-              </AccordionDetails>
-            </Accordion>
-          </>
-        )}
+                      Configure RSUs
+                    </Button>
+                  </FormGroup>
+                </AccordionDetails>
+              </Accordion>
+            </>
+          )}
+        </ConditionalRenderRsu>
       </div>
-      <PrimaryButton
-        sx={{
-          zIndex: 90,
-          position: 'absolute',
-          top: `${headerTabHeight + 25}px`,
-          right: '25px',
-        }}
-        className="museo-slab capital-case"
-        onClick={() => dispatch(toggleMapMenuSelection('Display Message Counts'))}
-      >
-        Message Counts
-      </PrimaryButton>
-      <PrimaryButton
-        sx={{
-          zIndex: 90,
-          position: 'absolute',
-          top: `${headerTabHeight + 25}px`,
-          right: '200px',
-        }}
-        className="museo-slab capital-case"
-        onClick={() => dispatch(toggleMapMenuSelection('Display RSU Status'))}
-      >
-        Display RSU Status
-      </PrimaryButton>
+      <ConditionalRenderRsu>
+        <PrimaryButton
+          sx={{
+            zIndex: 90,
+            position: 'absolute',
+            top: `${headerTabHeight + 25}px`,
+            right: '25px',
+          }}
+          className="museo-slab capital-case"
+          onClick={() => dispatch(toggleMapMenuSelection('Display Message Counts'))}
+        >
+          Message Counts
+        </PrimaryButton>
+      </ConditionalRenderRsu>
+      <ConditionalRenderRsu>
+        <PrimaryButton
+          sx={{
+            zIndex: 90,
+            position: 'absolute',
+            top: `${headerTabHeight + 25}px`,
+            right: '200px',
+          }}
+          className="museo-slab capital-case"
+          onClick={() => dispatch(toggleMapMenuSelection('Display RSU Status'))}
+        >
+          Display RSU Status
+        </PrimaryButton>
+      </ConditionalRenderRsu>
       <Container
         fluid={true}
         style={{

--- a/webapp/src/styles/components/BorderedImage.tsx
+++ b/webapp/src/styles/components/BorderedImage.tsx
@@ -4,4 +4,5 @@ export const BorderedImage = styled('img')(({ theme }) => ({
   display: 'block',
   marginLeft: 'auto',
   marginRight: 'auto',
+  maxWidth: '900px',
 }))


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Fixing the following bugs discovered during testing the Q2 release changes:
- [x] [CV Manager RSU Configuration Menu Button Disabling After Double Click](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2079?workitem=316001)
    - [x] fix: changed logic to enable button after double click
- [x] [Intersection Map Changing BSM Trail length Has No Effect](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2079?workitem=316008)
    - [x] fix: Re-linked button to correctly update redux state and propagate update to map
- [x] [CV Manager Help Page Images Are Too Large](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2079?workitem=316014)
    - [x] fix: Added max-width to BorderedImage (used only in Help page)
- [x] [Feature flags not affecting map menu](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2079?workitem=316356)
    - [x] fix: Added feature flag conditional rendering to map menu
- [x] [CV Manager Intersection map Time Window Not Changing](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2079?workitem=316389)
    - [x] fix: Fixed propagation of time render window onChange to update as expected

## How Has This Been Tested?

- RSU Configuration Menu (images of before, then after)
    - On map page, enable "RSU Viewer layer", select 2 points, then double click. The "Configure RSUs" button should be enabled
![image](https://github.com/user-attachments/assets/b510826b-e1e4-4b8f-8083-3ccbef14eb43)
![image](https://github.com/user-attachments/assets/4a37b0fc-c06e-432a-84c6-8f2a5be7e63c)
- BSM Trail Length
    - On the intersection map, select intersection 12109, then open the settings menu, then change the BSM trail length, then move the time slider. The number of BSMs of each color should match the updated value
- Help Page (images of before, then after)
    - Navigate to the help page, confirm that images are a reasonable size, with different window sizes. The issue before was most obvious with larger window sizes
![image](https://github.com/user-attachments/assets/4a07cb2d-1c49-4244-a5b6-702cbec2df11)
![image](https://github.com/user-attachments/assets/221f3cac-9ad3-4344-bcdc-2ba1c56dcc3d)
- Feature Flags
    - Disable various features in the environment variables, and confirm that all related UI elements are not present
    - All features disabled:
![image](https://github.com/user-attachments/assets/d3603184-386c-4fe2-bd45-e488cc46fc87)
    - Only RSU features enabled
![image](https://github.com/user-attachments/assets/c6d8b563-acaf-4a29-90db-f231e80abcd8)
- Time render window not changing
    - navigate to the intersection map, select intersection 12109, then reduce the time render window to 5 seconds and confirm that fewer BSMs are displayed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
