### PR TITLE
Prevent RSU selection during point selection                          

### DIFF
--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -876,6 +876,12 @@ function MapPage() {
     event: React.SyntheticEvent<Element, Event>,
     origin: 'config' | 'msgViewer' | 'mooveai'
   ) => {
+    // Deselect any selected RSU when toggling point select tools
+    dispatch(selectRsu(null))
+    dispatch(clearFirmware())
+    setSelectedRsuCount(null)
+
+    // Toggle the corresponding point select tool based on the origin
     if (origin === 'config') {
       dispatch(toggleConfigPointSelect())
       if (addGeoMsgPoint) dispatch(toggleGeoMsgPointSelect())
@@ -1190,6 +1196,8 @@ function MapPage() {
                   latitude={rsu.geometry.coordinates[1]}
                   longitude={rsu.geometry.coordinates[0]}
                   onClick={(e) => {
+                    // Prevent RSU selection if adding points to geospatial polygon selection
+                    if (addConfigPoint || addGeoMsgPoint || addMooveAiPoint) return
                     e.originalEvent.stopPropagation()
                     dispatch(selectRsu(rsu))
                     setSelectedWZDxMarkerIndex(null)
@@ -1205,6 +1213,8 @@ function MapPage() {
                   <button
                     className="marker-btn"
                     onClick={(e) => {
+                      // Prevent RSU selection if adding points to geospatial polygon selection
+                      if (addConfigPoint || addGeoMsgPoint || addMooveAiPoint) return
                       e.stopPropagation()
                       dispatch(selectRsu(rsu))
                       dispatch(clearFirmware()) // TODO: Should remove??


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Update the behavior of the CV Manager web application to not allow the selection of RSUs while using the point selection tool for relevant features. (RSU Configuration, V2X Message Viewer and Moove.AI) To make point selection easier, any already selected RSUs will automatically be deselected when toggling the point selection tool.

![image](https://github.com/user-attachments/assets/d2093397-8812-434d-83e0-71e3fd851df8)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally with the `basic, webapp` compose profiles
- Tested locally with the `basic` compose profile and running the webapp through `npm start`. Some environment variables need to be changed to make this work.
- `npm test` tests all pass

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.