### PR TITLE
Fixing Notification Dismissal Response

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -43,6 +43,11 @@ Enhancements in this release:
 - [CDOT PR 196](https://github.com/CDOT-CV/jpo-cvmanager/pull/196): Fixing Q2 Testing Bugs
 - [CDOT PR 198](https://github.com/CDOT-CV/jpo-cvmanager/pull/198): RSU popup display fixes
 - [CDOT PR 199](https://github.com/CDOT-CV/jpo-cvmanager/pull/199): Improving Intersection Dashboard Assessment Plot Formatting
+- [CDOT PR 206](https://github.com/CDOT-CV/jpo-cvmanager/pull/206): Adding additional required package to dockerfile
+- [CDOT PR 204](https://github.com/CDOT-CV/jpo-cvmanager/pull/204): Prevent RSU selection during point selection
+- [CDOT PR 189](https://github.com/CDOT-CV/jpo-cvmanager/pull/189): Update the collection and topic names based on the new event names
+- [CDOT PR 205](https://github.com/CDOT-CV/jpo-cvmanager/pull/205): Upgrading Intersection API ODE Dependencies
+- [CDOT PR 208](https://github.com/CDOT-CV/jpo-cvmanager/pull/208): Fixing Notification Dismissal Response
 
 ## Version 1.5.0
 

--- a/webapp/src/apis/intersections/notification-api.ts
+++ b/webapp/src/apis/intersections/notification-api.ts
@@ -58,17 +58,15 @@ class NotificationApi {
     for (const id of ids) {
       success =
         success &&
-        (
-          await authApiHelper.invokeApi({
-            path: `/notifications/active`,
-            method: 'DELETE',
-            abortController,
-            token: token,
-            body: id.toString(),
-            booleanResponse: true,
-            tag: 'intersection',
-          })
-        )?.content?.[0]
+        (await authApiHelper.invokeApi({
+          path: `/notifications/active`,
+          method: 'DELETE',
+          abortController,
+          token: token,
+          body: id.toString(),
+          booleanResponse: true,
+          tag: 'intersection',
+        }))
     }
     if (success) {
       toast.success(`Successfully Dismissed ${ids.length} Notifications`)

--- a/webapp/src/features/api/intersectionApiSlice.ts
+++ b/webapp/src/features/api/intersectionApiSlice.ts
@@ -53,7 +53,7 @@ export const intersectionApiSlice = createApi({
         url: 'config/default',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body,
+        body: { ...body, roadRegulatorID: -1 }, // necessary for Intersection API deserialization, not used by webapp
       }),
       async onQueryStarted(props, { dispatch, queryFulfilled }) {
         await queryFulfilled
@@ -73,7 +73,7 @@ export const intersectionApiSlice = createApi({
         url: 'config/intersection',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body,
+        body: { ...body, roadRegulatorID: -1 }, // necessary for Intersection API deserialization, not used by webapp
       }),
       transformResponse: (response: any, meta: any) => response as IntersectionConfig,
       invalidatesTags: ['intersectionConfigs'],
@@ -83,7 +83,7 @@ export const intersectionApiSlice = createApi({
         url: `config/intersection`,
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: config,
+        body: { ...config, roadRegulatorID: -1 }, // necessary for Intersection API deserialization, not used by webapp
       }),
       transformResponse: (response: any, meta: any) => response as IntersectionConfig,
       invalidatesTags: ['intersectionConfigs'],

--- a/webapp/src/features/intersections/configuration/configuration-list-table.tsx
+++ b/webapp/src/features/intersections/configuration/configuration-list-table.tsx
@@ -82,7 +82,6 @@ export const ConfigParamListTable = (props) => {
           {param.value.toString()}
           {
             <Chip
-              color="secondary"
               sx={{ ml: 3 }}
               label={
                 <Typography


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This PR fixes a bug causing the Intersection Dashboard notification dismissal processes to display an error message, whether the dismissal was successful or not. This error is caused from incorrectly processing the API's response to a notification dismissal
Additional bugs fixed:
- Notification toast now correct after successful dismissal
- Intersection dashboard configuration override text now has increased contrast: 
![image](https://github.com/user-attachments/assets/d69ce0b5-8203-4381-9389-ffd454efc9fd)
- Intersection dashboard configuration override creation now includes required roadRegulatorID parameter
    - The roadRegulatorID was removed from all front-end components, but is still required by some underlying ConflictMonitor types. In this case, the IntersectionConfig<T> class still requires the roadRegulatorID field

## How Has This Been Tested?

This was tested locally, by initializing the project with the default sample data, navigating to the intersection dashboard for intersection 12109, selecting one or more notifications, dismissing them, and observing the resulting success/failure toast notification.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
