### PR TITLE
Restricting CI sonar pipeline to only run on USDOT-JPO-ODE repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           rm -rf $GITHUB_WORKSPACE/services/intersection-api/api/target
 
   sonar:
+    if: github.event.pull_request.base.repo.owner.login == 'usdot-jpo-ode'
     needs: [build_api, webapp]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Restricting CI sonar pipeline to only run on USDOT-JPO-ODE repos
- These changes were pulled from this PR: https://github.com/CDOT-CV/jpo-ode/pull/203/files

## How Has This Been Tested?

Confirm that the sonar CI pipeline does not run on CDOT-CV repositories

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
