### PR TITLE
Admin page object not found - using loading instead of unknownUser

### DIFF
--- a/webapp/src/features/adminEditUser/AdminEditUser.tsx
+++ b/webapp/src/features/adminEditUser/AdminEditUser.tsx
@@ -13,6 +13,7 @@ import {
   submitForm,
   updateOrganizations,
   UserApiDataOrgs,
+  selectLoading,
 } from './adminEditUserSlice'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -46,8 +47,8 @@ const AdminEditUser = () => {
   const apiData = useSelector(selectApiData)
   const submitAttempt = useSelector(selectSubmitAttempt)
   const userTableData = useSelector(selectTableData)
+  const loading = useSelector(selectLoading)
   const [open, setOpen] = useState(true)
-  const [unknownUser, setUnknownUser] = useState(false)
   const navigate = useNavigate()
   const {
     register,
@@ -81,12 +82,10 @@ const AdminEditUser = () => {
       setValue('first_name', currUser.first_name)
       setValue('last_name', currUser.last_name)
       setValue('super_user', currUser.super_user)
-      if (unknownUser) setUnknownUser(false)
     } else {
-      setUnknownUser(true)
       console.error('Encountered Unknown User: ', email)
     }
-  }, [apiData, email, setValue, unknownUser, userTableData])
+  }, [apiData, email, setValue, userTableData])
 
   const onSubmit = (data: UserApiDataOrgs) => {
     dispatch(submitForm({ data })).then((data: any) => {
@@ -102,7 +101,7 @@ const AdminEditUser = () => {
 
   return (
     <>
-      {Object.keys(apiData ?? {}).length !== 0 && !unknownUser ? (
+      {apiData && !loading ? (
         <Dialog open={open}>
           <DialogContent sx={{ width: '600px', padding: '5px 10px' }}>
             <SideBarHeader
@@ -219,12 +218,12 @@ const AdminEditUser = () => {
                 </FormControl>
               </Form.Group>
 
-            {selectedOrganizations.length > 0 && (
-              <Form.Group controlId="roles">
-                <Form.Label className="trebuchet">Roles</Form.Label>
-                <p className="spacer" />
-                {selectedOrganizations.map((organization) => {
-                  const role = { role: organization.role }
+              {selectedOrganizations.length > 0 && (
+                <Form.Group controlId="roles">
+                  <Form.Label className="trebuchet">Roles</Form.Label>
+                  <p className="spacer" />
+                  {selectedOrganizations.map((organization) => {
+                    const role = { role: organization.role }
 
                     return (
                       <Form.Group controlId={organization.id.toString()}>
@@ -283,7 +282,7 @@ const AdminEditUser = () => {
           </DialogActions>
         </Dialog>
       ) : (
-        unknownUser && (
+        !loading && (
           <Dialog open={open}>
             <DialogContent sx={{ width: '600px', padding: '5px 10px' }}>
               <Typography variant={'h4'}>


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This switches the Admin edit user 'unknownUser' detection from an explicit variable to relying on the adminEditUser.loading state variable

## How Has This Been Tested?

This was tested by navigating to the admin users page, then selecting edit on the test@gmail.com user. I also tested changing the editUser address to an invalid address (e.x. http://localhost:3000/dashboard/admin/users/editUser/fail@gmail.com) to confirm that it shows the 404 page as expected

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
