### PR TITLE
Fix DisplayRsuErrors formatting for single RSU

### DIFF
--- a/webapp/src/features/menu/DisplayRsuErrors.tsx
+++ b/webapp/src/features/menu/DisplayRsuErrors.tsx
@@ -184,16 +184,15 @@ const DisplayRsuErrors = ({ initialSelectedRsu }: { initialSelectedRsu?: RsuInfo
                 <Typography>Online Status</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <div style={errorPageStyle}>
-                  <p>
+                <div>
+                  <Typography fontSize="small" sx={{ color: theme.palette.text.secondary }}>
                     <b>RSU Online Status: </b>
                     {getRSUOnlineStatus(selectedRSU.properties.ipv4_address)}
-                  </p>
-                  <br />
-                  <p>
+                  </Typography>
+                  <Typography fontSize="small" sx={{ color: theme.palette.text.secondary }}>
                     <b>RSU Last Online: </b>
                     {getRSULastOnline(selectedRSU.properties.ipv4_address)}
-                  </p>
+                  </Typography>
                 </div>
               </AccordionDetails>
             </Accordion>
@@ -202,16 +201,15 @@ const DisplayRsuErrors = ({ initialSelectedRsu }: { initialSelectedRsu?: RsuInfo
                 <Typography>SCMS Status</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <div style={errorPageStyle}>
-                  <p>
+                <div>
+                  <Typography fontSize="small" sx={{ color: theme.palette.text.secondary }}>
                     <b>SCMS Status: </b>
                     {getRSUSCMSStatus(selectedRSU.properties.ipv4_address) === '1' ? 'Healthy' : 'Unhealthy'}
-                  </p>
-                  <br />
-                  <p>
+                  </Typography>
+                  <Typography fontSize="small" sx={{ color: theme.palette.text.secondary }}>
                     <b>SCMS Expiration: </b>
                     {getRSUSCMSExpiration(selectedRSU.properties.ipv4_address)}
-                  </p>
+                  </Typography>
                 </div>
               </AccordionDetails>
             </Accordion>

--- a/webapp/src/features/menu/__snapshots__/DisplayRsuErrors.test.tsx.snap
+++ b/webapp/src/features/menu/__snapshots__/DisplayRsuErrors.test.tsx.snap
@@ -93,17 +93,18 @@ exports[`should take a snapshot 1`] = `
                   <div
                     class="MuiAccordionDetails-root css-mocked-MuiAccordionDetails-root"
                   >
-                    <div
-                      style="background-color: rgb(0, 0, 0); border-top: 1px solid white; border-bottom: 1px solid white; font-family: \\"museo-slab\\" Arial Helvetica Sans-Serif; width: 90%; padding: 0.5rem 1rem;"
-                    >
-                      <p>
+                    <div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-mocked-MuiTypography-root"
+                      >
                         <b>
                           RSU Online Status: 
                         </b>
                         Offline
                       </p>
-                      <br />
-                      <p>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-mocked-MuiTypography-root"
+                      >
                         <b>
                           RSU Last Online: 
                         </b>
@@ -172,17 +173,18 @@ exports[`should take a snapshot 1`] = `
                   <div
                     class="MuiAccordionDetails-root css-mocked-MuiAccordionDetails-root"
                   >
-                    <div
-                      style="background-color: rgb(0, 0, 0); border-top: 1px solid white; border-bottom: 1px solid white; font-family: \\"museo-slab\\" Arial Helvetica Sans-Serif; width: 90%; padding: 0.5rem 1rem;"
-                    >
-                      <p>
+                    <div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-mocked-MuiTypography-root"
+                      >
                         <b>
                           SCMS Status: 
                         </b>
                         Unhealthy
                       </p>
-                      <br />
-                      <p>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-mocked-MuiTypography-root"
+                      >
                         <b>
                           SCMS Expiration: 
                         </b>


### PR DESCRIPTION
# PR Details

This PR fixes the odd border, text size, and formatting after selecting an RSU on the RSU Status menu.

## How Has This Been Tested?

This has been tested locally with Docker compose.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [ X ] All existing tests pass.
