### PR TITLE
Optimizing Intersection API Paging Implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,7 +95,9 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   "files.eol": "\n",
   "[java]": {
-    "editor.defaultFormatter": "redhat.java"
+    "editor.defaultFormatter": "redhat.java",
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false
   },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -78,6 +78,7 @@ public interface PageableQuery {
             @Nonnull Class<T> outputType) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
         Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        logger.error("findGeneric query {}: {}", collectionName, mongoQuery.getQueryObject());
         if (!fieldsToExclude.isEmpty()) {
             for (String field : fieldsToExclude) {
                 mongoQuery.fields().exclude(field);
@@ -132,6 +133,7 @@ public interface PageableQuery {
             @Nullable List<String> excludedFields) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
         Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        logger.error("findDocuments query {}: {}", collectionName, mongoQuery.getQueryObject());
         if (!fieldsToExclude.isEmpty()) {
             for (String field : fieldsToExclude) {
                 mongoQuery.fields().exclude(field);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -106,11 +106,6 @@ public interface PageableQuery {
             @Nullable List<String> excludedFields) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
 
-        // If pageable is null, short-circuit the aggregation and just return the normal
-        // find results
-        if (pageable.getPageNumber() == -1) {
-        }
-
         AggregationResult result = getAggregationResult(mongoTemplate, collectionName, pageable, criteria, sort,
                 fieldsToExclude);
         if (result == null || result.getMetadata().isEmpty()) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -84,7 +84,7 @@ public interface PageableQuery {
             }
         }
         List<T> results = mongoTemplate.find(mongoQuery, outputType, collectionName);
-        return new PageImpl<>(results, PageRequest.of(0, results.size()), results.size());
+        return new PageImpl<>(results, PageRequest.of(0, limit), results.size());
     }
 
     /**
@@ -138,7 +138,7 @@ public interface PageableQuery {
             }
         }
         List<Document> results = mongoTemplate.find(mongoQuery, Document.class, collectionName);
-        return new PageImpl<>(results, PageRequest.of(0, results.size()), results.size());
+        return new PageImpl<>(results, PageRequest.of(0, limit), results.size());
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -78,7 +78,6 @@ public interface PageableQuery {
             @Nonnull Class<T> outputType) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
         Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
-        logger.error("findGeneric query {}: {}", collectionName, mongoQuery.getQueryObject());
         if (!fieldsToExclude.isEmpty()) {
             for (String field : fieldsToExclude) {
                 mongoQuery.fields().exclude(field);
@@ -133,7 +132,6 @@ public interface PageableQuery {
             @Nullable List<String> excludedFields) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
         Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
-        logger.error("findDocuments query {}: {}", collectionName, mongoQuery.getQueryObject());
         if (!fieldsToExclude.isEmpty()) {
             for (String field : fieldsToExclude) {
                 mongoQuery.fields().exclude(field);
@@ -196,8 +194,6 @@ public interface PageableQuery {
 
         // Execute the aggregation
         Aggregation aggregation = Aggregation.newAggregation(operations);
-        Document pipeline = aggregation.toDocument(collectionName, Aggregation.DEFAULT_CONTEXT);
-        logger.error("Aggregation Pipeline for {}: {}", collectionName, pipeline.toJson());
         AggregationResults<AggregationResult> results = mongoTemplate
                 .aggregate(aggregation, collectionName, AggregationResult.class);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -5,11 +5,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.*;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 
@@ -66,6 +68,25 @@ public interface PageableQuery {
         return new PageImpl<>(results, pageable, aggregationResult.getMetadata().getFirst().getCount());
     }
 
+    default <T> Page<T> findGeneric(
+            @Nonnull MongoTemplate mongoTemplate,
+            @Nonnull String collectionName,
+            @Nonnull int limit,
+            @Nonnull Criteria criteria,
+            @Nonnull Sort sort,
+            @Nullable List<String> excludedFields,
+            @Nonnull Class<T> outputType) {
+        List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
+        Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        if (!fieldsToExclude.isEmpty()) {
+            for (String field : fieldsToExclude) {
+                mongoQuery.fields().exclude(field);
+            }
+        }
+        List<T> results = mongoTemplate.find(mongoQuery, outputType, collectionName);
+        return new PageImpl<>(results, PageRequest.of(0, results.size()), results.size());
+    }
+
     /**
      * Find paginated data based on the given criteria and pageable object
      *
@@ -85,6 +106,11 @@ public interface PageableQuery {
             @Nullable List<String> excludedFields) {
         List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
 
+        // If pageable is null, short-circuit the aggregation and just return the normal
+        // find results
+        if (pageable.getPageNumber() == -1) {
+        }
+
         AggregationResult result = getAggregationResult(mongoTemplate, collectionName, pageable, criteria, sort,
                 fieldsToExclude);
         if (result == null || result.getMetadata().isEmpty()) {
@@ -95,6 +121,24 @@ public interface PageableQuery {
         long totalElements = result.getMetadata().getFirst().getCount();
 
         return new PageImpl<>(data, pageable, totalElements);
+    }
+
+    default Page<Document> findDocuments(
+            @Nonnull MongoTemplate mongoTemplate,
+            @Nonnull String collectionName,
+            @Nonnull int limit,
+            @Nonnull Criteria criteria,
+            @Nonnull Sort sort,
+            @Nullable List<String> excludedFields) {
+        List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
+        Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        if (!fieldsToExclude.isEmpty()) {
+            for (String field : fieldsToExclude) {
+                mongoQuery.fields().exclude(field);
+            }
+        }
+        List<Document> results = mongoTemplate.find(mongoQuery, Document.class, collectionName);
+        return new PageImpl<>(results, PageRequest.of(0, results.size()), results.size());
     }
 
     /**
@@ -150,6 +194,8 @@ public interface PageableQuery {
 
         // Execute the aggregation
         Aggregation aggregation = Aggregation.newAggregation(operations);
+        Document pipeline = aggregation.toDocument(collectionName, Aggregation.DEFAULT_CONTEXT);
+        logger.error("Aggregation Pipeline for {}: {}", collectionName, pipeline.toJson());
         AggregationResults<AggregationResult> results = mongoTemplate
                 .aggregate(aggregation, collectionName, AggregationResult.class);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/PageableQuery.java
@@ -130,15 +130,7 @@ public interface PageableQuery {
             @Nonnull Criteria criteria,
             @Nonnull Sort sort,
             @Nullable List<String> excludedFields) {
-        List<String> fieldsToExclude = excludedFields != null ? excludedFields : Collections.emptyList();
-        Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
-        if (!fieldsToExclude.isEmpty()) {
-            for (String field : fieldsToExclude) {
-                mongoQuery.fields().exclude(field);
-            }
-        }
-        List<Document> results = mongoTemplate.find(mongoQuery, Document.class, collectionName);
-        return new PageImpl<>(results, PageRequest.of(0, limit), results.size());
+       return findGeneric(mongoTemplate, collectionName, limit, criteria, sort, excludedFields, Document.class);
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepository.java
@@ -2,7 +2,6 @@
 package us.dot.its.jpo.ode.api.accessors.assessments.connection_of_travel_assessment;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -11,5 +10,6 @@ public interface ConnectionOfTravelAssessmentRepository extends DataLoader<Conne
 
     Page<ConnectionOfTravelAssessment> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<ConnectionOfTravelAssessment> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<ConnectionOfTravelAssessment> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepositoryImpl.java
@@ -9,24 +9,26 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
-
-import java.util.Collections;
 
 @Component
 public class ConnectionOfTravelAssessmentRepositoryImpl
         implements ConnectionOfTravelAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ConnectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,8 +97,15 @@ public class ConnectionOfTravelAssessmentRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, Collections.emptyList(),
-                ConnectionOfTravelAssessment.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    ConnectionOfTravelAssessment.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    ConnectionOfTravelAssessment.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/connection_of_travel_assessment/ConnectionOfTravelAssessmentRepositoryImpl.java
@@ -2,14 +2,13 @@ package us.dot.its.jpo.ode.api.accessors.assessments.connection_of_travel_assess
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -18,17 +17,14 @@ public class ConnectionOfTravelAssessmentRepositoryImpl
         implements ConnectionOfTravelAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ConnectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -92,17 +88,17 @@ public class ConnectionOfTravelAssessmentRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     ConnectionOfTravelAssessment.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     ConnectionOfTravelAssessment.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepository.java
@@ -4,7 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.assessments.lane_direction_of_travel_as
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -13,7 +12,8 @@ public interface LaneDirectionOfTravelAssessmentRepository extends DataLoader<La
 
     Page<LaneDirectionOfTravelAssessment> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<LaneDirectionOfTravelAssessment> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<LaneDirectionOfTravelAssessment> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<LaneDirectionOfTravelAssessment> getLaneDirectionOfTravelOverTime(int intersectionID, long startTime,
             long endTime);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -24,14 +25,17 @@ public class LaneDirectionOfTravelAssessmentRepositoryImpl
         implements LaneDirectionOfTravelAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public LaneDirectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
+    public LaneDirectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -100,12 +104,18 @@ public class LaneDirectionOfTravelAssessmentRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                LaneDirectionOfTravelAssessment.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
+                    LaneDirectionOfTravelAssessment.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null, LaneDirectionOfTravelAssessment.class);
+        }
     }
 
     // TODO: Consider making pageable
-    public List<LaneDirectionOfTravelAssessment> getLaneDirectionOfTravelOverTime(int intersectionID, long startTime,
+    public List<LaneDirectionOfTravelAssessment> getLaneDirectionOfTravelOverTime(int intersectionID,
+            long startTime,
             long endTime) {
 
         Aggregation aggregation = Aggregation.newAggregation(

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/lane_direction_of_travel_assessment/LaneDirectionOfTravelAssessmentRepositoryImpl.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -13,7 +13,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -25,17 +24,14 @@ public class LaneDirectionOfTravelAssessmentRepositoryImpl
         implements LaneDirectionOfTravelAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public LaneDirectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public LaneDirectionOfTravelAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -99,16 +95,16 @@ public class LaneDirectionOfTravelAssessmentRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort, null,
                     LaneDirectionOfTravelAssessment.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null, LaneDirectionOfTravelAssessment.class);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepository.java
@@ -2,7 +2,6 @@
 package us.dot.its.jpo.ode.api.accessors.assessments.stop_line_passage_assessment;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -12,5 +11,6 @@ public interface StopLinePassageAssessmentRepository extends DataLoader<StopLine
 
     Page<StopLinePassageAssessment> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLinePassageAssessment> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLinePassageAssessment> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepositoryImpl.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.assessments.stop_line_passage_assessmen
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -11,7 +11,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -19,17 +18,14 @@ import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 public class StopLinePassageAssessmentRepositoryImpl implements StopLinePassageAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLinePassageAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLinePassageAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -93,17 +89,17 @@ public class StopLinePassageAssessmentRepositoryImpl implements StopLinePassageA
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLinePassageAssessment.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLinePassageAssessment.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_passage_assessment/StopLinePassageAssessmentRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -18,14 +19,17 @@ import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 public class StopLinePassageAssessmentRepositoryImpl implements StopLinePassageAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLinePassageAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLinePassageAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -94,7 +98,15 @@ public class StopLinePassageAssessmentRepositoryImpl implements StopLinePassageA
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, StopLinePassageAssessment.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLinePassageAssessment.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLinePassageAssessment.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepository.java
@@ -2,7 +2,6 @@
 package us.dot.its.jpo.ode.api.accessors.assessments.stop_line_stop_assessment;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -12,5 +11,6 @@ public interface StopLineStopAssessmentRepository extends DataLoader<StopLineSto
 
     Page<StopLineStopAssessment> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLineStopAssessment> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLineStopAssessment> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -18,14 +19,17 @@ import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 public class StopLineStopAssessmentRepositoryImpl implements StopLineStopAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLineStopAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLineStopAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -94,7 +98,15 @@ public class StopLineStopAssessmentRepositoryImpl implements StopLineStopAssessm
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, StopLineStopAssessment.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLineStopAssessment.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLineStopAssessment.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/assessments/stop_line_stop_assessment/StopLineStopAssessmentRepositoryImpl.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.assessments.stop_line_stop_assessment;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -11,7 +11,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -19,17 +18,14 @@ import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 public class StopLineStopAssessmentRepositoryImpl implements StopLineStopAssessmentRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopAssessment";
     private final String DATE_FIELD = "assessmentGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLineStopAssessmentRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLineStopAssessmentRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -93,17 +89,17 @@ public class StopLineStopAssessmentRepositoryImpl implements StopLineStopAssessm
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLineStopAssessment.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLineStopAssessment.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
@@ -1,14 +1,13 @@
 package us.dot.its.jpo.ode.api.accessors.bsm;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
 public interface OdeBsmJsonRepository extends DataLoader<OdeBsmData> {
     Page<OdeBsmData> find(String originIp, String vehicleId, Long startTime, Long endTime,
-            Double longitude, Double latitude, Double distance, Pageable pageable);
+            Double longitude, Double latitude, Double distance, Integer pageNumber, int limit);
 
     long count(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude,
             Double latitude, Double distance);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
@@ -7,9 +7,9 @@ import org.bson.Document;
 import org.geotools.referencing.GeodeticCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.model.OdeBsmData;
@@ -28,7 +27,6 @@ import us.dot.its.jpo.ode.model.OdeBsmData;
 public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
     private final ObjectMapper mapper = DateJsonMapper.getInstance()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -38,10 +36,8 @@ public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQ
     private final String VEHICLE_ID_FIELD = "payload.data.coreData.id";
 
     @Autowired
-    public OdeBsmJsonRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public OdeBsmJsonRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -100,7 +96,7 @@ public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQ
      *                  2x distance)
      */
     public Page<OdeBsmData> find(String originIp, String vehicleId, Long startTime, Long endTime,
-            Double centerLng, Double centerLat, Double distance, Pageable pageable) {
+            Double centerLng, Double centerLat, Double distance, Integer pageNumber, int limit) {
 
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(ORIGIN_IP_FIELD, originIp)
@@ -118,19 +114,16 @@ public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQ
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
         List<String> excludedFields = List.of("recordGeneratedAt");
 
-        Page<Document> aggregationResult;
-        if (pageable != null) {
-            aggregationResult = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                    criteria, sort, excludedFields);
-        } else {
-            aggregationResult = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
-                    criteria, sort, excludedFields);
-        }
+        Page<Document> aggregationResult = (pageNumber != null)
+                ? findDocumentsWithPagination(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit),
+                        criteria, sort, excludedFields)
+                : findDocuments(mongoTemplate, collectionName, limit, criteria, sort, excludedFields);
 
         List<OdeBsmData> bsms = aggregationResult.getContent().stream()
                 .map(document -> mapper.convertValue(document, OdeBsmData.class)).toList();
 
-        return new PageImpl<>(bsms, pageable, aggregationResult.getTotalElements());
+        int page = pageNumber != null ? pageNumber : 0;
+        return new PageImpl<>(bsms, PageRequest.of(page, limit), aggregationResult.getTotalElements());
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.model.OdeBsmData;
@@ -27,6 +28,7 @@ import us.dot.its.jpo.ode.model.OdeBsmData;
 public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
     private final ObjectMapper mapper = DateJsonMapper.getInstance()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -36,8 +38,10 @@ public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQ
     private final String VEHICLE_ID_FIELD = "payload.data.coreData.id";
 
     @Autowired
-    public OdeBsmJsonRepositoryImpl(MongoTemplate mongoTemplate) {
+    public OdeBsmJsonRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -114,8 +118,14 @@ public class OdeBsmJsonRepositoryImpl implements OdeBsmJsonRepository, PageableQ
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
         List<String> excludedFields = List.of("recordGeneratedAt");
 
-        Page<Document> aggregationResult = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                criteria, sort, excludedFields);
+        Page<Document> aggregationResult;
+        if (pageable != null) {
+            aggregationResult = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
+                    criteria, sort, excludedFields);
+        } else {
+            aggregationResult = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
+                    criteria, sort, excludedFields);
+        }
 
         List<OdeBsmData> bsms = aggregationResult.getContent().stream()
                 .map(document -> mapper.convertValue(document, OdeBsmData.class)).toList();

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepository.java
@@ -3,7 +3,6 @@ package us.dot.its.jpo.ode.api.accessors.events.bsm_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
@@ -15,7 +14,7 @@ public interface BsmEventRepository extends DataLoader<BsmEvent> {
     Page<BsmEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<BsmEvent> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 
     List<IDCount> getAggregatedDailyBsmEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepositoryImpl.java
@@ -4,10 +4,9 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -17,7 +16,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
-import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -32,17 +30,14 @@ public class BsmEventRepositoryImpl
         implements BsmEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmBsmEvents";
     private final String DATE_FIELD = "startingBsmTimestamp";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public BsmEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public BsmEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -106,7 +101,7 @@ public class BsmEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
@@ -114,12 +109,12 @@ public class BsmEventRepositoryImpl
 
         List<String> excludedFields = List.of("recordGeneratedAt");
 
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     excludedFields,
                     BsmEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, excludedFields,
                     BsmEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_event/BsmEventRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -16,6 +17,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
+import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -30,14 +32,17 @@ public class BsmEventRepositoryImpl
         implements BsmEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmBsmEvents";
     private final String DATE_FIELD = "startingBsmTimestamp";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public BsmEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public BsmEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -108,7 +113,16 @@ public class BsmEventRepositoryImpl
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
 
         List<String> excludedFields = List.of("recordGeneratedAt");
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, excludedFields, BsmEvent.class);
+
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    excludedFields,
+                    BsmEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, excludedFields,
+                    BsmEvent.class);
+        }
     }
 
     @Override
@@ -130,12 +144,15 @@ public class BsmEventRepositoryImpl
                 Aggregation.match(Criteria.where("").gte(startTime).lte(endTime)),
                 Aggregation.project("startingBsmTimestamp"),
                 Aggregation.project()
-                        .and(ConvertOperators.ToDate.toDate("$startingBsmTimestamp")).as("date"),
+                        .and(ConvertOperators.ToDate.toDate("$startingBsmTimestamp"))
+                        .as("date"),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("date").toString("%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("date").toString("%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
         List<IDCount> results = result.getMappedResults();
 
         return results;

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionEventRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.events.bsm_message_count_progression_event;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.BsmMessageCountProgressionEvent;
 
@@ -11,5 +10,5 @@ public interface BsmMessageCountProgressionEventRepository extends DataLoader<Bs
     Page<BsmMessageCountProgressionEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<BsmMessageCountProgressionEvent> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionRepositoryImpl.java
@@ -7,10 +7,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class BsmMessageCountProgressionRepositoryImpl
         implements BsmMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmBsmMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public BsmMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public BsmMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class BsmMessageCountProgressionRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     BsmMessageCountProgressionEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     BsmMessageCountProgressionEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/bsm_message_count_progression_event/BsmMessageCountProgressionRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class BsmMessageCountProgressionRepositoryImpl
         implements BsmMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmBsmMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public BsmMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
+    public BsmMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class BsmMessageCountProgressionRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                BsmMessageCountProgressionEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    BsmMessageCountProgressionEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    BsmMessageCountProgressionEvent.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepository.java
@@ -4,8 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.events.connection_of_travel_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.LaneConnectionCount;
@@ -16,7 +14,8 @@ public interface ConnectionOfTravelEventRepository extends DataLoader<Connection
 
     Page<ConnectionOfTravelEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<ConnectionOfTravelEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<ConnectionOfTravelEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailyConnectionOfTravelEventCounts(int intersectionID, Long startTime, Long endTime);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
+import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,14 +32,17 @@ public class ConnectionOfTravelEventRepositoryImpl
         implements ConnectionOfTravelEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ConnectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -106,7 +111,15 @@ public class ConnectionOfTravelEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, ConnectionOfTravelEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    ConnectionOfTravelEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    ConnectionOfTravelEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyConnectionOfTravelEventCounts(int intersectionID, Long startTime,

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/connection_of_travel_event/ConnectionOfTravelEventRepositoryImpl.java
@@ -20,10 +20,9 @@ import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.LaneConnectionCount;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -32,17 +31,14 @@ public class ConnectionOfTravelEventRepositoryImpl
         implements ConnectionOfTravelEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ConnectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -106,17 +102,17 @@ public class ConnectionOfTravelEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     ConnectionOfTravelEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     ConnectionOfTravelEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepository.java
@@ -4,8 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.events.intersection_reference_alignment
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenceAlignmentEvent;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.api.models.IDCount;
@@ -16,7 +14,7 @@ public interface IntersectionReferenceAlignmentEventRepository extends DataLoade
     Page<IntersectionReferenceAlignmentEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<IntersectionReferenceAlignmentEvent> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 
     List<IDCount> getAggregatedDailyIntersectionReferenceAlignmentEventCounts(int intersectionID, Long startTime,
             Long endTime);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepositoryImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -28,14 +29,17 @@ public class IntersectionReferenceAlignmentEventRepositoryImpl
         implements IntersectionReferenceAlignmentEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmIntersectionReferenceAlignmentEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public IntersectionReferenceAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public IntersectionReferenceAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -104,11 +108,19 @@ public class IntersectionReferenceAlignmentEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                IntersectionReferenceAlignmentEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    IntersectionReferenceAlignmentEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    IntersectionReferenceAlignmentEvent.class);
+        }
     }
 
-    public List<IDCount> getAggregatedDailyIntersectionReferenceAlignmentEventCounts(int intersectionID, Long startTime,
+    public List<IDCount> getAggregatedDailyIntersectionReferenceAlignmentEventCounts(int intersectionID,
+            Long startTime,
             Long endTime) {
         Date startTimeDate = new Date(0);
         Date endTimeDate = new Date();
@@ -122,12 +134,15 @@ public class IntersectionReferenceAlignmentEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("date").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("date").toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/intersection_reference_alignment_event/IntersectionReferenceAlignmentEventRepositoryImpl.java
@@ -14,10 +14,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -29,17 +28,14 @@ public class IntersectionReferenceAlignmentEventRepositoryImpl
         implements IntersectionReferenceAlignmentEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmIntersectionReferenceAlignmentEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public IntersectionReferenceAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public IntersectionReferenceAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -103,17 +99,17 @@ public class IntersectionReferenceAlignmentEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     IntersectionReferenceAlignmentEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     IntersectionReferenceAlignmentEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepository.java
@@ -4,9 +4,9 @@ package us.dot.its.jpo.ode.api.accessors.events.lane_direction_of_travel_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
+
 import us.dot.its.jpo.ode.api.models.IDCount;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
 public interface LaneDirectionOfTravelEventRepository extends DataLoader<LaneDirectionOfTravelEvent> {
@@ -14,7 +14,8 @@ public interface LaneDirectionOfTravelEventRepository extends DataLoader<LaneDir
 
     Page<LaneDirectionOfTravelEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<LaneDirectionOfTravelEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<LaneDirectionOfTravelEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailyLaneDirectionOfTravelEventCounts(int intersectionID, Long startTime, Long endTime);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepositoryImpl.java
@@ -20,10 +20,9 @@ import tech.units.indriya.unit.Units;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -39,7 +38,6 @@ public class LaneDirectionOfTravelEventRepositoryImpl
         implements LaneDirectionOfTravelEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -49,10 +47,8 @@ public class LaneDirectionOfTravelEventRepositoryImpl
     private final Double ONE_CENTIMETER_IN_FEET = one_centimeter.to(USCustomary.FOOT).getValue().doubleValue();
 
     @Autowired
-    public LaneDirectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public LaneDirectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -116,17 +112,17 @@ public class LaneDirectionOfTravelEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     LaneDirectionOfTravelEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     LaneDirectionOfTravelEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/lane_direction_of_travel_event/LaneDirectionOfTravelEventRepositoryImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -38,6 +39,7 @@ public class LaneDirectionOfTravelEventRepositoryImpl
         implements LaneDirectionOfTravelEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -47,8 +49,10 @@ public class LaneDirectionOfTravelEventRepositoryImpl
     private final Double ONE_CENTIMETER_IN_FEET = one_centimeter.to(USCustomary.FOOT).getValue().doubleValue();
 
     @Autowired
-    public LaneDirectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public LaneDirectionOfTravelEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -117,8 +121,15 @@ public class LaneDirectionOfTravelEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                LaneDirectionOfTravelEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    LaneDirectionOfTravelEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    LaneDirectionOfTravelEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyLaneDirectionOfTravelEventCounts(int intersectionID, Long startTime,
@@ -135,12 +146,16 @@ public class LaneDirectionOfTravelEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }
@@ -152,13 +167,16 @@ public class LaneDirectionOfTravelEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(ArithmeticOperators.Multiply.valueOf("medianDistanceFromCenterline")
+                        .and(ArithmeticOperators.Multiply
+                                .valueOf("medianDistanceFromCenterline")
                                 .multiplyBy(ONE_CENTIMETER_IN_FEET))
                         .as("medianDistanceFromCenterlineFeet"),
                 Aggregation.project()
-                        .and(ArithmeticOperators.Trunc.truncValueOf("medianDistanceFromCenterlineFeet"))
+                        .and(ArithmeticOperators.Trunc
+                                .truncValueOf("medianDistanceFromCenterlineFeet"))
                         .as("medianDistanceFromCenterlineFeet"),
 
                 Aggregation.group("medianDistanceFromCenterlineFeet").count().as("count"),
@@ -166,7 +184,8 @@ public class LaneDirectionOfTravelEventRepositoryImpl
 
         );
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }
@@ -178,16 +197,20 @@ public class LaneDirectionOfTravelEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(ArithmeticOperators.Subtract.valueOf("medianVehicleHeading").subtract("expectedHeading"))
+                        .and(ArithmeticOperators.Subtract.valueOf("medianVehicleHeading")
+                                .subtract("expectedHeading"))
                         .as("medianHeadingDelta"),
                 Aggregation.project()
-                        .and(ArithmeticOperators.Trunc.truncValueOf("medianHeadingDelta")).as("medianHeadingDelta"),
+                        .and(ArithmeticOperators.Trunc.truncValueOf("medianHeadingDelta"))
+                        .as("medianHeadingDelta"),
                 Aggregation.group("medianHeadingDelta").count().as("count"),
                 Aggregation.sort(Sort.Direction.ASC, "_id"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepository.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.events.map_broadcast_rate_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -13,7 +13,8 @@ public interface MapBroadcastRateEventRepository extends DataLoader<MapBroadcast
 
     Page<MapBroadcastRateEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<MapBroadcastRateEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<MapBroadcastRateEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailyMapBroadcastRateEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -29,14 +30,17 @@ public class MapBroadcastRateEventRepositoryImpl
         implements MapBroadcastRateEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapBroadcastRateEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public MapBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -105,7 +109,15 @@ public class MapBroadcastRateEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, MapBroadcastRateEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    MapBroadcastRateEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    MapBroadcastRateEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyMapBroadcastRateEventCounts(int intersectionID, Long startTime,
@@ -122,12 +134,16 @@ public class MapBroadcastRateEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_broadcast_rate_event/MapBroadcastRateEventRepositoryImpl.java
@@ -12,10 +12,9 @@ import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,17 +29,14 @@ public class MapBroadcastRateEventRepositoryImpl
         implements MapBroadcastRateEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapBroadcastRateEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public MapBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -104,17 +100,17 @@ public class MapBroadcastRateEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     MapBroadcastRateEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     MapBroadcastRateEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionEventRepository.java
@@ -1,14 +1,14 @@
 package us.dot.its.jpo.ode.api.accessors.events.map_message_count_progression_event;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.MapMessageCountProgressionEvent;
+import us.dot.its.jpo.ode.api.models.DataLoader;
 
 public interface MapMessageCountProgressionEventRepository extends DataLoader<MapMessageCountProgressionEvent> {
     long count(Integer intersectionID, Long startTime, Long endTime);
 
     Page<MapMessageCountProgressionEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<MapMessageCountProgressionEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<MapMessageCountProgressionEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class MapMessageCountProgressionRepositoryImpl
         implements MapMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
+    public MapMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class MapMessageCountProgressionRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                MapMessageCountProgressionEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    MapMessageCountProgressionEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    MapMessageCountProgressionEvent.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_message_count_progression_event/MapMessageCountProgressionRepositoryImpl.java
@@ -7,10 +7,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class MapMessageCountProgressionRepositoryImpl
         implements MapMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public MapMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class MapMessageCountProgressionRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     MapMessageCountProgressionEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     MapMessageCountProgressionEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepository.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.events.map_minimum_data_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMinimumDataEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -13,7 +13,7 @@ public interface MapMinimumDataEventRepository extends DataLoader<MapMinimumData
 
     Page<MapMinimumDataEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<MapMinimumDataEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<MapMinimumDataEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber, int limit);
 
     List<IDCount> getAggregatedDailyMapMinimumDataEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepositoryImpl.java
@@ -10,10 +10,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -29,17 +28,14 @@ public class MapMinimumDataEventRepositoryImpl
         implements MapMinimumDataEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapMinimumDataEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public MapMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -103,17 +99,17 @@ public class MapMinimumDataEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     MapMinimumDataEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     MapMinimumDataEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/map_minimum_data_event/MapMinimumDataEventRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -28,14 +29,17 @@ public class MapMinimumDataEventRepositoryImpl
         implements MapMinimumDataEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapMinimumDataEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public MapMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -104,7 +108,15 @@ public class MapMinimumDataEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, MapMinimumDataEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    MapMinimumDataEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    MapMinimumDataEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyMapMinimumDataEventCounts(int intersectionID, Long startTime, Long endTime) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepository.java
@@ -4,7 +4,7 @@ package us.dot.its.jpo.ode.api.accessors.events.signal_group_alignment_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalGroupAlignmentEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -14,7 +14,8 @@ public interface SignalGroupAlignmentEventRepository extends DataLoader<SignalGr
 
     Page<SignalGroupAlignmentEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SignalGroupAlignmentEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SignalGroupAlignmentEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailySignalGroupAlignmentEventCounts(int intersectionID, Long startTime, Long endTime);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepositoryImpl.java
@@ -12,10 +12,9 @@ import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalGroupAlignmentEvent;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -31,17 +30,14 @@ public class SignalGroupAlignmentEventRepositoryImpl
         implements SignalGroupAlignmentEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalGroupAlignmentEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalGroupAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SignalGroupAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -105,17 +101,17 @@ public class SignalGroupAlignmentEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SignalGroupAlignmentEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SignalGroupAlignmentEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_group_alignment_event/SignalGroupAlignmentEventRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,14 +31,17 @@ public class SignalGroupAlignmentEventRepositoryImpl
         implements SignalGroupAlignmentEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalGroupAlignmentEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalGroupAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SignalGroupAlignmentEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -106,7 +110,15 @@ public class SignalGroupAlignmentEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, SignalGroupAlignmentEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SignalGroupAlignmentEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SignalGroupAlignmentEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailySignalGroupAlignmentEventCounts(int intersectionID, Long startTime,
@@ -125,10 +137,12 @@ public class SignalGroupAlignmentEventRepositoryImpl
                 Aggregation.project()
                         .and(ConvertOperators.ToDate.toDate("$timestamp")).as("date"),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("date").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("date").toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, "CmLaneDirectionOfTravelEvent",
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation,
+                "CmLaneDirectionOfTravelEvent",
                 IDCount.class);
 
         return result.getMappedResults();

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepository.java
@@ -4,7 +4,7 @@ package us.dot.its.jpo.ode.api.accessors.events.signal_state_conflict_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalStateConflictEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -14,7 +14,8 @@ public interface SignalStateConflictEventRepository extends DataLoader<SignalSta
 
     Page<SignalStateConflictEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SignalStateConflictEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SignalStateConflictEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailySignalStateConflictEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepositoryImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,14 +31,17 @@ public class SignalStateConflictEventRepositoryImpl
         implements SignalStateConflictEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalStateConflictEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalStateConflictEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SignalStateConflictEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -106,7 +110,15 @@ public class SignalStateConflictEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, SignalStateConflictEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SignalStateConflictEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SignalStateConflictEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailySignalStateConflictEventCounts(int intersectionID, Long startTime,
@@ -123,12 +135,16 @@ public class SignalStateConflictEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/signal_state_conflict_event/SignalStateConflictEventRepositoryImpl.java
@@ -13,10 +13,9 @@ import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalStateConflictEvent;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -31,17 +30,14 @@ public class SignalStateConflictEventRepositoryImpl
         implements SignalStateConflictEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalStateConflictEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalStateConflictEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SignalStateConflictEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -105,17 +101,17 @@ public class SignalStateConflictEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SignalStateConflictEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SignalStateConflictEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepository.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.events.spat_broadcast_rate_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatBroadcastRateEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -13,7 +13,8 @@ public interface SpatBroadcastRateEventRepository extends DataLoader<SpatBroadca
 
     Page<SpatBroadcastRateEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SpatBroadcastRateEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SpatBroadcastRateEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailySpatBroadcastRateEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -28,14 +29,17 @@ public class SpatBroadcastRateEventRepositoryImpl
         implements SpatBroadcastRateEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatBroadcastRateEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SpatBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -104,7 +108,15 @@ public class SpatBroadcastRateEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, SpatBroadcastRateEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SpatBroadcastRateEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SpatBroadcastRateEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailySpatBroadcastRateEventCounts(int intersectionID, Long startTime,
@@ -121,12 +133,16 @@ public class SpatBroadcastRateEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_broadcast_rate_event/SpatBroadcastRateEventRepositoryImpl.java
@@ -10,10 +10,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -29,17 +28,14 @@ public class SpatBroadcastRateEventRepositoryImpl
         implements SpatBroadcastRateEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatBroadcastRateEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SpatBroadcastRateEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -103,17 +99,17 @@ public class SpatBroadcastRateEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SpatBroadcastRateEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SpatBroadcastRateEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionEventRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.events.spat_message_count_progression_event;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SpatMessageCountProgressionEvent;
 
@@ -11,5 +10,5 @@ public interface SpatMessageCountProgressionEventRepository extends DataLoader<S
     Page<SpatMessageCountProgressionEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<SpatMessageCountProgressionEvent> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class SpatMessageCountProgressionRepositoryImpl
         implements SpatMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SpatMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class SpatMessageCountProgressionRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                SpatMessageCountProgressionEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SpatMessageCountProgressionEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SpatMessageCountProgressionEvent.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_message_count_progression_event/SpatMessageCountProgressionRepositoryImpl.java
@@ -7,10 +7,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class SpatMessageCountProgressionRepositoryImpl
         implements SpatMessageCountProgressionEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatMessageCountProgressionEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SpatMessageCountProgressionRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class SpatMessageCountProgressionRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SpatMessageCountProgressionEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SpatMessageCountProgressionEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepository.java
@@ -3,7 +3,6 @@ package us.dot.its.jpo.ode.api.accessors.events.spat_minimum_data_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -13,7 +12,8 @@ public interface SpatMinimumDataEventRepository extends DataLoader<SpatMinimumDa
 
     Page<SpatMinimumDataEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SpatMinimumDataEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SpatMinimumDataEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailySpatMinimumDataEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -28,14 +29,17 @@ public class SpatMinimumDataEventRepositoryImpl
         implements SpatMinimumDataEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatMinimumDataEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SpatMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -104,7 +108,15 @@ public class SpatMinimumDataEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, SpatMinimumDataEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SpatMinimumDataEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SpatMinimumDataEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailySpatMinimumDataEventCounts(int intersectionID, Long startTime,
@@ -121,12 +133,16 @@ public class SpatMinimumDataEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/spat_minimum_data_event/SpatMinimumDataEventRepositoryImpl.java
@@ -10,10 +10,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -29,17 +28,14 @@ public class SpatMinimumDataEventRepositoryImpl
         implements SpatMinimumDataEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatMinimumDataEvents";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SpatMinimumDataEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -103,17 +99,17 @@ public class SpatMinimumDataEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SpatMinimumDataEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SpatMinimumDataEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepository.java
@@ -4,7 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.events.stop_line_passage_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -14,7 +13,8 @@ public interface StopLinePassageEventRepository extends DataLoader<StopLinePassa
 
     Page<StopLinePassageEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLinePassageEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLinePassageEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailyStopLinePassageEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,6 +31,7 @@ public class StopLinePassageEventRepositoryImpl
         implements StopLinePassageEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -37,8 +39,10 @@ public class StopLinePassageEventRepositoryImpl
 
     @Autowired
 
-    public StopLinePassageEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLinePassageEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -107,7 +111,15 @@ public class StopLinePassageEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, StopLinePassageEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLinePassageEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLinePassageEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyStopLinePassageEventCounts(int intersectionID, Long startTime,
@@ -124,12 +136,16 @@ public class StopLinePassageEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("}%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("}%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_passage_event/StopLinePassageEventRepositoryImpl.java
@@ -11,10 +11,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -31,7 +30,6 @@ public class StopLinePassageEventRepositoryImpl
         implements StopLinePassageEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -39,10 +37,8 @@ public class StopLinePassageEventRepositoryImpl
 
     @Autowired
 
-    public StopLinePassageEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLinePassageEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -106,17 +102,17 @@ public class StopLinePassageEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLinePassageEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLinePassageEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepository.java
@@ -4,7 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.events.stop_line_stop_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLineStopEvent;
 import us.dot.its.jpo.ode.api.models.IDCount;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -14,7 +13,7 @@ public interface StopLineStopEventRepository extends DataLoader<StopLineStopEven
 
     Page<StopLineStopEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLineStopEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLineStopEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber, int limit);
 
     List<IDCount> getAggregatedDailyStopLineStopEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepositoryImpl.java
@@ -11,10 +11,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -31,7 +30,6 @@ public class StopLineStopEventRepositoryImpl
         implements StopLineStopEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -39,10 +37,8 @@ public class StopLineStopEventRepositoryImpl
 
     @Autowired
 
-    public StopLineStopEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLineStopEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -106,17 +102,17 @@ public class StopLineStopEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLineStopEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLineStopEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/stop_line_stop_event/StopLineStopEventRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,6 +31,7 @@ public class StopLineStopEventRepositoryImpl
         implements StopLineStopEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
@@ -37,8 +39,10 @@ public class StopLineStopEventRepositoryImpl
 
     @Autowired
 
-    public StopLineStopEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLineStopEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -107,7 +111,15 @@ public class StopLineStopEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, StopLineStopEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLineStopEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLineStopEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyStopLineStopEventCounts(int intersectionID, Long startTime,
@@ -124,12 +136,16 @@ public class StopLineStopEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepository.java
@@ -4,7 +4,6 @@ package us.dot.its.jpo.ode.api.accessors.events.time_change_details_event;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.TimeChangeDetailsEvent;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.api.models.IDCount;
@@ -14,7 +13,8 @@ public interface TimeChangeDetailsEventRepository extends DataLoader<TimeChangeD
 
     Page<TimeChangeDetailsEvent> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<TimeChangeDetailsEvent> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<TimeChangeDetailsEvent> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 
     List<IDCount> getAggregatedDailyTimeChangeDetailsEventCounts(int intersectionID, Long startTime, Long endTime);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.data.mongodb.core.aggregation.DateOperators;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -30,14 +31,17 @@ public class TimeChangeDetailsEventRepositoryImpl
         implements TimeChangeDetailsEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatTimeChangeDetailsEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public TimeChangeDetailsEventRepositoryImpl(MongoTemplate mongoTemplate) {
+    public TimeChangeDetailsEventRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -106,7 +110,15 @@ public class TimeChangeDetailsEventRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, TimeChangeDetailsEvent.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    TimeChangeDetailsEvent.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    TimeChangeDetailsEvent.class);
+        }
     }
 
     public List<IDCount> getAggregatedDailyTimeChangeDetailsEventCounts(int intersectionID, Long startTime,
@@ -123,12 +135,16 @@ public class TimeChangeDetailsEventRepositoryImpl
 
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
-                Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+                Aggregation.match(
+                        Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
                 Aggregation.project()
-                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+                        .and(DateOperators.DateToString.dateOf("eventGeneratedAt")
+                                .toString("%Y-%m-%d"))
+                        .as("dateStr"),
                 Aggregation.group("dateStr").count().as("count"));
 
-        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName,
+                IDCount.class);
 
         return result.getMappedResults();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/time_change_details_event/TimeChangeDetailsEventRepositoryImpl.java
@@ -18,9 +18,9 @@ import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.aggregation.DateOperators;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -31,17 +31,14 @@ public class TimeChangeDetailsEventRepositoryImpl
         implements TimeChangeDetailsEventRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatTimeChangeDetailsEvent";
     private final String DATE_FIELD = "eventGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public TimeChangeDetailsEventRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public TimeChangeDetailsEventRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -105,17 +102,17 @@ public class TimeChangeDetailsEventRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     TimeChangeDetailsEvent.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     TimeChangeDetailsEvent.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/haas/HaasLocationDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/haas/HaasLocationDataRepositoryImpl.java
@@ -2,6 +2,7 @@ package us.dot.its.jpo.ode.api.accessors.haas;
 
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocation;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocationResult;
@@ -20,115 +21,118 @@ import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 
 @Component
 public class HaasLocationDataRepositoryImpl
-                implements HaasLocationDataRepository {
+        implements HaasLocationDataRepository {
 
-        private final MongoTemplate mongoTemplate;
+    private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
-        private final String collectionName = "HaasAlertLocation";
-        private final String DATE_FIELD = "start_time";
-        private final String IS_ACTIVE_FIELD = "is_active";
-        private final String ID_FIELD = "id";
+    private final String collectionName = "HaasAlertLocation";
+    private final String DATE_FIELD = "start_time";
+    private final String IS_ACTIVE_FIELD = "is_active";
+    private final String ID_FIELD = "id";
 
-        @Autowired
-        public HaasLocationDataRepositoryImpl(MongoTemplate mongoTemplate) {
-                this.mongoTemplate = mongoTemplate;
+    @Autowired
+    public HaasLocationDataRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
+        this.mongoTemplate = mongoTemplate;
+        this.props = props;
+    }
+
+    /**
+     * Get a limited list of HAAS locations with the given criteria
+     *
+     * @param activeOnly the active only filter, if true will only return active
+     *                   records
+     * @param startTime  the start time to query by, if null will not be applied
+     * @param endTime    the end time to query by, if null will not be applied
+     * @param limit      the maximum number of records to return
+     * @return the HaasLocationResult containing locations and truncation info
+     */
+    public HaasLocationResult findWithLimit(
+            boolean activeOnly,
+            Long startTime,
+            Long endTime,
+            int limit) {
+        Criteria timeCriteria = new IntersectionCriteria()
+                .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
+
+        // Create base aggregation pipeline
+        List<AggregationOperation> pipeline = buildBasePipeline(timeCriteria, activeOnly);
+
+        // Add limit operation (request one more to check if there are more results)
+        pipeline.add(Aggregation.limit(limit + 1));
+
+        // Execute aggregation
+        Aggregation aggregation = Aggregation.newAggregation(pipeline);
+        AggregationResults<HaasLocation> results = mongoTemplate.aggregate(
+                aggregation, collectionName, HaasLocation.class);
+
+        List<HaasLocation> allResults = results.getMappedResults();
+
+        // Check if there are more results available
+        boolean hasMoreResults = allResults.size() > limit;
+
+        // If we got more results than the limit, trim to the limit
+        List<HaasLocation> finalResults = hasMoreResults ? allResults.subList(0, limit) : allResults;
+
+        return new HaasLocationResult(finalResults, hasMoreResults);
+    }
+
+    /**
+     * Builds the base aggregation pipeline with time filtering and active-only
+     * logic
+     */
+    private List<AggregationOperation> buildBasePipeline(Criteria timeCriteria, boolean activeOnly) {
+        List<AggregationOperation> pipeline = new ArrayList<>();
+
+        // Match documents within time window
+        pipeline.add(Aggregation.match(timeCriteria));
+
+        if (activeOnly) {
+            addActiveOnlyFilter(pipeline, timeCriteria);
         }
 
-        /**
-         * Get a limited list of HAAS locations with the given criteria
-         *
-         * @param activeOnly the active only filter, if true will only return active
-         *                   records
-         * @param startTime  the start time to query by, if null will not be applied
-         * @param endTime    the end time to query by, if null will not be applied
-         * @param limit      the maximum number of records to return
-         * @return the HaasLocationResult containing locations and truncation info
-         */
-        public HaasLocationResult findWithLimit(
-                        boolean activeOnly,
-                        Long startTime,
-                        Long endTime,
-                        int limit) {
-                Criteria timeCriteria = new IntersectionCriteria()
-                                .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
+        // Group by ID and get the latest record for each ID
+        pipeline.add(Aggregation.sort(Sort.Direction.DESC, DATE_FIELD));
+        pipeline.add(Aggregation.group(ID_FIELD).first("$$ROOT").as("latest"));
+        pipeline.add(Aggregation.replaceRoot("latest"));
 
-                // Create base aggregation pipeline
-                List<AggregationOperation> pipeline = buildBasePipeline(timeCriteria, activeOnly);
+        return pipeline;
+    }
 
-                // Add limit operation (request one more to check if there are more results)
-                pipeline.add(Aggregation.limit(limit + 1));
+    /**
+     * Adds filtering logic for active-only records
+     */
+    private void addActiveOnlyFilter(List<AggregationOperation> pipeline, Criteria timeCriteria) {
+        // For activeOnly, exclude IDs that have any inactive records
+        List<Object> inactiveIds = getInactiveIds(timeCriteria);
+        pipeline.add(Aggregation.match(
+                Criteria.where(ID_FIELD).not().in(inactiveIds)));
+        pipeline.add(Aggregation.match(Criteria.where(IS_ACTIVE_FIELD).is(true)));
+    }
 
-                // Execute aggregation
-                Aggregation aggregation = Aggregation.newAggregation(pipeline);
-                AggregationResults<HaasLocation> results = mongoTemplate.aggregate(
-                                aggregation, collectionName, HaasLocation.class);
+    /**
+     * Gets the list of IDs that have inactive records within the time window
+     */
+    private List<Object> getInactiveIds(Criteria timeCriteria) {
+        Aggregation inactiveIdsAggregation = Aggregation.newAggregation(
+                Aggregation.match(new Criteria()
+                        .andOperator(
+                                timeCriteria,
+                                Criteria.where(IS_ACTIVE_FIELD).is(false))),
+                Aggregation.group(ID_FIELD));
 
-                List<HaasLocation> allResults = results.getMappedResults();
+        AggregationResults<Document> inactiveResults = mongoTemplate.aggregate(
+                inactiveIdsAggregation, collectionName, Document.class);
 
-                // Check if there are more results available
-                boolean hasMoreResults = allResults.size() > limit;
+        return inactiveResults.getMappedResults().stream()
+                .map(doc -> doc.get("_id"))
+                .toList();
+    }
 
-                // If we got more results than the limit, trim to the limit
-                List<HaasLocation> finalResults = hasMoreResults ? allResults.subList(0, limit) : allResults;
-
-                return new HaasLocationResult(finalResults, hasMoreResults);
-        }
-
-        /**
-         * Builds the base aggregation pipeline with time filtering and active-only
-         * logic
-         */
-        private List<AggregationOperation> buildBasePipeline(Criteria timeCriteria, boolean activeOnly) {
-                List<AggregationOperation> pipeline = new ArrayList<>();
-
-                // Match documents within time window
-                pipeline.add(Aggregation.match(timeCriteria));
-
-                if (activeOnly) {
-                        addActiveOnlyFilter(pipeline, timeCriteria);
-                }
-
-                // Group by ID and get the latest record for each ID
-                pipeline.add(Aggregation.sort(Sort.Direction.DESC, DATE_FIELD));
-                pipeline.add(Aggregation.group(ID_FIELD).first("$$ROOT").as("latest"));
-                pipeline.add(Aggregation.replaceRoot("latest"));
-
-                return pipeline;
-        }
-
-        /**
-         * Adds filtering logic for active-only records
-         */
-        private void addActiveOnlyFilter(List<AggregationOperation> pipeline, Criteria timeCriteria) {
-                // For activeOnly, exclude IDs that have any inactive records
-                List<Object> inactiveIds = getInactiveIds(timeCriteria);
-                pipeline.add(Aggregation.match(
-                                Criteria.where(ID_FIELD).not().in(inactiveIds)));
-                pipeline.add(Aggregation.match(Criteria.where(IS_ACTIVE_FIELD).is(true)));
-        }
-
-        /**
-         * Gets the list of IDs that have inactive records within the time window
-         */
-        private List<Object> getInactiveIds(Criteria timeCriteria) {
-                Aggregation inactiveIdsAggregation = Aggregation.newAggregation(
-                                Aggregation.match(new Criteria()
-                                                .andOperator(
-                                                                timeCriteria,
-                                                                Criteria.where(IS_ACTIVE_FIELD).is(false))),
-                                Aggregation.group(ID_FIELD));
-
-                AggregationResults<Document> inactiveResults = mongoTemplate.aggregate(
-                                inactiveIdsAggregation, collectionName, Document.class);
-
-                return inactiveResults.getMappedResults().stream()
-                                .map(doc -> doc.get("_id"))
-                                .toList();
-        }
-
-        @Override
-        public void add(HaasLocation item) {
-                mongoTemplate.insert(item, collectionName);
-        }
+    @Override
+    public void add(HaasLocation item) {
+        mongoTemplate.insert(item, collectionName);
+    }
 
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/haas/HaasLocationDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/haas/HaasLocationDataRepositoryImpl.java
@@ -2,7 +2,6 @@ package us.dot.its.jpo.ode.api.accessors.haas;
 
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocation;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocationResult;
@@ -24,7 +23,6 @@ public class HaasLocationDataRepositoryImpl
         implements HaasLocationDataRepository {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "HaasAlertLocation";
     private final String DATE_FIELD = "start_time";
@@ -32,10 +30,8 @@ public class HaasLocationDataRepositoryImpl
     private final String ID_FIELD = "id";
 
     @Autowired
-    public HaasLocationDataRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public HaasLocationDataRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.map;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.model.OdeMapData;
 
@@ -10,5 +9,5 @@ public interface OdeMapDataRepository extends DataLoader<OdeMapData> {
 
     Page<OdeMapData> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<OdeMapData> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<OdeMapData> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
+import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.model.OdeMapData;
@@ -17,14 +19,17 @@ import us.dot.its.jpo.ode.model.OdeMapData;
 public class OdeMapDataRepositoryImpl implements OdeMapDataRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "OdeMapJson";
     private final String DATE_FIELD = "properties.timeStamp";
     private final String INTERSECTION_ID_FIELD = "properties.intersectionId";
 
     @Autowired
-    public OdeMapDataRepositoryImpl(MongoTemplate mongoTemplate) {
+    public OdeMapDataRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -93,9 +98,15 @@ public class OdeMapDataRepositoryImpl implements OdeMapDataRepository, PageableQ
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria,
-                sort,
-                null, OdeMapData.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    OdeMapData.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    OdeMapData.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/OdeMapDataRepositoryImpl.java
@@ -2,15 +2,13 @@ package us.dot.its.jpo.ode.api.accessors.map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
-import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.model.OdeMapData;
@@ -19,17 +17,14 @@ import us.dot.its.jpo.ode.model.OdeMapData;
 public class OdeMapDataRepositoryImpl implements OdeMapDataRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "OdeMapJson";
     private final String DATE_FIELD = "properties.timeStamp";
     private final String INTERSECTION_ID_FIELD = "properties.intersectionId";
 
     @Autowired
-    public OdeMapDataRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public OdeMapDataRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -93,17 +88,17 @@ public class OdeMapDataRepositoryImpl implements OdeMapDataRepository, PageableQ
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     OdeMapData.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     OdeMapData.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepository.java
@@ -3,7 +3,6 @@ package us.dot.its.jpo.ode.api.accessors.map;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
@@ -17,7 +16,7 @@ public interface ProcessedMapRepository extends DataLoader<ProcessedMap<LineStri
     Page<ProcessedMap<LineString>> findLatest(Integer intersectionID, Long startTime, Long endTime, boolean compact);
 
     Page<ProcessedMap<LineString>> find(Integer intersectionID, Long startTime, Long endTime, boolean compact,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 
     List<IntersectionReferenceData> getIntersectionIDs();
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
@@ -32,6 +32,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.api.models.IDCount;
@@ -45,6 +46,7 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "ProcessedMap";
     private final String DATE_FIELD = "properties.timeStamp";
@@ -58,8 +60,10 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, Pagea
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Autowired
-    public ProcessedMapRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ProcessedMapRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -141,8 +145,14 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, Pagea
             excludedFields.add(VALIDATION_MESSAGES_FIELD);
         }
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        Page<Document> hashMap = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                criteria, sort, excludedFields);
+        Page<Document> hashMap;
+        if (pageable != null) {
+            hashMap = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
+                    criteria, sort, excludedFields);
+        } else {
+            hashMap = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
+                    criteria, sort, excludedFields);
+        }
         List<ProcessedMap<LineString>> processedMaps = hashMap.getContent().stream()
                 .map(document -> mapper.convertValue(document, processedMapTypeReference)).toList();
         return new PageImpl<>(processedMaps, pageable, hashMap.getTotalElements());

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
@@ -10,8 +10,10 @@ import org.bson.Document;
 import org.locationtech.jts.geom.CoordinateXY;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -32,7 +34,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.api.models.IDCount;
@@ -46,7 +47,6 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "ProcessedMap";
     private final String DATE_FIELD = "properties.timeStamp";
@@ -60,10 +60,8 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, Pagea
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Autowired
-    public ProcessedMapRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ProcessedMapRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -135,7 +133,7 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, Pagea
             Long startTime,
             Long endTime,
             boolean compact,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
@@ -145,17 +143,16 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository, Pagea
             excludedFields.add(VALIDATION_MESSAGES_FIELD);
         }
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        Page<Document> hashMap;
-        if (pageable != null) {
-            hashMap = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                    criteria, sort, excludedFields);
-        } else {
-            hashMap = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
-                    criteria, sort, excludedFields);
-        }
+
+        Page<Document> hashMap = (pageNumber != null)
+                ? findDocumentsWithPagination(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit),
+                        criteria, sort, excludedFields)
+                : findDocuments(mongoTemplate, collectionName, limit, criteria, sort, excludedFields);
         List<ProcessedMap<LineString>> processedMaps = hashMap.getContent().stream()
                 .map(document -> mapper.convertValue(document, processedMapTypeReference)).toList();
-        return new PageImpl<>(processedMaps, pageable, hashMap.getTotalElements());
+
+        int page = pageNumber != null ? pageNumber : 0;
+        return new PageImpl<>(processedMaps, PageRequest.of(page, limit), hashMap.getTotalElements());
     }
 
     public List<IntersectionReferenceData> getIntersectionIDs() {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.active_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.Notification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -9,7 +8,7 @@ public interface ActiveNotificationRepository extends DataLoader<Notification> {
     long count(Integer intersectionID, String notificationType, String key);
 
     Page<Notification> find(Integer intersectionID, String notificationType, String key,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 
     long delete(String key);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepositoryImpl.java
@@ -1,17 +1,17 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.active_notification;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.bson.Document;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -40,7 +40,6 @@ public class ActiveNotificationRepositoryImpl
         implements ActiveNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmNotification";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
@@ -48,10 +47,8 @@ public class ActiveNotificationRepositoryImpl
     private final String KEY_FIELD = "key";
 
     @Autowired
-    public ActiveNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ActiveNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -113,20 +110,17 @@ public class ActiveNotificationRepositoryImpl
             Integer intersectionID,
             String notificationType,
             String key,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .whereOptional(NOTIFICATION_TYPE_FIELD, notificationType)
                 .whereOptional(KEY_FIELD, key);
         Sort sort = Sort.by(Sort.Direction.DESC, NOTIFICATION_TYPE_FIELD);
-        Page<Document> dbObjects;
-        if (pageable != null) {
-            dbObjects = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                    criteria, sort, Collections.emptyList());
-        } else {
-            dbObjects = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
-                    criteria, sort, Collections.emptyList());
-        }
+
+        Page<Document> dbObjects = (pageNumber != null)
+                ? findDocumentsWithPagination(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit),
+                        criteria, sort, null)
+                : findDocuments(mongoTemplate, collectionName, limit, criteria, sort, null);
 
         List<Notification> notifications = new ArrayList<>();
         for (Document dbObject : dbObjects.getContent()) {
@@ -169,7 +163,8 @@ public class ActiveNotificationRepositoryImpl
                     log.warn("Attempted to find unknown notificationType: {}", type);
             }
         }
-        return new PageImpl<>(notifications, pageable, dbObjects.getTotalElements());
+        int page = pageNumber != null ? pageNumber : 0;
+        return new PageImpl<>(notifications, PageRequest.of(page, limit), dbObjects.getTotalElements());
     }
 
     public long delete(String key) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/active_notification/ActiveNotificationRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -39,6 +40,7 @@ public class ActiveNotificationRepositoryImpl
         implements ActiveNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmNotification";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
@@ -46,8 +48,10 @@ public class ActiveNotificationRepositoryImpl
     private final String KEY_FIELD = "key";
 
     @Autowired
-    public ActiveNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ActiveNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -115,8 +119,14 @@ public class ActiveNotificationRepositoryImpl
                 .whereOptional(NOTIFICATION_TYPE_FIELD, notificationType)
                 .whereOptional(KEY_FIELD, key);
         Sort sort = Sort.by(Sort.Direction.DESC, NOTIFICATION_TYPE_FIELD);
-        Page<Document> dbObjects = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
-                criteria, sort, Collections.emptyList());
+        Page<Document> dbObjects;
+        if (pageable != null) {
+            dbObjects = findDocumentsWithPagination(mongoTemplate, collectionName, pageable,
+                    criteria, sort, Collections.emptyList());
+        } else {
+            dbObjects = findDocuments(mongoTemplate, collectionName, props.getMaximumResponseSize(),
+                    criteria, sort, Collections.emptyList());
+        }
 
         List<Notification> notifications = new ArrayList<>();
         for (Document dbObject : dbObjects.getContent()) {
@@ -124,29 +134,36 @@ public class ActiveNotificationRepositoryImpl
             switch (type) {
                 case "ConnectionOfTravelNotification" ->
                     notifications
-                            .add(mongoTemplate.getConverter().read(ConnectionOfTravelNotification.class,
+                            .add(mongoTemplate.getConverter().read(
+                                    ConnectionOfTravelNotification.class,
                                     dbObject));
                 case "IntersectionReferenceAlignmentNotification" -> notifications.add(
-                        mongoTemplate.getConverter().read(IntersectionReferenceAlignmentNotification.class,
+                        mongoTemplate.getConverter().read(
+                                IntersectionReferenceAlignmentNotification.class,
                                 dbObject));
                 case "LaneDirectionOfTravelAssessmentNotification" ->
                     notifications
-                            .add(mongoTemplate.getConverter().read(LaneDirectionOfTravelNotification.class,
+                            .add(mongoTemplate.getConverter().read(
+                                    LaneDirectionOfTravelNotification.class,
                                     dbObject));
                 case "SignalGroupAlignmentNotification" ->
                     notifications
-                            .add(mongoTemplate.getConverter().read(SignalGroupAlignmentNotification.class,
+                            .add(mongoTemplate.getConverter().read(
+                                    SignalGroupAlignmentNotification.class,
                                     dbObject));
                 case "SignalStateConflictNotification" ->
                     notifications
-                            .add(mongoTemplate.getConverter().read(SignalStateConflictNotification.class,
+                            .add(mongoTemplate.getConverter().read(
+                                    SignalStateConflictNotification.class,
                                     dbObject));
                 case "TimeChangeDetailsNotification" ->
-                    notifications.add(mongoTemplate.getConverter().read(TimeChangeDetailsNotification.class,
+                    notifications.add(mongoTemplate.getConverter().read(
+                            TimeChangeDetailsNotification.class,
                             dbObject));
                 case "AppHealthNotification" ->
                     notifications
-                            .add(mongoTemplate.getConverter().read(KafkaStreamsAnomalyNotification.class,
+                            .add(mongoTemplate.getConverter().read(
+                                    KafkaStreamsAnomalyNotification.class,
                                     dbObject));
                 default ->
                     log.warn("Attempted to find unknown notificationType: {}", type);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.connection_of_travel_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.ConnectionOfTravelNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -11,5 +10,6 @@ public interface ConnectionOfTravelNotificationRepository extends DataLoader<Con
 
     Page<ConnectionOfTravelNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<ConnectionOfTravelNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<ConnectionOfTravelNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepositoryImpl.java
@@ -2,15 +2,14 @@ package us.dot.its.jpo.ode.api.accessors.notifications.connection_of_travel_noti
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.ConnectionOfTravelNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -19,17 +18,14 @@ public class ConnectionOfTravelNotificationRepositoryImpl
         implements ConnectionOfTravelNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ConnectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -93,17 +89,17 @@ public class ConnectionOfTravelNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     ConnectionOfTravelNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     ConnectionOfTravelNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/connection_of_travel_notification/ConnectionOfTravelNotificationRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.ConnectionOfTravelNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -18,14 +19,17 @@ public class ConnectionOfTravelNotificationRepositoryImpl
         implements ConnectionOfTravelNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmConnectionOfTravelNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public ConnectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ConnectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -94,8 +98,15 @@ public class ConnectionOfTravelNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                ConnectionOfTravelNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    ConnectionOfTravelNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    ConnectionOfTravelNotification.class);
+        }
     }
 
     public void add(ConnectionOfTravelNotification item) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.intersection_reference_alignment_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.IntersectionReferenceAlignmentNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -12,5 +11,5 @@ public interface IntersectionReferenceAlignmentNotificationRepository
     Page<IntersectionReferenceAlignmentNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<IntersectionReferenceAlignmentNotification> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +20,17 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImpl
         implements IntersectionReferenceAlignmentNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmIntersectionReferenceAlignmentNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public IntersectionReferenceAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public IntersectionReferenceAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,8 +99,15 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                IntersectionReferenceAlignmentNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    IntersectionReferenceAlignmentNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    IntersectionReferenceAlignmentNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/intersection_reference_alignment_notification/IntersectionReferenceAlignmentNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.intersection_reference_alignment_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +19,14 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImpl
         implements IntersectionReferenceAlignmentNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmIntersectionReferenceAlignmentNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public IntersectionReferenceAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public IntersectionReferenceAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -94,17 +90,17 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     IntersectionReferenceAlignmentNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     IntersectionReferenceAlignmentNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.lane_direction_of_travel_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.LaneDirectionOfTravelNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -11,5 +10,5 @@ public interface LaneDirectionOfTravelNotificationRepository extends DataLoader<
     Page<LaneDirectionOfTravelNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<LaneDirectionOfTravelNotification> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +20,17 @@ public class LaneDirectionOfTravelNotificationRepositoryImpl
         implements LaneDirectionOfTravelNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public LaneDirectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public LaneDirectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,8 +99,15 @@ public class LaneDirectionOfTravelNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                LaneDirectionOfTravelNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    LaneDirectionOfTravelNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    LaneDirectionOfTravelNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/lane_direction_of_travel_notification/LaneDirectionOfTravelNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.lane_direction_of_travel_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +19,14 @@ public class LaneDirectionOfTravelNotificationRepositoryImpl
         implements LaneDirectionOfTravelNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmLaneDirectionOfTravelNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public LaneDirectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public LaneDirectionOfTravelNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -94,17 +90,17 @@ public class LaneDirectionOfTravelNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     LaneDirectionOfTravelNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     LaneDirectionOfTravelNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.map_broadcast_rate_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.MapBroadcastRateNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -10,5 +9,6 @@ public interface MapBroadcastRateNotificationRepository extends DataLoader<MapBr
 
     Page<MapBroadcastRateNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<MapBroadcastRateNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<MapBroadcastRateNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class MapBroadcastRateNotificationRepositoryImpl
         implements MapBroadcastRateNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapBroadcastRateNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public MapBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class MapBroadcastRateNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                MapBroadcastRateNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    MapBroadcastRateNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    MapBroadcastRateNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/map_broadcast_rate_notification/MapBroadcastRateNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.map_broadcast_rate_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class MapBroadcastRateNotificationRepositoryImpl
         implements MapBroadcastRateNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmMapBroadcastRateNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public MapBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public MapBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class MapBroadcastRateNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     MapBroadcastRateNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     MapBroadcastRateNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.signal_group_alignment_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAlignmentNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -11,5 +10,5 @@ public interface SignalGroupAlignmentNotificationRepository extends DataLoader<S
     Page<SignalGroupAlignmentNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
     Page<SignalGroupAlignmentNotification> find(Integer intersectionID, Long startTime, Long endTime,
-            Pageable pageable);
+            Integer pageNumber, int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.signal_group_alignment_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,17 +19,14 @@ public class SignalGroupAlignmentNotificationRepositoryImpl
         implements SignalGroupAlignmentNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalGroupAlignmentNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalGroupAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SignalGroupAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -94,17 +90,17 @@ public class SignalGroupAlignmentNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SignalGroupAlignmentNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SignalGroupAlignmentNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_group_alignment_notification/SignalGroupAlignmentNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -19,14 +20,17 @@ public class SignalGroupAlignmentNotificationRepositoryImpl
         implements SignalGroupAlignmentNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalGroupAlignmentNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalGroupAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SignalGroupAlignmentNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,8 +99,15 @@ public class SignalGroupAlignmentNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                SignalGroupAlignmentNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SignalGroupAlignmentNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SignalGroupAlignmentNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.signal_state_conflict_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -10,5 +9,6 @@ public interface SignalStateConflictNotificationRepository extends DataLoader<Si
 
     Page<SignalStateConflictNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SignalStateConflictNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SignalStateConflictNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.signal_state_conflict_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class SignalStateConflictNotificationRepositoryImpl
         implements SignalStateConflictNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalStateConflictNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalStateConflictNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SignalStateConflictNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class SignalStateConflictNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SignalStateConflictNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SignalStateConflictNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/signal_state_conflict_notification/SignalStateConflictNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class SignalStateConflictNotificationRepositoryImpl
         implements SignalStateConflictNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSignalStateConflictNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SignalStateConflictNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SignalStateConflictNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class SignalStateConflictNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                SignalStateConflictNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SignalStateConflictNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SignalStateConflictNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.spat_broadcast_rate_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.SpatBroadcastRateNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
@@ -11,5 +10,6 @@ public interface SpatBroadcastRateNotificationRepository extends DataLoader<Spat
 
     Page<SpatBroadcastRateNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<SpatBroadcastRateNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<SpatBroadcastRateNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.spat_broadcast_rate_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -21,17 +20,14 @@ public class SpatBroadcastRateNotificationRepositoryImpl
         implements SpatBroadcastRateNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatBroadcastRateNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public SpatBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -95,17 +91,17 @@ public class SpatBroadcastRateNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     SpatBroadcastRateNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     SpatBroadcastRateNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/spat_broadcast_rate_notification/SpatBroadcastRateNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,14 +21,17 @@ public class SpatBroadcastRateNotificationRepositoryImpl
         implements SpatBroadcastRateNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmSpatBroadcastRateNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public SpatBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public SpatBroadcastRateNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -96,8 +100,15 @@ public class SpatBroadcastRateNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                SpatBroadcastRateNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    SpatBroadcastRateNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    SpatBroadcastRateNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.stop_line_passage_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLinePassageNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -10,5 +9,6 @@ public interface StopLinePassageNotificationRepository extends DataLoader<StopLi
 
     Page<StopLinePassageNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLinePassageNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLinePassageNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,14 +19,17 @@ public class StopLinePassageNotificationRepositoryImpl
         implements StopLinePassageNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLinePassageNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLinePassageNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -94,8 +98,15 @@ public class StopLinePassageNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                StopLinePassageNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLinePassageNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLinePassageNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_passage_notification/StopLinePassageNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.stop_line_passage_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,17 +18,14 @@ public class StopLinePassageNotificationRepositoryImpl
         implements StopLinePassageNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLinePassageNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLinePassageNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLinePassageNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -93,17 +89,17 @@ public class StopLinePassageNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLinePassageNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLinePassageNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.stop_line_stop_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLineStopNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -10,5 +9,6 @@ public interface StopLineStopNotificationRepository extends DataLoader<StopLineS
 
     Page<StopLineStopNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<StopLineStopNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<StopLineStopNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.stop_line_stop_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +19,14 @@ public class StopLineStopNotificationRepositoryImpl
         implements StopLineStopNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLineStopNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public StopLineStopNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -94,17 +90,17 @@ public class StopLineStopNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     StopLineStopNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     StopLineStopNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/stop_line_stop_notification/StopLineStopNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +20,17 @@ public class StopLineStopNotificationRepositoryImpl
         implements StopLineStopNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmStopLineStopNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public StopLineStopNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public StopLineStopNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,7 +99,15 @@ public class StopLineStopNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null, StopLineStopNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    StopLineStopNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    StopLineStopNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.time_change_details_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
@@ -10,5 +9,6 @@ public interface TimeChangeDetailsNotificationRepository extends DataLoader<Time
 
     Page<TimeChangeDetailsNotification> findLatest(Integer intersectionID, Long startTime, Long endTime);
 
-    Page<TimeChangeDetailsNotification> find(Integer intersectionID, Long startTime, Long endTime, Pageable pageable);
+    Page<TimeChangeDetailsNotification> find(Integer intersectionID, Long startTime, Long endTime, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +20,17 @@ public class TimeChangeDetailsNotificationRepositoryImpl
         implements TimeChangeDetailsNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmTimeChangeDetailsNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public TimeChangeDetailsNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
+    public TimeChangeDetailsNotificationRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -95,8 +99,15 @@ public class TimeChangeDetailsNotificationRepositoryImpl
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, null,
-                TimeChangeDetailsNotification.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    null,
+                    TimeChangeDetailsNotification.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, null,
+                    TimeChangeDetailsNotification.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/notifications/time_change_details_notification/TimeChangeDetailsNotificationRepositoryImpl.java
@@ -1,10 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.notifications.time_change_details_notification;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +19,14 @@ public class TimeChangeDetailsNotificationRepositoryImpl
         implements TimeChangeDetailsNotificationRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmTimeChangeDetailsNotification";
     private final String DATE_FIELD = "notificationGeneratedAt";
     private final String INTERSECTION_ID_FIELD = "intersectionID";
 
     @Autowired
-    public TimeChangeDetailsNotificationRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public TimeChangeDetailsNotificationRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -94,17 +90,17 @@ public class TimeChangeDetailsNotificationRepositoryImpl
             Integer intersectionID,
             Long startTime,
             Long endTime,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, false);
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     null,
                     TimeChangeDetailsNotification.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, null,
                     TimeChangeDetailsNotification.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepository.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.ode.api.accessors.reports;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.api.models.ReportDocument;
 
@@ -12,6 +11,6 @@ public interface ReportRepository extends DataLoader<ReportDocument> {
             boolean includeReportContents);
 
     Page<ReportDocument> find(String reportName, Integer intersectionID, Long startTime, Long endTime,
-            boolean includeReportContents, Pageable pageable);
+            boolean includeReportContents, Integer pageNumber, int limit);
 
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepositoryImpl.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,7 @@ public class ReportRepositoryImpl
         implements ReportRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmReport";
     private final String DATE_FIELD = "reportGeneratedAt";
@@ -29,8 +32,10 @@ public class ReportRepositoryImpl
     private final String REPORT_NAME_FIELD = "reportName";
 
     @Autowired
-    public ReportRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ReportRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     private Criteria applyDateCriteria(Criteria criteria, Long startDate, Long endDate) {
@@ -122,7 +127,15 @@ public class ReportRepositoryImpl
         if (!includeReportContents) {
             excludedFields.add("reportContents");
         }
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, excludedFields, ReportDocument.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    excludedFields,
+                    ReportDocument.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, excludedFields,
+                    ReportDocument.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/reports/ReportRepositoryImpl.java
@@ -4,11 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +23,6 @@ public class ReportRepositoryImpl
         implements ReportRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "CmReport";
     private final String DATE_FIELD = "reportGeneratedAt";
@@ -32,10 +30,8 @@ public class ReportRepositoryImpl
     private final String REPORT_NAME_FIELD = "reportName";
 
     @Autowired
-    public ReportRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ReportRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     private Criteria applyDateCriteria(Criteria criteria, Long startDate, Long endDate) {
@@ -117,7 +113,7 @@ public class ReportRepositoryImpl
             Long startTime,
             Long endTime,
             boolean includeReportContents,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(REPORT_NAME_FIELD, reportName)
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID);
@@ -127,12 +123,12 @@ public class ReportRepositoryImpl
         if (!includeReportContents) {
             excludedFields.add("reportContents");
         }
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     excludedFields,
                     ReportDocument.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, excludedFields,
                     ReportDocument.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/OdeSpatDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/OdeSpatDataRepositoryImpl.java
@@ -3,6 +3,7 @@ package us.dot.its.jpo.ode.api.accessors.spat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -19,14 +20,17 @@ public class OdeSpatDataRepositoryImpl
         implements OdeSpatDataRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "OdeSpatJson";
     private final String DATE_FIELD = "properties.timeStamp";
     private final String INTERSECTION_ID_FIELD = "properties.intersectionId";
 
     @Autowired
-    public OdeSpatDataRepositoryImpl(MongoTemplate mongoTemplate) {
+    public OdeSpatDataRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/OdeSpatDataRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/OdeSpatDataRepositoryImpl.java
@@ -1,9 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.spat;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 
@@ -20,17 +20,14 @@ public class OdeSpatDataRepositoryImpl
         implements OdeSpatDataRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "OdeSpatJson";
     private final String DATE_FIELD = "properties.timeStamp";
     private final String INTERSECTION_ID_FIELD = "properties.intersectionId";
 
     @Autowired
-    public OdeSpatDataRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public OdeSpatDataRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepository.java
@@ -4,12 +4,12 @@ import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 import us.dot.its.jpo.ode.api.models.DataLoader;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface ProcessedSpatRepository extends DataLoader<ProcessedSpat> {
     long count(Integer intersectionID, Long startTime, Long endTime);
 
     Page<ProcessedSpat> findLatest(Integer intersectionID, Long startTime, Long endTime, boolean compact);
 
-    Page<ProcessedSpat> find(Integer intersectionID, Long startTime, Long endTime, boolean compact, Pageable pageable);
+    Page<ProcessedSpat> find(Integer intersectionID, Long startTime, Long endTime, boolean compact, Integer pageNumber,
+            int limit);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepositoryImpl.java
@@ -4,10 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
 import us.dot.its.jpo.ode.api.models.ReportDocument;
@@ -23,7 +22,6 @@ import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
-    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "ProcessedSpat";
     private final String DATE_FIELD = "utcTimeStamp";
@@ -31,10 +29,8 @@ public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, Pag
     private final String RECORD_GENERATED_AT_FIELD = "recordGeneratedAt";
     private final String VALIDATION_MESSAGES_FIELD = "properties.validationMessages";
 
-    public ProcessedSpatRepositoryImpl(MongoTemplate mongoTemplate,
-            ConflictMonitorApiProperties props) {
+    public ProcessedSpatRepositoryImpl(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
-        this.props = props;
     }
 
     /**
@@ -105,7 +101,7 @@ public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, Pag
             Long startTime,
             Long endTime,
             boolean compact,
-            Pageable pageable) {
+            Integer pageNumber, int limit) {
         Criteria criteria = new IntersectionCriteria()
                 .whereOptional(INTERSECTION_ID_FIELD, intersectionID)
                 .withinTimeWindow(DATE_FIELD, startTime, endTime, true);
@@ -115,12 +111,12 @@ public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, Pag
             excludedFields.add(VALIDATION_MESSAGES_FIELD);
         }
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        if (pageable != null) {
-            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+        if (pageNumber != null) {
+            return findPage(mongoTemplate, collectionName, PageRequest.of(pageNumber, limit), criteria, sort,
                     excludedFields,
                     ProcessedSpat.class);
         } else {
-            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+            return findGeneric(mongoTemplate, collectionName, limit, criteria,
                     sort, excludedFields,
                     ProcessedSpat.class);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/spat/ProcessedSpatRepositoryImpl.java
@@ -7,8 +7,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.IntersectionCriteria;
 import us.dot.its.jpo.ode.api.accessors.PageableQuery;
+import us.dot.its.jpo.ode.api.models.ReportDocument;
+
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -20,6 +23,7 @@ import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, PageableQuery {
 
     private final MongoTemplate mongoTemplate;
+    private final ConflictMonitorApiProperties props;
 
     private final String collectionName = "ProcessedSpat";
     private final String DATE_FIELD = "utcTimeStamp";
@@ -27,8 +31,10 @@ public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, Pag
     private final String RECORD_GENERATED_AT_FIELD = "recordGeneratedAt";
     private final String VALIDATION_MESSAGES_FIELD = "properties.validationMessages";
 
-    public ProcessedSpatRepositoryImpl(MongoTemplate mongoTemplate) {
+    public ProcessedSpatRepositoryImpl(MongoTemplate mongoTemplate,
+            ConflictMonitorApiProperties props) {
         this.mongoTemplate = mongoTemplate;
+        this.props = props;
     }
 
     /**
@@ -109,7 +115,15 @@ public class ProcessedSpatRepositoryImpl implements ProcessedSpatRepository, Pag
             excludedFields.add(VALIDATION_MESSAGES_FIELD);
         }
         Sort sort = Sort.by(Sort.Direction.DESC, DATE_FIELD);
-        return findPage(mongoTemplate, collectionName, pageable, criteria, sort, List.of(), ProcessedSpat.class);
+        if (pageable != null) {
+            return findPage(mongoTemplate, collectionName, pageable, criteria, sort,
+                    excludedFields,
+                    ProcessedSpat.class);
+        } else {
+            return findGeneric(mongoTemplate, collectionName, props.getMaximumResponseSize(), criteria,
+                    sort, excludedFields,
+                    ProcessedSpat.class);
+        }
     }
 
     @Override

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
@@ -71,7 +71,7 @@ public class ReportsController {
             @RequestParam(name = "intersection_id") int intersectionID,
             @RequestParam(name = "start_time_utc_millis") long startTime,
             @RequestParam(name = "end_time_utc_millis") long endTime,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "latest") boolean latest) {
 
@@ -79,7 +79,7 @@ public class ReportsController {
             return ResponseEntity.ok(reportRepo.findLatest(reportName, intersectionID, startTime, endTime, false));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ReportDocument> response = reportRepo.find(reportName, intersectionID, startTime, endTime,
                     false, pageable);
             return ResponseEntity.ok(response);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.ode.api.accessors.reports.ReportRepository;
@@ -71,7 +72,7 @@ public class ReportsController {
             @RequestParam(name = "intersection_id") int intersectionID,
             @RequestParam(name = "start_time_utc_millis") long startTime,
             @RequestParam(name = "end_time_utc_millis") long endTime,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "latest") boolean latest) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/ReportsController.java
@@ -72,16 +72,15 @@ public class ReportsController {
             @RequestParam(name = "start_time_utc_millis") long startTime,
             @RequestParam(name = "end_time_utc_millis") long endTime,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "latest") boolean latest) {
 
         if (latest) {
             return ResponseEntity.ok(reportRepo.findLatest(reportName, intersectionID, startTime, endTime, false));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ReportDocument> response = reportRepo.find(reportName, intersectionID, startTime, endTime,
-                    false, pageable);
+                    false, page, size);
             return ResponseEntity.ok(response);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
@@ -56,7 +56,7 @@ public class BsmController {
             @RequestParam(name = "longitude", required = false) Double longitude,
             @RequestParam(name = "distance", required = false) Double distanceInMeters,
             @Parameter(description = "Page number (0-based). If not set, no paging will be applied and all matching results will be returned (up to the 'size' limit).") @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -64,9 +64,8 @@ public class BsmController {
             return ResponseEntity
                     .ok(new PageImpl<>(list, PageRequest.of(page != null ? page : 0, size), list.size()));
         } else {
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<OdeBsmData> response = odeBsmJsonRepo.find(originIp, vehicleId, startTime, endTime,
-                    longitude, latitude, distanceInMeters, pageable);
+                    longitude, latitude, distanceInMeters, page, size);
             return ResponseEntity.ok(response);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepository;
@@ -54,16 +55,16 @@ public class BsmController {
             @RequestParam(name = "latitude", required = false) Double latitude,
             @RequestParam(name = "longitude", required = false) Double longitude,
             @RequestParam(name = "distance", required = false) Double distanceInMeters,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied and all matching results will be returned (up to the 'size' limit).") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
             List<OdeBsmData> list = MockBsmGenerator.getJsonBsms();
             return ResponseEntity
-                    .ok(new PageImpl<>(list, PageRequest.of(page, size), list.size()));
+                    .ok(new PageImpl<>(list, PageRequest.of(page != null ? page : 0, size), list.size()));
         } else {
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<OdeBsmData> response = odeBsmJsonRepo.find(originIp, vehicleId, startTime, endTime,
                     longitude, latitude, distanceInMeters, pageable);
             return ResponseEntity.ok(response);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/BsmController.java
@@ -55,7 +55,7 @@ public class BsmController {
             @RequestParam(name = "latitude", required = false) Double latitude,
             @RequestParam(name = "longitude", required = false) Double longitude,
             @RequestParam(name = "distance", required = false) Double distanceInMeters,
-            @Parameter(description = "Page number (0-based). If not set, no paging will be applied and all matching results will be returned (up to the 'size' limit).") @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
@@ -68,7 +68,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -83,7 +83,7 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelAssessment> response = connectionOfTravelAssessmentRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -124,7 +124,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -139,7 +139,7 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelAssessment> response = laneDirectionOfTravelAssessmentRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -182,7 +182,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -197,7 +197,7 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopAssessment> response = stopLineStopAssessmentRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -239,7 +239,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -254,7 +254,7 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageAssessment> response = stopLinePassageAssessmentRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
@@ -68,7 +69,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -123,7 +124,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -180,7 +181,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -236,7 +237,7 @@ public class CmAssessmentController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentController.java
@@ -69,7 +69,7 @@ public class CmAssessmentController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -83,9 +83,8 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelAssessment> response = connectionOfTravelAssessmentRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -125,7 +124,7 @@ public class CmAssessmentController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -139,9 +138,8 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelAssessment> response = laneDirectionOfTravelAssessmentRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
 
@@ -183,7 +181,7 @@ public class CmAssessmentController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -197,9 +195,8 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopAssessment> response = stopLineStopAssessmentRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -240,7 +237,7 @@ public class CmAssessmentController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -254,9 +251,8 @@ public class CmAssessmentController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageAssessment> response = stopLinePassageAssessmentRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
@@ -144,7 +144,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
 
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -158,7 +158,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<IntersectionReferenceAlignmentEvent> response = intersectionReferenceAlignmentEventRepo
                     .find(intersectionID, startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -199,7 +199,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -213,7 +213,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelEvent> response = connectionOfTravelEventRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -276,7 +276,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -290,7 +290,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelEvent> response = laneDirectionOfTravelEventRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -353,7 +353,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -367,7 +367,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalGroupAlignmentEvent> response = signalGroupAlignmentEventRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -430,7 +430,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -444,7 +444,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalStateConflictEvent> response = signalStateConflictEventRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -507,7 +507,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -521,7 +521,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageEvent> response = stopLinePassageEventRepo.find(intersectionID, startTime, endTime,
                     pageable);
             return ResponseEntity.ok(response);
@@ -586,7 +586,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -600,7 +600,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopEvent> response = stopLineStopEventRepo.find(intersectionID, startTime, endTime,
                     pageable);
             return ResponseEntity.ok(response);
@@ -664,7 +664,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -678,7 +678,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<TimeChangeDetailsEvent> response = timeChangeDetailsEventRepo.find(intersectionID, startTime, endTime,
                     pageable);
             return ResponseEntity.ok(response);
@@ -741,7 +741,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -755,7 +755,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatMinimumDataEvent> response = spatMinimumDataEventRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -796,7 +796,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -810,7 +810,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapMinimumDataEvent> response = mapMinimumDataEventRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -851,7 +851,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -865,7 +865,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapBroadcastRateEvent> response = mapBroadcastRateEventRepo.find(intersectionID, startTime, endTime,
                     pageable);
             return ResponseEntity.ok(response);
@@ -906,7 +906,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -920,7 +920,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatBroadcastRateEvent> response = spatBroadcastRateEventRepo.find(intersectionID, startTime, endTime,
                     pageable);
             return ResponseEntity.ok(response);
@@ -961,7 +961,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -975,7 +975,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatMessageCountProgressionEvent> response = spatMessageCountProgressionEventRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -1016,7 +1016,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1030,7 +1030,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapMessageCountProgressionEvent> response = mapMessageCountProgressionEventRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -1071,7 +1071,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1085,7 +1085,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<BsmMessageCountProgressionEvent> response = bsmMessageCountProgressionEventRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -1126,7 +1126,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1140,7 +1140,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<BsmEvent> response = bsmEventRepo.find(intersectionID, startTime, endTime, pageable);
             return ResponseEntity.ok(response);
         }
@@ -1180,7 +1180,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -1205,7 +1205,7 @@ public class CmEventController {
             pagedEvents = bsmEventRepo.findLatest(intersectionID, startTime, endTime);
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             pagedEvents = bsmEventRepo.find(intersectionID, startTime, endTime, pageable);
         }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
@@ -145,7 +145,7 @@ public class CmEventController {
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
 
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<IntersectionReferenceAlignmentEvent> list = new ArrayList<>();
@@ -158,9 +158,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<IntersectionReferenceAlignmentEvent> response = intersectionReferenceAlignmentEventRepo
-                    .find(intersectionID, startTime, endTime, pageable);
+                    .find(intersectionID, startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -200,7 +199,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<ConnectionOfTravelEvent> list = new ArrayList<>();
@@ -213,9 +212,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelEvent> response = connectionOfTravelEventRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -277,7 +275,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<LaneDirectionOfTravelEvent> list = new ArrayList<>();
@@ -290,9 +288,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelEvent> response = laneDirectionOfTravelEventRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -354,7 +351,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SignalGroupAlignmentEvent> list = new ArrayList<>();
@@ -367,9 +364,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalGroupAlignmentEvent> response = signalGroupAlignmentEventRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -431,7 +427,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SignalStateConflictEvent> list = new ArrayList<>();
@@ -444,9 +440,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalStateConflictEvent> response = signalStateConflictEventRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -508,7 +503,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<StopLinePassageEvent> list = new ArrayList<>();
@@ -521,9 +516,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageEvent> response = stopLinePassageEventRepo.find(intersectionID, startTime, endTime,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -587,7 +581,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<StopLineStopEvent> list = new ArrayList<>();
@@ -600,9 +594,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopEvent> response = stopLineStopEventRepo.find(intersectionID, startTime, endTime,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -665,7 +658,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<TimeChangeDetailsEvent> list = new ArrayList<>();
@@ -678,9 +671,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<TimeChangeDetailsEvent> response = timeChangeDetailsEventRepo.find(intersectionID, startTime, endTime,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -742,7 +734,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -755,9 +747,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatMinimumDataEvent> response = spatMinimumDataEventRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -797,7 +788,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -810,9 +801,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapMinimumDataEvent> response = mapMinimumDataEventRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -852,7 +842,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<MapBroadcastRateEvent> list = new ArrayList<>();
@@ -865,9 +855,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapBroadcastRateEvent> response = mapBroadcastRateEventRepo.find(intersectionID, startTime, endTime,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -907,7 +896,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SpatBroadcastRateEvent> list = new ArrayList<>();
@@ -920,9 +909,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatBroadcastRateEvent> response = spatBroadcastRateEventRepo.find(intersectionID, startTime, endTime,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -962,7 +950,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SpatMessageCountProgressionEvent> list = new ArrayList<>();
@@ -975,9 +963,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatMessageCountProgressionEvent> response = spatMessageCountProgressionEventRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -1017,7 +1004,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<MapMessageCountProgressionEvent> list = new ArrayList<>();
@@ -1030,9 +1017,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapMessageCountProgressionEvent> response = mapMessageCountProgressionEventRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -1072,7 +1058,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<BsmMessageCountProgressionEvent> list = new ArrayList<>();
@@ -1085,9 +1071,8 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<BsmMessageCountProgressionEvent> response = bsmMessageCountProgressionEventRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -1127,7 +1112,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<BsmEvent> list = new ArrayList<>();
@@ -1140,8 +1125,7 @@ public class CmEventController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
-            Page<BsmEvent> response = bsmEventRepo.find(intersectionID, startTime, endTime, pageable);
+            Page<BsmEvent> response = bsmEventRepo.find(intersectionID, startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -1181,7 +1165,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -1205,8 +1189,7 @@ public class CmEventController {
             pagedEvents = bsmEventRepo.findLatest(intersectionID, startTime, endTime);
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
-            pagedEvents = bsmEventRepo.find(intersectionID, startTime, endTime, pageable);
+            pagedEvents = bsmEventRepo.find(intersectionID, startTime, endTime, page, size);
         }
 
         List<BsmEvent> events = pagedEvents.getContent();

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmEventController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
@@ -144,7 +145,7 @@ public class CmEventController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
 
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -198,7 +199,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -274,7 +275,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -350,7 +351,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -426,7 +427,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -502,7 +503,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -580,7 +581,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -657,7 +658,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -733,7 +734,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -787,7 +788,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -841,7 +842,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -895,7 +896,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -949,7 +950,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1003,7 +1004,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1057,7 +1058,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1111,7 +1112,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -1164,7 +1165,7 @@ public class CmEventController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
@@ -103,7 +103,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             // Mock response for test data
@@ -115,9 +115,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelNotification> response = connectionOfTravelNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -157,7 +156,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<IntersectionReferenceAlignmentNotification> list = new ArrayList<>();
@@ -170,9 +169,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<IntersectionReferenceAlignmentNotification> response = intersectionReferenceAlignmentNotificationRepo
-                    .find(intersectionID, startTime, endTime, pageable);
+                    .find(intersectionID, startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -212,7 +210,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<LaneDirectionOfTravelNotification> list = new ArrayList<>();
@@ -225,9 +223,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelNotification> response = laneDirectionOfTravelNotificationRepo
-                    .find(intersectionID, startTime, endTime, pageable);
+                    .find(intersectionID, startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -267,7 +264,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<MapBroadcastRateNotification> list = new ArrayList<>();
@@ -280,9 +277,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapBroadcastRateNotification> response = mapBroadcastRateNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -322,7 +318,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SignalGroupAlignmentNotification> list = new ArrayList<>();
@@ -335,9 +331,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalGroupAlignmentNotification> response = signalGroupAlignmentNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -377,7 +372,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SignalStateConflictNotification> list = new ArrayList<>();
@@ -390,9 +385,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalStateConflictNotification> response = signalStateConflictNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -432,7 +426,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<SpatBroadcastRateNotification> list = new ArrayList<>();
@@ -445,9 +439,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatBroadcastRateNotification> response = spatBroadcastRateNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -487,7 +480,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<StopLineStopNotification> list = new ArrayList<>();
@@ -500,9 +493,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopNotification> response = stopLineStopNotificationRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -542,7 +534,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<StopLinePassageNotification> list = new ArrayList<>();
@@ -555,9 +547,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageNotification> response = stopLinePassageNotificationRepo.find(intersectionID, startTime,
-                    endTime, pageable);
+                    endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }
@@ -597,7 +588,7 @@ public class CmNotificationController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<TimeChangeDetailsNotification> list = new ArrayList<>();
@@ -610,9 +601,8 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<TimeChangeDetailsNotification> response = timeChangeDetailsNotificationRepo.find(intersectionID,
-                    startTime, endTime, pageable);
+                    startTime, endTime, page, size);
             return ResponseEntity.ok(response);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -102,7 +103,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -155,7 +156,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -209,7 +210,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -263,7 +264,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -317,7 +318,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -371,7 +372,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -425,7 +426,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -479,7 +480,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -533,7 +534,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -587,7 +588,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationController.java
@@ -102,7 +102,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -115,7 +115,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ConnectionOfTravelNotification> response = connectionOfTravelNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -156,7 +156,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -170,7 +170,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<IntersectionReferenceAlignmentNotification> response = intersectionReferenceAlignmentNotificationRepo
                     .find(intersectionID, startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -211,7 +211,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -225,7 +225,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<LaneDirectionOfTravelNotification> response = laneDirectionOfTravelNotificationRepo
                     .find(intersectionID, startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -266,7 +266,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -280,7 +280,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<MapBroadcastRateNotification> response = mapBroadcastRateNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -321,7 +321,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -335,7 +335,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalGroupAlignmentNotification> response = signalGroupAlignmentNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -376,7 +376,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -390,7 +390,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SignalStateConflictNotification> response = signalStateConflictNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -431,7 +431,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -445,7 +445,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<SpatBroadcastRateNotification> response = spatBroadcastRateNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);
@@ -486,7 +486,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -500,7 +500,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLineStopNotification> response = stopLineStopNotificationRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -541,7 +541,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -555,7 +555,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<StopLinePassageNotification> response = stopLinePassageNotificationRepo.find(intersectionID, startTime,
                     endTime, pageable);
             return ResponseEntity.ok(response);
@@ -596,7 +596,7 @@ public class CmNotificationController {
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -610,7 +610,7 @@ public class CmNotificationController {
                     startTime, endTime));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<TimeChangeDetailsNotification> response = timeChangeDetailsNotificationRepo.find(intersectionID,
                     startTime, endTime, pageable);
             return ResponseEntity.ok(response);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
@@ -54,7 +54,7 @@ public class MapController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -67,7 +67,7 @@ public class MapController {
             return ResponseEntity.ok(processedMapRepo.findLatest(intersectionID, startTime, endTime, compact));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ProcessedMap<LineString>> response = processedMapRepo.find(intersectionID, startTime, endTime, compact,
                     pageable);
             return ResponseEntity.ok(response);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
@@ -54,7 +55,7 @@ public class MapController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/MapController.java
@@ -55,7 +55,7 @@ public class MapController {
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -67,9 +67,8 @@ public class MapController {
             return ResponseEntity.ok(processedMapRepo.findLatest(intersectionID, startTime, endTime, compact));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ProcessedMap<LineString>> response = processedMapRepo.find(intersectionID, startTime, endTime, compact,
-                    pageable);
+                    page, size);
             return ResponseEntity.ok(response);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
@@ -52,7 +53,7 @@ public class SpatController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
@@ -52,7 +52,7 @@ public class SpatController {
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
@@ -65,7 +65,7 @@ public class SpatController {
             return ResponseEntity.ok(processedSpatRepo.findLatest(intersectionID, startTime, endTime, compact));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = PageRequest.of(page, size);
+            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ProcessedSpat> response = processedSpatRepo.find(intersectionID, startTime, endTime, compact,
                     pageable);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/SpatController.java
@@ -53,7 +53,7 @@ public class SpatController {
             @RequestParam(name = "latest", required = false, defaultValue = "false") boolean latest,
             @RequestParam(name = "compact", required = false, defaultValue = "false") boolean compact,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
@@ -65,9 +65,8 @@ public class SpatController {
             return ResponseEntity.ok(processedSpatRepo.findLatest(intersectionID, startTime, endTime, compact));
         } else {
             // Retrieve a paginated result from the repository
-            PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
             Page<ProcessedSpat> response = processedSpatRepo.find(intersectionID, startTime, endTime, compact,
-                    pageable);
+                    page, size);
 
             return ResponseEntity.ok(response);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -61,7 +62,7 @@ public class ActiveNotificationController {
             @RequestParam(name = "intersection_id") Integer intersectionID,
             @RequestParam(name = "notification_type", required = false) String notificationType,
             @RequestParam(name = "key", required = false) String key,
-            @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Page number (0-based). If not set, no paging will be applied, but the results will still be limited by size.") @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
@@ -61,7 +61,7 @@ public class ActiveNotificationController {
             @RequestParam(name = "intersection_id") Integer intersectionID,
             @RequestParam(name = "notification_type", required = false) String notificationType,
             @RequestParam(name = "key", required = false) String key,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "page", required = false) Integer page,
             @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
@@ -71,7 +71,7 @@ public class ActiveNotificationController {
         }
 
         // Retrieve a paginated result from the repository
-        PageRequest pageable = PageRequest.of(page, size);
+        PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
         Page<Notification> response = activeNotificationRepo.find(intersectionID, notificationType, key, pageable);
         return ResponseEntity.ok(response);
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
@@ -62,7 +62,7 @@ public class ActiveNotificationController {
             @RequestParam(name = "notification_type", required = false) String notificationType,
             @RequestParam(name = "key", required = false) String key,
             @RequestParam(name = "page", required = false) Integer page,
-            @RequestParam(name = "size", required = false, defaultValue = "10000") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "1000") int size,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
         if (testData) {
             List<Notification> list = new ArrayList<>();
@@ -71,8 +71,7 @@ public class ActiveNotificationController {
         }
 
         // Retrieve a paginated result from the repository
-        PageRequest pageable = page != null ? PageRequest.of(page, size) : null;
-        Page<Notification> response = activeNotificationRepo.find(intersectionID, notificationType, key, pageable);
+        Page<Notification> response = activeNotificationRepo.find(intersectionID, notificationType, key, page, size);
         return ResponseEntity.ok(response);
     }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/ReportService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/ReportService.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
@@ -19,6 +17,7 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMini
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.lane_direction_of_travel_assessment.LaneDirectionOfTravelAssessmentRepository;
 import us.dot.its.jpo.ode.api.accessors.events.connection_of_travel_event.ConnectionOfTravelEventRepository;
 import us.dot.its.jpo.ode.api.accessors.events.intersection_reference_alignment_event.IntersectionReferenceAlignmentEventRepository;
@@ -46,220 +45,220 @@ import us.dot.its.jpo.ode.api.models.StopLineStopReportData;
 @Service
 public class ReportService {
 
-        private final ProcessedMapRepository processedMapRepo;
-        private final StopLinePassageEventRepository stopLinePassageEventRepo;
-        private final StopLineStopEventRepository stopLineStopEventRepo;
-        private final ConnectionOfTravelEventRepository connectionOfTravelEventRepo;
-        private final IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo;
-        private final LaneDirectionOfTravelEventRepository laneDirectionOfTravelEventRepo;
-        private final SignalStateConflictEventRepository signalStateConflictEventRepo;
-        private final TimeChangeDetailsEventRepository timeChangeDetailsEventRepo;
-        private final LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo;
-        private final SpatMinimumDataEventRepository spatMinimumDataEventRepo;
-        private final MapMinimumDataEventRepository mapMinimumDataEventRepo;
-        private final SpatBroadcastRateEventRepository spatBroadcastRateEventRepo;
-        private final MapBroadcastRateEventRepository mapBroadcastRateEventRepo;
-        private final ReportRepository reportRepo;
-        private final int maximumResponseSize;
+    private final ProcessedMapRepository processedMapRepo;
+    private final StopLinePassageEventRepository stopLinePassageEventRepo;
+    private final StopLineStopEventRepository stopLineStopEventRepo;
+    private final ConnectionOfTravelEventRepository connectionOfTravelEventRepo;
+    private final IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo;
+    private final LaneDirectionOfTravelEventRepository laneDirectionOfTravelEventRepo;
+    private final SignalStateConflictEventRepository signalStateConflictEventRepo;
+    private final TimeChangeDetailsEventRepository timeChangeDetailsEventRepo;
+    private final LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo;
+    private final SpatMinimumDataEventRepository spatMinimumDataEventRepo;
+    private final MapMinimumDataEventRepository mapMinimumDataEventRepo;
+    private final SpatBroadcastRateEventRepository spatBroadcastRateEventRepo;
+    private final MapBroadcastRateEventRepository mapBroadcastRateEventRepo;
+    private final ReportRepository reportRepo;
+    private final ConflictMonitorApiProperties props;
 
-        @Autowired
-        public ReportService(ProcessedMapRepository processedMapRepo,
-                        StopLinePassageEventRepository stopLinePassageEventRepo,
-                        StopLineStopEventRepository stopLineStopEventRepo,
-                        ConnectionOfTravelEventRepository connectionOfTravelEventRepo,
-                        IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo,
-                        LaneDirectionOfTravelEventRepository laneDirectionOfTravelEventRepo,
-                        SignalStateConflictEventRepository signalStateConflictEventRepo,
-                        TimeChangeDetailsEventRepository timeChangeDetailsEventRepo,
-                        LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo,
-                        SpatMinimumDataEventRepository spatMinimumDataEventRepo,
-                        MapMinimumDataEventRepository mapMinimumDataEventRepo,
-                        SpatBroadcastRateEventRepository spatBroadcastRateEventRepo,
-                        MapBroadcastRateEventRepository mapBroadcastRateEventRepo,
-                        ReportRepository reportRepo,
-                        @Value("${maximumResponseSize}") int maximumResponseSize) {
-                this.processedMapRepo = processedMapRepo;
-                this.stopLinePassageEventRepo = stopLinePassageEventRepo;
-                this.stopLineStopEventRepo = stopLineStopEventRepo;
-                this.connectionOfTravelEventRepo = connectionOfTravelEventRepo;
-                this.intersectionReferenceAlignmentEventRepo = intersectionReferenceAlignmentEventRepo;
-                this.laneDirectionOfTravelEventRepo = laneDirectionOfTravelEventRepo;
-                this.signalStateConflictEventRepo = signalStateConflictEventRepo;
-                this.timeChangeDetailsEventRepo = timeChangeDetailsEventRepo;
-                this.laneDirectionOfTravelAssessmentRepo = laneDirectionOfTravelAssessmentRepo;
-                this.spatMinimumDataEventRepo = spatMinimumDataEventRepo;
-                this.mapMinimumDataEventRepo = mapMinimumDataEventRepo;
-                this.spatBroadcastRateEventRepo = spatBroadcastRateEventRepo;
-                this.mapBroadcastRateEventRepo = mapBroadcastRateEventRepo;
-                this.reportRepo = reportRepo;
-                this.maximumResponseSize = maximumResponseSize;
+    @Autowired
+    public ReportService(ProcessedMapRepository processedMapRepo,
+            StopLinePassageEventRepository stopLinePassageEventRepo,
+            StopLineStopEventRepository stopLineStopEventRepo,
+            ConnectionOfTravelEventRepository connectionOfTravelEventRepo,
+            IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo,
+            LaneDirectionOfTravelEventRepository laneDirectionOfTravelEventRepo,
+            SignalStateConflictEventRepository signalStateConflictEventRepo,
+            TimeChangeDetailsEventRepository timeChangeDetailsEventRepo,
+            LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo,
+            SpatMinimumDataEventRepository spatMinimumDataEventRepo,
+            MapMinimumDataEventRepository mapMinimumDataEventRepo,
+            SpatBroadcastRateEventRepository spatBroadcastRateEventRepo,
+            MapBroadcastRateEventRepository mapBroadcastRateEventRepo,
+            ReportRepository reportRepo,
+            ConflictMonitorApiProperties props) {
+        this.processedMapRepo = processedMapRepo;
+        this.stopLinePassageEventRepo = stopLinePassageEventRepo;
+        this.stopLineStopEventRepo = stopLineStopEventRepo;
+        this.connectionOfTravelEventRepo = connectionOfTravelEventRepo;
+        this.intersectionReferenceAlignmentEventRepo = intersectionReferenceAlignmentEventRepo;
+        this.laneDirectionOfTravelEventRepo = laneDirectionOfTravelEventRepo;
+        this.signalStateConflictEventRepo = signalStateConflictEventRepo;
+        this.timeChangeDetailsEventRepo = timeChangeDetailsEventRepo;
+        this.laneDirectionOfTravelAssessmentRepo = laneDirectionOfTravelAssessmentRepo;
+        this.spatMinimumDataEventRepo = spatMinimumDataEventRepo;
+        this.mapMinimumDataEventRepo = mapMinimumDataEventRepo;
+        this.spatBroadcastRateEventRepo = spatBroadcastRateEventRepo;
+        this.mapBroadcastRateEventRepo = mapBroadcastRateEventRepo;
+        this.reportRepo = reportRepo;
+        this.props = props;
+    }
+
+    private List<String> cleanMissingElements(List<String> elements, boolean isMap) {
+        return elements.stream()
+                .filter(element -> !(isMap && element.contains("connectsTo")))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    public ReportDocument buildReport(int intersectionID, long startTime, long endTime) {
+        // ####### 1. Name Report #######
+        String reportName = "CmReport_" + intersectionID + "_" + startTime + "_" + endTime;
+
+        // ####### 2. Collect Report Data By Category #######
+        // Lane Direction of Travel Info
+        List<IDCount> laneDirectionOfTravelEventCounts = laneDirectionOfTravelEventRepo
+                .getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID, startTime, endTime);
+        List<IDCount> laneDirectionOfTravelMedianDistanceDistribution = laneDirectionOfTravelEventRepo
+                .countEventsByCenterlineDistance(intersectionID, startTime, endTime);
+        List<IDCount> laneDirectionOfTravelMedianHeadingDistribution = laneDirectionOfTravelEventRepo
+                .getMedianDistanceByDegree(intersectionID, startTime, endTime);
+        List<LaneDirectionOfTravelAssessment> laneDirectionOfTravelAssessmentCount = laneDirectionOfTravelAssessmentRepo
+                .getLaneDirectionOfTravelOverTime(intersectionID, startTime, endTime);
+
+        // Connection of Travel Info
+        List<IDCount> connectionOfTravelEventCounts = connectionOfTravelEventRepo
+                .getAggregatedDailyConnectionOfTravelEventCounts(intersectionID, startTime, endTime);
+        List<LaneConnectionCount> laneConnectionCounts = connectionOfTravelEventRepo
+                .getConnectionOfTravelEventsByConnection(intersectionID, startTime, endTime);
+
+        // Retrieve the most recent ProcessedMap
+        List<ProcessedMap<LineString>> processedMaps = processedMapRepo
+                .findLatest(intersectionID, null, null, true)
+                .getContent();
+        ProcessedMap<LineString> mostRecentProcessedMap = processedMaps.isEmpty() ? null
+                : processedMaps.getFirst();
+
+        // Process connection of travel data
+        List<ConnectionData> validConnectionOfTravelData = new ArrayList<>();
+        List<ConnectionData> invalidConnectionOfTravelData = new ArrayList<>();
+        if (mostRecentProcessedMap != null && !laneConnectionCounts.isEmpty()) {
+            ConnectionOfTravelData connectionData = ConnectionOfTravelData
+                    .processConnectionOfTravelData(laneConnectionCounts, mostRecentProcessedMap);
+            validConnectionOfTravelData = connectionData.getValidConnections();
+            invalidConnectionOfTravelData = connectionData.getInvalidConnections();
         }
 
-        private List<String> cleanMissingElements(List<String> elements, boolean isMap) {
-                return elements.stream()
-                                .filter(element -> !(isMap && element.contains("connectsTo")))
-                                .map(String::trim)
-                                .collect(Collectors.toList());
+        // Stop Line Passage Event Counts
+        List<IDCount> stopLinePassageEventCounts = stopLinePassageEventRepo
+                .getAggregatedDailyStopLinePassageEventCounts(
+                        intersectionID, startTime,
+                        endTime);
+
+        // Stop Line Stop Events
+        List<IDCount> stopLineStopEventCounts = stopLineStopEventRepo
+                .getAggregatedDailyStopLineStopEventCounts(intersectionID, startTime, endTime);
+
+        // Signal state Conflict Events
+        List<IDCount> signalStateConflictEventCounts = signalStateConflictEventRepo
+                .getAggregatedDailySignalStateConflictEventCounts(intersectionID, startTime, endTime);
+
+        // Time Change Details Events
+        List<IDCount> timeChangeDetailsEventCounts = timeChangeDetailsEventRepo
+                .getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID, startTime, endTime);
+
+        // Intersection Reference Alignment Event Counts
+        List<IDCount> intersectionReferenceAlignmentEventCounts = intersectionReferenceAlignmentEventRepo
+                .getAggregatedDailyIntersectionReferenceAlignmentEventCounts(intersectionID, startTime,
+                        endTime);
+
+        // Map / Spat counts
+        List<IDCount> mapMinimumDataEventCount = mapMinimumDataEventRepo
+                .getAggregatedDailyMapMinimumDataEventCounts(
+                        intersectionID,
+                        startTime, endTime);
+        List<IDCount> spatMinimumDataEventCount = spatMinimumDataEventRepo
+                .getAggregatedDailySpatMinimumDataEventCounts(
+                        intersectionID,
+                        startTime, endTime);
+
+        List<IDCount> mapBroadcastRateEventCount = mapBroadcastRateEventRepo
+                .getAggregatedDailyMapBroadcastRateEventCounts(intersectionID, startTime, endTime);
+        List<IDCount> spatBroadcastRateEventCount = spatBroadcastRateEventRepo
+                .getAggregatedDailySpatBroadcastRateEventCounts(intersectionID, startTime, endTime);
+
+        List<SpatMinimumDataEvent> spatMinimumDataEvents = spatMinimumDataEventRepo
+                .findLatest(intersectionID, startTime, endTime).getContent();
+        List<MapMinimumDataEvent> mapMinimumDataEvents = mapMinimumDataEventRepo
+                .findLatest(intersectionID, startTime, endTime).getContent();
+
+        // Parse missing elements from minimum data events
+        List<String> latestMapMinimumDataEventMissingElements = mapMinimumDataEvents.isEmpty()
+                ? Collections.emptyList()
+                : cleanMissingElements(mapMinimumDataEvents.getFirst().getMissingDataElements(), true);
+
+        List<String> latestSpatMinimumDataEventMissingElements = spatMinimumDataEvents.isEmpty()
+                ? Collections.emptyList()
+                : cleanMissingElements(spatMinimumDataEvents.getFirst().getMissingDataElements(),
+                        false);
+
+        // Process lane direction of travel data
+        List<LaneDirectionOfTravelReportData> laneDirectionOfTravelReportData = LaneDirectionOfTravelReportData
+                .processLaneDirectionOfTravelData(laneDirectionOfTravelAssessmentCount);
+
+        // Extract HeadingTolerance and DistanceTolerance from the most recent
+        // assessment
+        double headingTolerance = 0.0;
+        double distanceTolerance = 0.0;
+        if (!laneDirectionOfTravelAssessmentCount.isEmpty()) {
+            LaneDirectionOfTravelAssessment mostRecentAssessment = laneDirectionOfTravelAssessmentCount
+                    .getFirst();
+            if (!mostRecentAssessment.getLaneDirectionOfTravelAssessmentGroup().isEmpty()) {
+                LaneDirectionOfTravelAssessmentGroup group = mostRecentAssessment
+                        .getLaneDirectionOfTravelAssessmentGroup().getFirst();
+                headingTolerance = group.getTolerance();
+                distanceTolerance = group.getDistanceFromCenterlineTolerance();
+            }
         }
 
-        public ReportDocument buildReport(int intersectionID, long startTime, long endTime) {
-                // ####### 1. Name Report #######
-                String reportName = "CmReport_" + intersectionID + "_" + startTime + "_" + endTime;
+        // Retrieve StopLineStopEvents
+        List<StopLineStopEvent> stopLineStopEvents = stopLineStopEventRepo
+                .find(intersectionID, startTime, endTime, null, props.getMaximumResponseSize())
+                .getContent();
+        List<StopLineStopReportData> stopLineStopReportData = StopLineStopReportData
+                .aggregateStopLineStopEvents(stopLineStopEvents);
 
-                // ####### 2. Collect Report Data By Category #######
-                // Lane Direction of Travel Info
-                List<IDCount> laneDirectionOfTravelEventCounts = laneDirectionOfTravelEventRepo
-                                .getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID, startTime, endTime);
-                List<IDCount> laneDirectionOfTravelMedianDistanceDistribution = laneDirectionOfTravelEventRepo
-                                .countEventsByCenterlineDistance(intersectionID, startTime, endTime);
-                List<IDCount> laneDirectionOfTravelMedianHeadingDistribution = laneDirectionOfTravelEventRepo
-                                .getMedianDistanceByDegree(intersectionID, startTime, endTime);
-                List<LaneDirectionOfTravelAssessment> laneDirectionOfTravelAssessmentCount = laneDirectionOfTravelAssessmentRepo
-                                .getLaneDirectionOfTravelOverTime(intersectionID, startTime, endTime);
+        // Retrieve StopLinePassageEvents
+        List<StopLinePassageEvent> stopLinePassageEvents = stopLinePassageEventRepo
+                .find(intersectionID, startTime, endTime,
+                        null, props.getMaximumResponseSize())
+                .getContent();
+        List<StopLinePassageReportData> stopLinePassageReportData = StopLinePassageReportData
+                .aggregateStopLinePassageEvents(stopLinePassageEvents);
 
-                // Connection of Travel Info
-                List<IDCount> connectionOfTravelEventCounts = connectionOfTravelEventRepo
-                                .getAggregatedDailyConnectionOfTravelEventCounts(intersectionID, startTime, endTime);
-                List<LaneConnectionCount> laneConnectionCounts = connectionOfTravelEventRepo
-                                .getConnectionOfTravelEventsByConnection(intersectionID, startTime, endTime);
+        // ####### 3. Create Report Document #######
+        ReportDocument doc = new ReportDocument();
+        doc.setIntersectionID(intersectionID);
+        doc.setReportGeneratedAt(Instant.now().toEpochMilli());
+        doc.setReportStartTime(startTime);
+        doc.setReportStopTime(endTime);
+        doc.setReportContents(new byte[] {});
+        doc.setReportName(reportName);
+        doc.setLaneDirectionOfTravelEventCounts(laneDirectionOfTravelEventCounts);
+        doc.setLaneDirectionOfTravelMedianDistanceDistribution(laneDirectionOfTravelMedianDistanceDistribution);
+        doc.setLaneDirectionOfTravelMedianHeadingDistribution(laneDirectionOfTravelMedianHeadingDistribution);
+        doc.setLaneDirectionOfTravelReportData(laneDirectionOfTravelReportData);
+        doc.setHeadingTolerance(headingTolerance);
+        doc.setDistanceTolerance(distanceTolerance);
+        doc.setConnectionOfTravelEventCounts(connectionOfTravelEventCounts);
+        doc.setValidConnectionOfTravelData(validConnectionOfTravelData);
+        doc.setInvalidConnectionOfTravelData(invalidConnectionOfTravelData);
+        doc.setSignalStateConflictEventCount(signalStateConflictEventCounts);
+        doc.setStopLinePassageEventCounts(stopLinePassageEventCounts);
+        doc.setStopLineStopEventCounts(stopLineStopEventCounts);
+        doc.setTimeChangeDetailsEventCount(timeChangeDetailsEventCounts);
+        doc.setIntersectionReferenceAlignmentEventCounts(intersectionReferenceAlignmentEventCounts);
+        doc.setMapBroadcastRateEventCount(mapBroadcastRateEventCount);
+        doc.setMapMinimumDataEventCount(mapMinimumDataEventCount);
+        doc.setSpatBroadcastRateEventCount(spatBroadcastRateEventCount);
+        doc.setSpatMinimumDataEventCount(spatMinimumDataEventCount);
+        doc.setLatestMapMinimumDataEventMissingElements(latestMapMinimumDataEventMissingElements);
+        doc.setLatestSpatMinimumDataEventMissingElements(latestSpatMinimumDataEventMissingElements);
+        doc.setStopLineStopReportData(stopLineStopReportData);
+        doc.setStopLinePassageReportData(stopLinePassageReportData);
 
-                // Retrieve the most recent ProcessedMap
-                List<ProcessedMap<LineString>> processedMaps = processedMapRepo
-                                .findLatest(intersectionID, null, null, true)
-                                .getContent();
-                ProcessedMap<LineString> mostRecentProcessedMap = processedMaps.isEmpty() ? null
-                                : processedMaps.getFirst();
-
-                // Process connection of travel data
-                List<ConnectionData> validConnectionOfTravelData = new ArrayList<>();
-                List<ConnectionData> invalidConnectionOfTravelData = new ArrayList<>();
-                if (mostRecentProcessedMap != null && !laneConnectionCounts.isEmpty()) {
-                        ConnectionOfTravelData connectionData = ConnectionOfTravelData
-                                        .processConnectionOfTravelData(laneConnectionCounts, mostRecentProcessedMap);
-                        validConnectionOfTravelData = connectionData.getValidConnections();
-                        invalidConnectionOfTravelData = connectionData.getInvalidConnections();
-                }
-
-                // Stop Line Passage Event Counts
-                List<IDCount> stopLinePassageEventCounts = stopLinePassageEventRepo
-                                .getAggregatedDailyStopLinePassageEventCounts(
-                                                intersectionID, startTime,
-                                                endTime);
-
-                // Stop Line Stop Events
-                List<IDCount> stopLineStopEventCounts = stopLineStopEventRepo
-                                .getAggregatedDailyStopLineStopEventCounts(intersectionID, startTime, endTime);
-
-                // Signal state Conflict Events
-                List<IDCount> signalStateConflictEventCounts = signalStateConflictEventRepo
-                                .getAggregatedDailySignalStateConflictEventCounts(intersectionID, startTime, endTime);
-
-                // Time Change Details Events
-                List<IDCount> timeChangeDetailsEventCounts = timeChangeDetailsEventRepo
-                                .getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID, startTime, endTime);
-
-                // Intersection Reference Alignment Event Counts
-                List<IDCount> intersectionReferenceAlignmentEventCounts = intersectionReferenceAlignmentEventRepo
-                                .getAggregatedDailyIntersectionReferenceAlignmentEventCounts(intersectionID, startTime,
-                                                endTime);
-
-                // Map / Spat counts
-                List<IDCount> mapMinimumDataEventCount = mapMinimumDataEventRepo
-                                .getAggregatedDailyMapMinimumDataEventCounts(
-                                                intersectionID,
-                                                startTime, endTime);
-                List<IDCount> spatMinimumDataEventCount = spatMinimumDataEventRepo
-                                .getAggregatedDailySpatMinimumDataEventCounts(
-                                                intersectionID,
-                                                startTime, endTime);
-
-                List<IDCount> mapBroadcastRateEventCount = mapBroadcastRateEventRepo
-                                .getAggregatedDailyMapBroadcastRateEventCounts(intersectionID, startTime, endTime);
-                List<IDCount> spatBroadcastRateEventCount = spatBroadcastRateEventRepo
-                                .getAggregatedDailySpatBroadcastRateEventCounts(intersectionID, startTime, endTime);
-
-                List<SpatMinimumDataEvent> spatMinimumDataEvents = spatMinimumDataEventRepo
-                                .findLatest(intersectionID, startTime, endTime).getContent();
-                List<MapMinimumDataEvent> mapMinimumDataEvents = mapMinimumDataEventRepo
-                                .findLatest(intersectionID, startTime, endTime).getContent();
-
-                // Parse missing elements from minimum data events
-                List<String> latestMapMinimumDataEventMissingElements = mapMinimumDataEvents.isEmpty()
-                                ? Collections.emptyList()
-                                : cleanMissingElements(mapMinimumDataEvents.getFirst().getMissingDataElements(), true);
-
-                List<String> latestSpatMinimumDataEventMissingElements = spatMinimumDataEvents.isEmpty()
-                                ? Collections.emptyList()
-                                : cleanMissingElements(spatMinimumDataEvents.getFirst().getMissingDataElements(),
-                                                false);
-
-                // Process lane direction of travel data
-                List<LaneDirectionOfTravelReportData> laneDirectionOfTravelReportData = LaneDirectionOfTravelReportData
-                                .processLaneDirectionOfTravelData(laneDirectionOfTravelAssessmentCount);
-
-                // Extract HeadingTolerance and DistanceTolerance from the most recent
-                // assessment
-                double headingTolerance = 0.0;
-                double distanceTolerance = 0.0;
-                if (!laneDirectionOfTravelAssessmentCount.isEmpty()) {
-                        LaneDirectionOfTravelAssessment mostRecentAssessment = laneDirectionOfTravelAssessmentCount
-                                        .getFirst();
-                        if (!mostRecentAssessment.getLaneDirectionOfTravelAssessmentGroup().isEmpty()) {
-                                LaneDirectionOfTravelAssessmentGroup group = mostRecentAssessment
-                                                .getLaneDirectionOfTravelAssessmentGroup().getFirst();
-                                headingTolerance = group.getTolerance();
-                                distanceTolerance = group.getDistanceFromCenterlineTolerance();
-                        }
-                }
-
-                // Retrieve StopLineStopEvents
-                List<StopLineStopEvent> stopLineStopEvents = stopLineStopEventRepo
-                                .find(intersectionID, startTime, endTime, PageRequest.of(0, maximumResponseSize))
-                                .getContent();
-                List<StopLineStopReportData> stopLineStopReportData = StopLineStopReportData
-                                .aggregateStopLineStopEvents(stopLineStopEvents);
-
-                // Retrieve StopLinePassageEvents
-                List<StopLinePassageEvent> stopLinePassageEvents = stopLinePassageEventRepo
-                                .find(intersectionID, startTime, endTime,
-                                                PageRequest.of(0, maximumResponseSize))
-                                .getContent();
-                List<StopLinePassageReportData> stopLinePassageReportData = StopLinePassageReportData
-                                .aggregateStopLinePassageEvents(stopLinePassageEvents);
-
-                // ####### 3. Create Report Document #######
-                ReportDocument doc = new ReportDocument();
-                doc.setIntersectionID(intersectionID);
-                doc.setReportGeneratedAt(Instant.now().toEpochMilli());
-                doc.setReportStartTime(startTime);
-                doc.setReportStopTime(endTime);
-                doc.setReportContents(new byte[] {});
-                doc.setReportName(reportName);
-                doc.setLaneDirectionOfTravelEventCounts(laneDirectionOfTravelEventCounts);
-                doc.setLaneDirectionOfTravelMedianDistanceDistribution(laneDirectionOfTravelMedianDistanceDistribution);
-                doc.setLaneDirectionOfTravelMedianHeadingDistribution(laneDirectionOfTravelMedianHeadingDistribution);
-                doc.setLaneDirectionOfTravelReportData(laneDirectionOfTravelReportData);
-                doc.setHeadingTolerance(headingTolerance);
-                doc.setDistanceTolerance(distanceTolerance);
-                doc.setConnectionOfTravelEventCounts(connectionOfTravelEventCounts);
-                doc.setValidConnectionOfTravelData(validConnectionOfTravelData);
-                doc.setInvalidConnectionOfTravelData(invalidConnectionOfTravelData);
-                doc.setSignalStateConflictEventCount(signalStateConflictEventCounts);
-                doc.setStopLinePassageEventCounts(stopLinePassageEventCounts);
-                doc.setStopLineStopEventCounts(stopLineStopEventCounts);
-                doc.setTimeChangeDetailsEventCount(timeChangeDetailsEventCounts);
-                doc.setIntersectionReferenceAlignmentEventCounts(intersectionReferenceAlignmentEventCounts);
-                doc.setMapBroadcastRateEventCount(mapBroadcastRateEventCount);
-                doc.setMapMinimumDataEventCount(mapMinimumDataEventCount);
-                doc.setSpatBroadcastRateEventCount(spatBroadcastRateEventCount);
-                doc.setSpatMinimumDataEventCount(spatMinimumDataEventCount);
-                doc.setLatestMapMinimumDataEventMissingElements(latestMapMinimumDataEventMissingElements);
-                doc.setLatestSpatMinimumDataEventMissingElements(latestSpatMinimumDataEventMissingElements);
-                doc.setStopLineStopReportData(stopLineStopReportData);
-                doc.setStopLinePassageReportData(stopLinePassageReportData);
-
-                // ####### 4. Save Report Document to Database #######
-                reportRepo.add(doc);
-                return doc;
-        }
+        // ####### 4. Save Report Document to Database #######
+        reportRepo.add(doc);
+        return doc;
+    }
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/tasks/EmailTask.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/tasks/EmailTask.java
@@ -160,7 +160,7 @@ public class EmailTask {
 
     public List<Notification> getActiveNotifications() {
         Page<Notification> notifications = activeNotificationRepo
-                .find(null, null, null, PageRequest.of(0, maximumResponseSize));
+                .find(null, null, null, null, maximumResponseSize);
         return notifications.getContent();
     }
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/PageableQueryTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/PageableQueryTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -125,6 +126,60 @@ public class PageableQueryTest {
     }
 
     @Test
+    void testFindGenericReturnsExpectedResults() {
+        int limit = 5;
+        Criteria criteria = new Criteria();
+        Sort sort = Sort.by(Sort.Direction.ASC, "someField");
+        List<String> excludedFields = List.of("excludedField");
+
+        List<ConnectionOfTravelNotification> expectedData = Arrays.asList(
+                new ConnectionOfTravelNotification(),
+                new ConnectionOfTravelNotification());
+
+        Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        for (String field : excludedFields) {
+            mongoQuery.fields().exclude(field);
+        }
+
+        when(mongoTemplate.find(any(Query.class), eq(ConnectionOfTravelNotification.class), eq("collectionName")))
+                .thenReturn(expectedData);
+
+        Page<ConnectionOfTravelNotification> result = paginatedQueryInterface.findGeneric(
+                mongoTemplate,
+                "collectionName",
+                limit,
+                criteria,
+                sort,
+                excludedFields,
+                ConnectionOfTravelNotification.class);
+
+        assertThat(result.getContent()).isEqualTo(expectedData);
+        assertThat(result.getTotalElements()).isEqualTo(expectedData.size());
+    }
+
+    @Test
+    void testFindGenericReturnsEmptyResults() {
+        int limit = 5;
+        Criteria criteria = new Criteria();
+        Sort sort = Sort.by(Sort.Direction.ASC, "someField");
+
+        when(mongoTemplate.find(any(Query.class), eq(ConnectionOfTravelNotification.class), eq("collectionName")))
+                .thenReturn(Collections.emptyList());
+
+        Page<ConnectionOfTravelNotification> result = paginatedQueryInterface.findGeneric(
+                mongoTemplate,
+                "collectionName",
+                limit,
+                criteria,
+                sort,
+                Collections.emptyList(),
+                ConnectionOfTravelNotification.class);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
     void testWrapSingleResultWithPage() {
         String latest = "latestData";
         Page<String> page = paginatedQueryInterface.wrapSingleResultWithPage(latest);
@@ -139,5 +194,57 @@ public class PageableQueryTest {
 
         assertThat(page.getContent()).isEmpty();
         assertThat(page.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    void testFindDocumentsReturnsExpectedResults() {
+        int limit = 3;
+        Criteria criteria = new Criteria();
+        Sort sort = Sort.by(Sort.Direction.ASC, "anotherField");
+        List<String> excludedFields = List.of("excludedField");
+
+        List<Document> expectedDocs = Arrays.asList(
+                new Document("field1", "value1"),
+                new Document("field2", "value2"));
+
+        Query mongoQuery = Query.query(criteria).with(sort).limit(limit);
+        for (String field : excludedFields) {
+            mongoQuery.fields().exclude(field);
+        }
+
+        when(mongoTemplate.find(any(Query.class), eq(Document.class), eq("collectionName")))
+                .thenReturn(expectedDocs);
+
+        Page<Document> result = paginatedQueryInterface.findDocuments(
+                mongoTemplate,
+                "collectionName",
+                limit,
+                criteria,
+                sort,
+                excludedFields);
+
+        assertThat(result.getContent()).isEqualTo(expectedDocs);
+        assertThat(result.getTotalElements()).isEqualTo(expectedDocs.size());
+    }
+
+    @Test
+    void testFindDocumentsReturnsEmptyResults() {
+        int limit = 3;
+        Criteria criteria = new Criteria();
+        Sort sort = Sort.by(Sort.Direction.ASC, "anotherField");
+
+        when(mongoTemplate.find(any(Query.class), eq(Document.class), eq("collectionName")))
+                .thenReturn(Collections.emptyList());
+
+        Page<Document> result = paginatedQueryInterface.findDocuments(
+                mongoTemplate,
+                "collectionName",
+                limit,
+                criteria,
+                sort,
+                Collections.emptyList());
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
     }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.connection_of_travel_assessment.ConnectionOfTravelAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -57,6 +58,9 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -80,7 +84,7 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelAssessmentRepositoryImpl(mongoTemplate);
+        repository = new ConnectionOfTravelAssessmentRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/ConnectionOfTravelAssessmentRepositoryImplTest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.ConnectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.connection_of_travel_assessment.ConnectionOfTravelAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -58,9 +57,6 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +80,7 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelAssessmentRepositoryImpl(mongoTemplate, props);
+        repository = new ConnectionOfTravelAssessmentRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -113,10 +109,9 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(ConnectionOfTravelAssessment.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<ConnectionOfTravelAssessment> results = repo.find(1, null, null, pageRequest);
+        Page<ConnectionOfTravelAssessment> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -151,9 +146,7 @@ public class ConnectionOfTravelAssessmentRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<ConnectionOfTravelAssessment> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<ConnectionOfTravelAssessment> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         verify(mongoTemplate).aggregate(any(Aggregation.class), anyString(),
                 eq(AggregationResult.class));

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.lane_direction_of_travel_assessment.LaneDirectionOfTravelAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -57,6 +58,9 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -80,7 +84,7 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelAssessmentRepositoryImpl(mongoTemplate);
+        repository = new LaneDirectionOfTravelAssessmentRepositoryImpl(mongoTemplate, props);
     }
 
     @Test
@@ -98,7 +102,8 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
 
     @Test
     public void testFind() {
-        LaneDirectionOfTravelAssessmentRepositoryImpl repo = mock(LaneDirectionOfTravelAssessmentRepositoryImpl.class);
+        LaneDirectionOfTravelAssessmentRepositoryImpl repo = mock(
+                LaneDirectionOfTravelAssessmentRepositoryImpl.class);
 
         when(repo.findPage(
                 any(),

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/LaneDirectionOfTravelAssessmentRepositoryImplTest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.lane_direction_of_travel_assessment.LaneDirectionOfTravelAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -58,9 +57,6 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +80,7 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelAssessmentRepositoryImpl(mongoTemplate, props);
+        repository = new LaneDirectionOfTravelAssessmentRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -113,10 +109,9 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(LaneDirectionOfTravelAssessment.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<LaneDirectionOfTravelAssessment> results = repo.find(1, null, null, pageRequest);
+        Page<LaneDirectionOfTravelAssessment> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -151,9 +146,7 @@ public class LaneDirectionOfTravelAssessmentRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<LaneDirectionOfTravelAssessment> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<LaneDirectionOfTravelAssessment> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLinePassageAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLinePassageAssessmentRepositoryImplTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.stop_line_passage_assessment.StopLinePassageAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -55,129 +56,132 @@ import us.dot.its.jpo.ode.api.models.AggregationResultCount;
 @AutoConfigureEmbeddedDatabase
 public class StopLinePassageAssessmentRepositoryImplTest {
 
-        @SpyBean
-        private MongoTemplate mongoTemplate;
+    @SpyBean
+    private MongoTemplate mongoTemplate;
 
-        @Mock
-        private AggregationResults<AggregationResult> mockAggregationResult;
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
-        @Mock
-        private Page<Document> mockDocumentPage;
+    @Mock
+    private AggregationResults<AggregationResult> mockAggregationResult;
 
-        @Mock
-        private Page<StopLinePassageAssessment> mockPage;
+    @Mock
+    private Page<Document> mockDocumentPage;
 
-        @InjectMocks
-        private StopLinePassageAssessmentRepositoryImpl repository;
+    @Mock
+    private Page<StopLinePassageAssessment> mockPage;
 
-        Integer intersectionID = 123;
-        Long startTime = 1724170658205L;
-        String startTimeString = "2024-08-20T16:17:38.205Z";
-        Long endTime = 1724170778205L;
-        String endTimeString = "2024-08-20T16:19:38.205Z";
-        boolean latest = true;
+    @InjectMocks
+    private StopLinePassageAssessmentRepositoryImpl repository;
 
-        @BeforeEach
-        void setUp() {
-                MockitoAnnotations.openMocks(this);
-                repository = new StopLinePassageAssessmentRepositoryImpl(mongoTemplate);
-        }
+    Integer intersectionID = 123;
+    Long startTime = 1724170658205L;
+    String startTimeString = "2024-08-20T16:17:38.205Z";
+    Long endTime = 1724170778205L;
+    String endTimeString = "2024-08-20T16:19:38.205Z";
+    boolean latest = true;
 
-        @Test
-        public void testCount() {
-                long expectedCount = 10;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        repository = new StopLinePassageAssessmentRepositoryImpl(mongoTemplate, props);
+    }
 
-                doReturn(expectedCount).when(mongoTemplate).count(any(),
-                                Mockito.<String>any());
+    @Test
+    public void testCount() {
+        long expectedCount = 10;
 
-                long resultCount = repository.count(1, null, null);
+        doReturn(expectedCount).when(mongoTemplate).count(any(),
+                Mockito.<String>any());
 
-                assertThat(resultCount).isEqualTo(expectedCount);
-                verify(mongoTemplate).count(any(Query.class), anyString());
-        }
+        long resultCount = repository.count(1, null, null);
 
-        @Test
-        public void testFind() {
-                StopLinePassageAssessmentRepositoryImpl repo = mock(StopLinePassageAssessmentRepositoryImpl.class);
+        assertThat(resultCount).isEqualTo(expectedCount);
+        verify(mongoTemplate).count(any(Query.class), anyString());
+    }
 
-                when(repo.findPage(
-                                any(),
-                                any(),
-                                any(PageRequest.class),
-                                any(Criteria.class),
-                                any(Sort.class),
-                                any(),
-                                eq(StopLinePassageAssessment.class))).thenReturn(mockPage);
-                PageRequest pageRequest = PageRequest.of(0, 1);
-                doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+    @Test
+    public void testFind() {
+        StopLinePassageAssessmentRepositoryImpl repo = mock(StopLinePassageAssessmentRepositoryImpl.class);
 
-                Page<StopLinePassageAssessment> results = repo.find(1, null, null, pageRequest);
+        when(repo.findPage(
+                any(),
+                any(),
+                any(PageRequest.class),
+                any(Criteria.class),
+                any(Sort.class),
+                any(),
+                eq(StopLinePassageAssessment.class))).thenReturn(mockPage);
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
 
-                assertThat(results).isEqualTo(mockPage);
-        }
+        Page<StopLinePassageAssessment> results = repo.find(1, null, null, pageRequest);
 
-        @Test
-        public void testFindWithData() throws IOException {
-                // Load sample JSON data
-                String json = new String(
-                                Files.readAllBytes(
-                                                Paths.get("src/test/resources/json/ConflictMonitor.CmStopLinePassageAssessment.json")));
-                ObjectMapper objectMapper = new ObjectMapper();
-                objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
-                                                                                                         // JavaTimeModule
+        assertThat(results).isEqualTo(mockPage);
+    }
 
-                List<Document> sampleDocuments = List.of(Document.parse(json));
+    @Test
+    public void testFindWithData() throws IOException {
+        // Load sample JSON data
+        String json = new String(
+                Files.readAllBytes(
+                        Paths.get("src/test/resources/json/ConflictMonitor.CmStopLinePassageAssessment.json")));
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
+                                                                                                 // JavaTimeModule
 
-                // Mock dependencies
-                when(mockDocumentPage.getContent()).thenReturn(sampleDocuments);
-                when(mockDocumentPage.getTotalElements()).thenReturn(1L);
+        List<Document> sampleDocuments = List.of(Document.parse(json));
 
-                AggregationResult aggregationResult = new AggregationResult();
-                aggregationResult.setResults(sampleDocuments);
-                AggregationResultCount aggregationResultCount = new AggregationResultCount();
-                aggregationResultCount.setCount(1L);
-                aggregationResult.setMetadata(List.of(aggregationResultCount));
+        // Mock dependencies
+        when(mockDocumentPage.getContent()).thenReturn(sampleDocuments);
+        when(mockDocumentPage.getTotalElements()).thenReturn(1L);
 
-                when(mockAggregationResult.getUniqueMappedResult()).thenReturn(aggregationResult);
+        AggregationResult aggregationResult = new AggregationResult();
+        aggregationResult.setResults(sampleDocuments);
+        AggregationResultCount aggregationResultCount = new AggregationResultCount();
+        aggregationResultCount.setCount(1L);
+        aggregationResult.setMetadata(List.of(aggregationResultCount));
 
-                ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
-                doReturn(mockAggregationResult).when(mongoTemplate).aggregate(aggregationCaptor.capture(),
-                                anyString(),
-                                eq(AggregationResult.class));
+        when(mockAggregationResult.getUniqueMappedResult()).thenReturn(aggregationResult);
 
-                // Call the repository find method
-                PageRequest pageRequest = PageRequest.of(0, 1);
-                Page<StopLinePassageAssessment> findResponse = repository.find(intersectionID, startTime, endTime,
-                                pageRequest);
+        ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
+        doReturn(mockAggregationResult).when(mongoTemplate).aggregate(aggregationCaptor.capture(),
+                anyString(),
+                eq(AggregationResult.class));
 
-                // Extract the captured Aggregation
-                Aggregation capturedAggregation = aggregationCaptor.getValue();
+        // Call the repository find method
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        Page<StopLinePassageAssessment> findResponse = repository.find(intersectionID, startTime, endTime,
+                pageRequest);
 
-                // Extract the MatchOperation from the Aggregation pipeline
-                Document pipeline = capturedAggregation.toPipeline(Aggregation.DEFAULT_CONTEXT).get(0);
+        // Extract the captured Aggregation
+        Aggregation capturedAggregation = aggregationCaptor.getValue();
 
-                // Assert the Match operation Criteria
-                assertThat(pipeline.toJson())
-                                .isEqualTo(String.format(
-                                                "{\"$match\": {\"intersectionID\": %s, \"assessmentGeneratedAt\": {\"$gte\": {\"$date\": \"%s\"}, \"$lte\": {\"$date\": \"%s\"}}}}",
-                                                intersectionID, startTimeString, endTimeString));
+        // Extract the MatchOperation from the Aggregation pipeline
+        Document pipeline = capturedAggregation.toPipeline(Aggregation.DEFAULT_CONTEXT).get(0);
 
-                // Serialize results to JSON and compare with the original JSON
-                String resultJson = objectMapper.writeValueAsString(findResponse.getContent().get(0));
+        // Assert the Match operation Criteria
+        assertThat(pipeline.toJson())
+                .isEqualTo(String.format(
+                        "{\"$match\": {\"intersectionID\": %s, \"assessmentGeneratedAt\": {\"$gte\": {\"$date\": \"%s\"}, \"$lte\": {\"$date\": \"%s\"}}}}",
+                        intersectionID, startTimeString, endTimeString));
 
-                // Remove unused fields from each entry
-                List<Document> expectedResult = sampleDocuments.stream().map(doc -> {
-                        doc.remove("_id");
-                        doc.remove("recordGeneratedAt");
-                        return doc;
-                }).toList();
-                String expectedJson = objectMapper.writeValueAsString(expectedResult.get(0));
+        // Serialize results to JSON and compare with the original JSON
+        String resultJson = objectMapper.writeValueAsString(findResponse.getContent().get(0));
 
-                // Compare JSON with ignored fields
-                JSONAssert.assertEquals(expectedJson, resultJson, new CustomComparator(
-                                JSONCompareMode.LENIENT, // Allows different key orders
-                                new Customization("properties.timeStamp", (o1, o2) -> true),
-                                new Customization("properties.odeReceivedAt", (o1, o2) -> true)));
-        }
+        // Remove unused fields from each entry
+        List<Document> expectedResult = sampleDocuments.stream().map(doc -> {
+            doc.remove("_id");
+            doc.remove("recordGeneratedAt");
+            return doc;
+        }).toList();
+        String expectedJson = objectMapper.writeValueAsString(expectedResult.get(0));
+
+        // Compare JSON with ignored fields
+        JSONAssert.assertEquals(expectedJson, resultJson, new CustomComparator(
+                JSONCompareMode.LENIENT, // Allows different key orders
+                new Customization("properties.timeStamp", (o1, o2) -> true),
+                new Customization("properties.odeReceivedAt", (o1, o2) -> true)));
+    }
 
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLinePassageAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLinePassageAssessmentRepositoryImplTest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLinePassageAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.stop_line_passage_assessment.StopLinePassageAssessmentRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -58,9 +57,6 @@ public class StopLinePassageAssessmentRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +80,7 @@ public class StopLinePassageAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLinePassageAssessmentRepositoryImpl(mongoTemplate, props);
+        repository = new StopLinePassageAssessmentRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -112,10 +108,9 @@ public class StopLinePassageAssessmentRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLinePassageAssessment.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLinePassageAssessment> results = repo.find(1, null, null, pageRequest);
+        Page<StopLinePassageAssessment> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -150,9 +145,7 @@ public class StopLinePassageAssessmentRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<StopLinePassageAssessment> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<StopLinePassageAssessment> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.stop_line_stop_assessment.StopLineStopAssessmentRepositoryImpl;
 
 @SpringBootTest
@@ -38,6 +40,9 @@ public class StopLineStopAssessmentRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<StopLineStopAssessment> mockPage;
@@ -53,7 +58,7 @@ public class StopLineStopAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLineStopAssessmentRepositoryImpl(mongoTemplate);
+        repository = new StopLineStopAssessmentRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/assessments/StopLineStopAssessmentRepositoryImplTest.java
@@ -23,13 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.StopLineStopAssessment;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.stop_line_stop_assessment.StopLineStopAssessmentRepositoryImpl;
 
 @SpringBootTest
@@ -40,9 +38,6 @@ public class StopLineStopAssessmentRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<StopLineStopAssessment> mockPage;
@@ -58,7 +53,7 @@ public class StopLineStopAssessmentRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLineStopAssessmentRepositoryImpl(mongoTemplate, props);
+        repository = new StopLineStopAssessmentRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -87,10 +82,9 @@ public class StopLineStopAssessmentRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLineStopAssessment.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLineStopAssessment> results = repo.find(1, null, null, pageRequest);
+        Page<StopLineStopAssessment> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -150,7 +150,7 @@ public class OdeBsmJsonRepositoryImplTest {
         Mockito.verify(repo).findDocumentsWithPagination(
                 any(),
                 any(),
-                eq(pageRequest),
+                any(PageRequest.class),
                 Mockito.argThat(criteria -> {
                     // Verify ORIGIN_IP_FIELD
                     assertThat(criteria.getCriteriaObject().get("metadata.originIp"))
@@ -220,7 +220,7 @@ public class OdeBsmJsonRepositoryImplTest {
         Mockito.verify(repo).findDocumentsWithPagination(
                 any(),
                 any(),
-                eq(pageRequest),
+                any(PageRequest.class),
                 Mockito.argThat(criteria -> {
                     // Verify ORIGIN_IP_FIELD
                     assertThat(criteria.getCriteriaObject().get("metadata.originIp"))
@@ -282,7 +282,7 @@ public class OdeBsmJsonRepositoryImplTest {
         Mockito.verify(repo).findDocumentsWithPagination(
                 any(),
                 any(),
-                eq(pageRequest),
+                any(PageRequest.class),
                 Mockito.argThat(criteria -> {
                     // Verify ORIGIN_IP_FIELD
                     assertThat(criteria.getCriteriaObject().get("metadata.originIp")).isNull();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -60,9 +59,6 @@ public class OdeBsmJsonRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -88,7 +84,7 @@ public class OdeBsmJsonRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeBsmJsonRepositoryImpl(mongoTemplate, props);
+        repository = new OdeBsmJsonRepositoryImpl(mongoTemplate);
         objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
                                                                                                  // JavaTimeModule
     }
@@ -98,8 +94,6 @@ public class OdeBsmJsonRepositoryImplTest {
         OdeBsmJsonRepositoryImpl repo = mock(OdeBsmJsonRepositoryImpl.class);
         ArgumentCaptor<Criteria> criteriaCaptor = ArgumentCaptor.forClass(Criteria.class);
 
-        PageRequest pageRequest = PageRequest.of(0, 1);
-
         when(repo.findDocumentsWithPagination(
                 any(),
                 any(),
@@ -108,10 +102,10 @@ public class OdeBsmJsonRepositoryImplTest {
                 any(Sort.class),
                 any())).thenReturn(mockDocumentPage);
         doCallRealMethod().when(repo).find(originIp, vehicleId, startTime, endTime, longitude, latitude,
-                distance, pageRequest);
+                distance, 0, 1);
 
         repo.find(originIp, vehicleId, startTime, endTime, longitude, latitude,
-                distance, pageRequest);
+                distance, 0, 1);
 
         // Extract the captured Aggregation
         Criteria capturedCriteria = criteriaCaptor.getValue();
@@ -138,10 +132,10 @@ public class OdeBsmJsonRepositoryImplTest {
                 any())).thenReturn(mockDocumentPage);
 
         doCallRealMethod().when(repo).find(originIp, vehicleId, startTime, endTime, longitude, latitude,
-                distance, pageRequest);
+                distance, 0, 1);
 
         repo.find(originIp, vehicleId, startTime, endTime, longitude, latitude,
-                distance, pageRequest);
+                distance, 0, 1);
 
         // Extract the captured Aggregation
         Criteria capturedCriteria = criteriaCaptor.getValue();
@@ -208,10 +202,10 @@ public class OdeBsmJsonRepositoryImplTest {
                 any())).thenReturn(mockDocumentPage);
 
         doCallRealMethod().when(repo).find(originIp, vehicleId, startTime, endTime, null, null, null,
-                pageRequest);
+                0, 1);
 
         repo.find(originIp, vehicleId, startTime, endTime, null, null, null,
-                pageRequest);
+                0, 1);
 
         // Extract the captured Aggregation
         Criteria capturedCriteria = criteriaCaptor.getValue();
@@ -272,9 +266,9 @@ public class OdeBsmJsonRepositoryImplTest {
                 any(Sort.class),
                 any())).thenReturn(mockDocumentPage);
 
-        doCallRealMethod().when(repo).find(null, null, startTime, endTime, null, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(null, null, startTime, endTime, null, null, null, 0, 1);
 
-        repo.find(null, null, startTime, endTime, null, null, null, pageRequest);
+        repo.find(null, null, startTime, endTime, null, null, null, 0, 1);
 
         // Extract the captured Aggregation
         Criteria capturedCriteria = criteriaCaptor.getValue();
@@ -346,10 +340,8 @@ public class OdeBsmJsonRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
         Page<OdeBsmData> findResponse = repository.find(originIp, vehicleId, startTime, endTime, -104.1, 36.8,
-                50.0,
-                pageRequest);
+                50.0, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -59,6 +60,9 @@ public class OdeBsmJsonRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +88,7 @@ public class OdeBsmJsonRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeBsmJsonRepositoryImpl(mongoTemplate);
+        repository = new OdeBsmJsonRepositoryImpl(mongoTemplate, props);
         objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
                                                                                                  // JavaTimeModule
     }
@@ -279,7 +283,8 @@ public class OdeBsmJsonRepositoryImplTest {
         assertThat(capturedCriteria.getCriteriaObject().toJson())
                 .isEqualTo(String.format(
                         "{\"metadata.odeReceivedAt\": {\"$gte\": \"%s\", \"$lte\": \"%s\"}}",
-                        startTimeString, endTimeString)); // Verify the Criteria passed to findPage
+                        startTimeString, endTimeString)); // Verify the Criteria passed to
+                                                          // findPage
         Mockito.verify(repo).findDocumentsWithPagination(
                 any(),
                 any(),

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
@@ -28,12 +28,10 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.bsm_event.BsmEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -48,9 +46,6 @@ public class BsmEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @InjectMocks
     private BsmEventRepositoryImpl repository;
 
@@ -63,7 +58,7 @@ public class BsmEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new BsmEventRepositoryImpl(mongoTemplate, props);
+        repository = new BsmEventRepositoryImpl(mongoTemplate);
     }
 
     // @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
@@ -28,10 +28,12 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.bsm_event.BsmEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,6 +48,9 @@ public class BsmEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @InjectMocks
     private BsmEventRepositoryImpl repository;
 
@@ -58,7 +63,7 @@ public class BsmEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new BsmEventRepositoryImpl(mongoTemplate);
+        repository = new BsmEventRepositoryImpl(mongoTemplate, props);
     }
 
     // @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.connection_of_travel_event.ConnectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,6 +63,9 @@ public class ConnectionOfTravelEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -84,7 +88,7 @@ public class ConnectionOfTravelEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelEventRepositoryImpl(mongoTemplate);
+        repository = new ConnectionOfTravelEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/ConnectionOfTravelEventRepositoryImplTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.connection_of_travel_event.ConnectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class ConnectionOfTravelEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class ConnectionOfTravelEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelEventRepositoryImpl(mongoTemplate, props);
+        repository = new ConnectionOfTravelEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class ConnectionOfTravelEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(ConnectionOfTravelEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<ConnectionOfTravelEvent> results = repo.find(1, null, null, pageRequest);
+        Page<ConnectionOfTravelEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class ConnectionOfTravelEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<ConnectionOfTravelEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<ConnectionOfTravelEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
@@ -30,10 +30,12 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenceAlignmentEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.intersection_reference_alignment_event.IntersectionReferenceAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -47,6 +49,9 @@ public class IntersectionReferenceAlignmentEventRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<IntersectionReferenceAlignmentEvent> mockPage;
@@ -62,7 +67,7 @@ public class IntersectionReferenceAlignmentEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new IntersectionReferenceAlignmentEventRepositoryImpl(mongoTemplate);
+        repository = new IntersectionReferenceAlignmentEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/IntersectionReferenceAlignmentEventRepositoryImplTest.java
@@ -30,12 +30,10 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenceAlignmentEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.intersection_reference_alignment_event.IntersectionReferenceAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -49,9 +47,6 @@ public class IntersectionReferenceAlignmentEventRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<IntersectionReferenceAlignmentEvent> mockPage;
@@ -67,7 +62,7 @@ public class IntersectionReferenceAlignmentEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new IntersectionReferenceAlignmentEventRepositoryImpl(mongoTemplate, props);
+        repository = new IntersectionReferenceAlignmentEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -96,10 +91,9 @@ public class IntersectionReferenceAlignmentEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(IntersectionReferenceAlignmentEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<IntersectionReferenceAlignmentEvent> results = repo.find(1, null, null, pageRequest);
+        Page<IntersectionReferenceAlignmentEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.lane_direction_of_travel_event.LaneDirectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,6 +63,9 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -84,7 +88,7 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelEventRepositoryImpl(mongoTemplate);
+        repository = new LaneDirectionOfTravelEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/LaneDirectionOfTravelEventRepositoryImplTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.lane_direction_of_travel_event.LaneDirectionOfTravelEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelEventRepositoryImpl(mongoTemplate, props);
+        repository = new LaneDirectionOfTravelEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(LaneDirectionOfTravelEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<LaneDirectionOfTravelEvent> results = repo.find(1, null, null, pageRequest);
+        Page<LaneDirectionOfTravelEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class LaneDirectionOfTravelEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<LaneDirectionOfTravelEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<LaneDirectionOfTravelEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.map_broadcast_rate_event.MapBroadcastRateEventRepositoryImpl;
 
 @SpringBootTest
@@ -61,6 +62,9 @@ public class MapBroadcastRateEventRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +88,7 @@ public class MapBroadcastRateEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapBroadcastRateEventRepositoryImpl(mongoTemplate);
+        repository = new MapBroadcastRateEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapBroadcastRateEventRepositoryImplTest.java
@@ -51,7 +51,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.map_broadcast_rate_event.MapBroadcastRateEventRepositoryImpl;
 
 @SpringBootTest
@@ -62,9 +61,6 @@ public class MapBroadcastRateEventRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -88,7 +84,7 @@ public class MapBroadcastRateEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapBroadcastRateEventRepositoryImpl(mongoTemplate, props);
+        repository = new MapBroadcastRateEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class MapBroadcastRateEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(MapBroadcastRateEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<MapBroadcastRateEvent> results = repo.find(1, null, null, pageRequest);
+        Page<MapBroadcastRateEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,10 +177,7 @@ public class MapBroadcastRateEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<MapBroadcastRateEvent> findResponse = repository.find(intersectionID,
-                startTime, endTime,
-                pageRequest);
+        Page<MapBroadcastRateEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMinimumDataEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.map_minimum_data_event.MapMinimumDataEventRepositoryImpl;
 
 @SpringBootTest
@@ -61,6 +62,9 @@ public class MapMinimumDataEventRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +88,7 @@ public class MapMinimumDataEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapMinimumDataEventRepositoryImpl(mongoTemplate);
+        repository = new MapMinimumDataEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/MapMinimumDataEventRepositoryImplTest.java
@@ -51,7 +51,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMinimumDataEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.map_minimum_data_event.MapMinimumDataEventRepositoryImpl;
 
 @SpringBootTest
@@ -62,9 +61,6 @@ public class MapMinimumDataEventRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -88,7 +84,7 @@ public class MapMinimumDataEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapMinimumDataEventRepositoryImpl(mongoTemplate, props);
+        repository = new MapMinimumDataEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class MapMinimumDataEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(MapMinimumDataEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<MapMinimumDataEvent> results = repo.find(1, null, null, pageRequest);
+        Page<MapMinimumDataEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class MapMinimumDataEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<MapMinimumDataEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<MapMinimumDataEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
@@ -29,12 +29,10 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.signal_group_alignment_event.SignalGroupAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -50,9 +48,6 @@ public class SignalGroupAlignmentEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private Page<SignalGroupAlignmentEvent> mockPage;
 
@@ -67,7 +62,7 @@ public class SignalGroupAlignmentEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalGroupAlignmentEventRepositoryImpl(mongoTemplate, props);
+        repository = new SignalGroupAlignmentEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -95,10 +90,9 @@ public class SignalGroupAlignmentEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SignalGroupAlignmentEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SignalGroupAlignmentEvent> results = repo.find(1, null, null, pageRequest);
+        Page<SignalGroupAlignmentEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalGroupAlignmentEventRepositoryImplTest.java
@@ -29,10 +29,12 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.signal_group_alignment_event.SignalGroupAlignmentEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -48,6 +50,9 @@ public class SignalGroupAlignmentEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private Page<SignalGroupAlignmentEvent> mockPage;
 
@@ -62,7 +67,7 @@ public class SignalGroupAlignmentEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalGroupAlignmentEventRepositoryImpl(mongoTemplate);
+        repository = new SignalGroupAlignmentEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.signal_state_conflict_event.SignalStateConflictEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,6 +63,9 @@ public class SignalStateConflictEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -84,7 +88,7 @@ public class SignalStateConflictEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalStateConflictEventRepositoryImpl(mongoTemplate);
+        repository = new SignalStateConflictEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SignalStateConflictEventRepositoryImplTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.signal_state_conflict_event.SignalStateConflictEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class SignalStateConflictEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class SignalStateConflictEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalStateConflictEventRepositoryImpl(mongoTemplate, props);
+        repository = new SignalStateConflictEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class SignalStateConflictEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SignalStateConflictEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SignalStateConflictEvent> results = repo.find(1, null, null, pageRequest);
+        Page<SignalStateConflictEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class SignalStateConflictEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<SignalStateConflictEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<SignalStateConflictEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatBroadcastRateEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.spat_broadcast_rate_event.SpatBroadcastRateEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class SpatBroadcastRateRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class SpatBroadcastRateRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatBroadcastRateEventRepositoryImpl(mongoTemplate, props);
+        repository = new SpatBroadcastRateEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class SpatBroadcastRateRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SpatBroadcastRateEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SpatBroadcastRateEvent> results = repo.find(1, null, null, pageRequest);
+        Page<SpatBroadcastRateEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class SpatBroadcastRateRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<SpatBroadcastRateEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<SpatBroadcastRateEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatBroadcastRateRepositoryImplTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatBroadcastRateEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.spat_broadcast_rate_event.SpatBroadcastRateEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,6 +63,9 @@ public class SpatBroadcastRateRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -84,7 +88,7 @@ public class SpatBroadcastRateRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatBroadcastRateEventRepositoryImpl(mongoTemplate);
+        repository = new SpatBroadcastRateEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.spat_minimum_data_event.SpatMinimumDataEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class SpatMinimumDataEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class SpatMinimumDataEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatMinimumDataEventRepositoryImpl(mongoTemplate, props);
+        repository = new SpatMinimumDataEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -116,10 +112,9 @@ public class SpatMinimumDataEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SpatMinimumDataEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SpatMinimumDataEvent> results = repo.find(1, null, null, pageRequest);
+        Page<SpatMinimumDataEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -182,9 +177,7 @@ public class SpatMinimumDataEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<SpatMinimumDataEvent> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<SpatMinimumDataEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/SpatMinimumDataEventRepositoryImplTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.spat_minimum_data_event.SpatMinimumDataEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,6 +63,9 @@ public class SpatMinimumDataEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -84,7 +88,7 @@ public class SpatMinimumDataEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatMinimumDataEventRepositoryImpl(mongoTemplate);
+        repository = new SpatMinimumDataEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLinePassageEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLinePassageEventRepositoryImplTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.stop_line_passage_event.StopLinePassageEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -59,162 +60,165 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 @AutoConfigureEmbeddedDatabase
 public class StopLinePassageEventRepositoryImplTest {
 
-        @SpyBean
-        private MongoTemplate mongoTemplate;
+    @SpyBean
+    private MongoTemplate mongoTemplate;
 
-        @Mock
-        private AggregationResults<AggregationResult> mockAggregationResult;
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
-        @Mock
-        private Page<Document> mockDocumentPage;
+    @Mock
+    private AggregationResults<AggregationResult> mockAggregationResult;
 
-        @Mock
-        private Page<StopLinePassageEvent> mockPage;
+    @Mock
+    private Page<Document> mockDocumentPage;
 
-        @InjectMocks
-        private StopLinePassageEventRepositoryImpl repository;
+    @Mock
+    private Page<StopLinePassageEvent> mockPage;
 
-        Integer intersectionID = 123;
-        Long startTime = 1724170658205L;
-        String startTimeString = "2024-08-20T16:17:38.205Z";
-        Long endTime = 1724170778205L;
-        String endTimeString = "2024-08-20T16:19:38.205Z";
-        boolean latest = true;
+    @InjectMocks
+    private StopLinePassageEventRepositoryImpl repository;
 
-        @BeforeEach
-        void setUp() {
-                MockitoAnnotations.openMocks(this);
-                repository = new StopLinePassageEventRepositoryImpl(mongoTemplate);
-        }
+    Integer intersectionID = 123;
+    Long startTime = 1724170658205L;
+    String startTimeString = "2024-08-20T16:17:38.205Z";
+    Long endTime = 1724170778205L;
+    String endTimeString = "2024-08-20T16:19:38.205Z";
+    boolean latest = true;
 
-        @Test
-        public void testCount() {
-                long expectedCount = 10;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        repository = new StopLinePassageEventRepositoryImpl(mongoTemplate, props);
+    }
 
-                doReturn(expectedCount).when(mongoTemplate).count(any(),
-                                Mockito.<String>any());
+    @Test
+    public void testCount() {
+        long expectedCount = 10;
 
-                long resultCount = repository.count(1, null, null);
+        doReturn(expectedCount).when(mongoTemplate).count(any(),
+                Mockito.<String>any());
 
-                assertThat(resultCount).isEqualTo(expectedCount);
-                verify(mongoTemplate).count(any(Query.class), anyString());
-        }
+        long resultCount = repository.count(1, null, null);
 
-        @Test
+        assertThat(resultCount).isEqualTo(expectedCount);
+        verify(mongoTemplate).count(any(Query.class), anyString());
+    }
 
-        public void testFind() {
-                StopLinePassageEventRepositoryImpl repo = mock(StopLinePassageEventRepositoryImpl.class);
+    @Test
 
-                when(repo.findPage(
-                                any(),
-                                any(),
-                                any(PageRequest.class),
-                                any(Criteria.class),
-                                any(Sort.class),
-                                any(),
-                                eq(StopLinePassageEvent.class))).thenReturn(mockPage);
-                PageRequest pageRequest = PageRequest.of(0, 1);
-                doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+    public void testFind() {
+        StopLinePassageEventRepositoryImpl repo = mock(StopLinePassageEventRepositoryImpl.class);
 
-                Page<StopLinePassageEvent> results = repo.find(1, null, null, pageRequest);
+        when(repo.findPage(
+                any(),
+                any(),
+                any(PageRequest.class),
+                any(Criteria.class),
+                any(Sort.class),
+                any(),
+                eq(StopLinePassageEvent.class))).thenReturn(mockPage);
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
 
-                assertThat(results).isEqualTo(mockPage);
-        }
+        Page<StopLinePassageEvent> results = repo.find(1, null, null, pageRequest);
 
-        @Test
-        public void testGetStopLinePassageEventsByDay() {
+        assertThat(results).isEqualTo(mockPage);
+    }
 
-                List<IDCount> aggregatedResults = new ArrayList<>();
-                IDCount result1 = new IDCount();
-                result1.setId("2023-06-26");
-                result1.setCount(3600);
-                IDCount result2 = new IDCount();
-                result2.setId("2023-06-26");
-                result2.setCount(7200);
-                aggregatedResults.add(result1);
-                aggregatedResults.add(result2);
+    @Test
+    public void testGetStopLinePassageEventsByDay() {
 
-                AggregationResults<IDCount> aggregationResults = new AggregationResults<>(aggregatedResults,
-                                new Document());
-                doReturn(aggregationResults).when(
-                                mongoTemplate)
-                                .aggregate(Mockito.any(Aggregation.class), Mockito.anyString(),
-                                                Mockito.eq(IDCount.class));
+        List<IDCount> aggregatedResults = new ArrayList<>();
+        IDCount result1 = new IDCount();
+        result1.setId("2023-06-26");
+        result1.setCount(3600);
+        IDCount result2 = new IDCount();
+        result2.setId("2023-06-26");
+        result2.setCount(7200);
+        aggregatedResults.add(result1);
+        aggregatedResults.add(result2);
 
-                List<IDCount> actualResults = repository.getAggregatedDailyStopLinePassageEventCounts(intersectionID,
-                                startTime,
-                                endTime);
+        AggregationResults<IDCount> aggregationResults = new AggregationResults<>(aggregatedResults,
+                new Document());
+        doReturn(aggregationResults).when(
+                mongoTemplate)
+                .aggregate(Mockito.any(Aggregation.class), Mockito.anyString(),
+                        Mockito.eq(IDCount.class));
 
-                assertThat(actualResults.size()).isEqualTo(2);
-                assertThat(actualResults.get(0).getId()).isEqualTo("2023-06-26");
-                assertThat(actualResults.get(0).getCount()).isEqualTo(3600);
-                assertThat(actualResults.get(1).getId()).isEqualTo("2023-06-26");
-                assertThat(actualResults.get(1).getCount()).isEqualTo(7200);
-        }
+        List<IDCount> actualResults = repository.getAggregatedDailyStopLinePassageEventCounts(intersectionID,
+                startTime,
+                endTime);
 
-        @Test
-        public void testFindWithData() throws IOException {
-                // Load sample JSON data
-                String json = new String(
-                                Files.readAllBytes(
-                                                Paths.get("src/test/resources/json/ConflictMonitor.CmStopLinePassageEvent.json")));
-                ObjectMapper objectMapper = new ObjectMapper();
-                objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
-                // JavaTimeModule
+        assertThat(actualResults.size()).isEqualTo(2);
+        assertThat(actualResults.get(0).getId()).isEqualTo("2023-06-26");
+        assertThat(actualResults.get(0).getCount()).isEqualTo(3600);
+        assertThat(actualResults.get(1).getId()).isEqualTo("2023-06-26");
+        assertThat(actualResults.get(1).getCount()).isEqualTo(7200);
+    }
 
-                List<Document> sampleDocuments = List.of(Document.parse(json));
+    @Test
+    public void testFindWithData() throws IOException {
+        // Load sample JSON data
+        String json = new String(
+                Files.readAllBytes(
+                        Paths.get("src/test/resources/json/ConflictMonitor.CmStopLinePassageEvent.json")));
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule()); // Register
+        // JavaTimeModule
 
-                // Mock dependencies
-                when(mockDocumentPage.getContent()).thenReturn(sampleDocuments);
-                when(mockDocumentPage.getTotalElements()).thenReturn(1L);
+        List<Document> sampleDocuments = List.of(Document.parse(json));
 
-                AggregationResult aggregationResult = new AggregationResult();
-                aggregationResult.setResults(sampleDocuments);
-                AggregationResultCount aggregationResultCount = new AggregationResultCount();
-                aggregationResultCount.setCount(1L);
-                aggregationResult.setMetadata(List.of(aggregationResultCount));
+        // Mock dependencies
+        when(mockDocumentPage.getContent()).thenReturn(sampleDocuments);
+        when(mockDocumentPage.getTotalElements()).thenReturn(1L);
 
-                when(mockAggregationResult.getUniqueMappedResult()).thenReturn(aggregationResult);
+        AggregationResult aggregationResult = new AggregationResult();
+        aggregationResult.setResults(sampleDocuments);
+        AggregationResultCount aggregationResultCount = new AggregationResultCount();
+        aggregationResultCount.setCount(1L);
+        aggregationResult.setMetadata(List.of(aggregationResultCount));
 
-                ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
-                doReturn(mockAggregationResult).when(mongoTemplate).aggregate(aggregationCaptor.capture(),
-                                anyString(),
-                                eq(AggregationResult.class));
+        when(mockAggregationResult.getUniqueMappedResult()).thenReturn(aggregationResult);
 
-                // Call the repository find method
-                PageRequest pageRequest = PageRequest.of(0, 1);
-                Page<StopLinePassageEvent> findResponse = repository.find(intersectionID,
-                                startTime, endTime,
-                                pageRequest);
+        ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
+        doReturn(mockAggregationResult).when(mongoTemplate).aggregate(aggregationCaptor.capture(),
+                anyString(),
+                eq(AggregationResult.class));
 
-                // Extract the captured Aggregation
-                Aggregation capturedAggregation = aggregationCaptor.getValue();
+        // Call the repository find method
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        Page<StopLinePassageEvent> findResponse = repository.find(intersectionID,
+                startTime, endTime,
+                pageRequest);
 
-                // Extract the MatchOperation from the Aggregation pipeline
-                Document pipeline = capturedAggregation.toPipeline(Aggregation.DEFAULT_CONTEXT).get(0);
+        // Extract the captured Aggregation
+        Aggregation capturedAggregation = aggregationCaptor.getValue();
 
-                // Assert the Match operation Criteria
-                assertThat(pipeline.toJson())
-                                .isEqualTo(String.format(
-                                                "{\"$match\": {\"intersectionID\": %s, \"eventGeneratedAt\": {\"$gte\": {\"$date\": \"%s\"}, \"$lte\": {\"$date\": \"%s\"}}}}",
-                                                intersectionID, startTimeString, endTimeString));
+        // Extract the MatchOperation from the Aggregation pipeline
+        Document pipeline = capturedAggregation.toPipeline(Aggregation.DEFAULT_CONTEXT).get(0);
 
-                // Serialize results to JSON and compare with the original JSON
-                String resultJson = objectMapper.writeValueAsString(findResponse.getContent().get(0));
+        // Assert the Match operation Criteria
+        assertThat(pipeline.toJson())
+                .isEqualTo(String.format(
+                        "{\"$match\": {\"intersectionID\": %s, \"eventGeneratedAt\": {\"$gte\": {\"$date\": \"%s\"}, \"$lte\": {\"$date\": \"%s\"}}}}",
+                        intersectionID, startTimeString, endTimeString));
 
-                // Remove unused fields from each entry
-                List<Document> expectedResult = sampleDocuments.stream().map(doc -> {
-                        doc.remove("_id");
-                        doc.remove("recordGeneratedAt");
-                        return doc;
-                }).toList();
-                String expectedJson = objectMapper.writeValueAsString(expectedResult.get(0));
+        // Serialize results to JSON and compare with the original JSON
+        String resultJson = objectMapper.writeValueAsString(findResponse.getContent().get(0));
 
-                // Compare JSON with ignored fields
-                JSONAssert.assertEquals(expectedJson, resultJson, new CustomComparator(
-                                JSONCompareMode.LENIENT, // Allows different key orders
-                                new Customization("properties.timeStamp", (o1, o2) -> true),
-                                new Customization("properties.odeReceivedAt", (o1, o2) -> true)));
-        }
+        // Remove unused fields from each entry
+        List<Document> expectedResult = sampleDocuments.stream().map(doc -> {
+            doc.remove("_id");
+            doc.remove("recordGeneratedAt");
+            return doc;
+        }).toList();
+        String expectedJson = objectMapper.writeValueAsString(expectedResult.get(0));
+
+        // Compare JSON with ignored fields
+        JSONAssert.assertEquals(expectedJson, resultJson, new CustomComparator(
+                JSONCompareMode.LENIENT, // Allows different key orders
+                new Customization("properties.timeStamp", (o1, o2) -> true),
+                new Customization("properties.odeReceivedAt", (o1, o2) -> true)));
+    }
 
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLinePassageEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLinePassageEventRepositoryImplTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.stop_line_passage_event.StopLinePassageEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -63,9 +62,6 @@ public class StopLinePassageEventRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -88,7 +84,7 @@ public class StopLinePassageEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLinePassageEventRepositoryImpl(mongoTemplate, props);
+        repository = new StopLinePassageEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -117,10 +113,9 @@ public class StopLinePassageEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLinePassageEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLinePassageEvent> results = repo.find(1, null, null, pageRequest);
+        Page<StopLinePassageEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -186,10 +181,7 @@ public class StopLinePassageEventRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<StopLinePassageEvent> findResponse = repository.find(intersectionID,
-                startTime, endTime,
-                pageRequest);
+        Page<StopLinePassageEvent> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLineStopEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLineStopEventRepositoryImplTest.java
@@ -29,10 +29,12 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.stop_line_stop_event.StopLineStopEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -45,89 +47,92 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLineStopEvent;
 @AutoConfigureEmbeddedDatabase
 public class StopLineStopEventRepositoryImplTest {
 
-        @Mock
-        private MongoTemplate mongoTemplate;
+    @Mock
+    private MongoTemplate mongoTemplate;
 
-        @Mock
-        private Page<StopLineStopEvent> mockPage;
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
-        @InjectMocks
-        private StopLineStopEventRepositoryImpl repository;
+    @Mock
+    private Page<StopLineStopEvent> mockPage;
 
-        Integer intersectionID = 123;
-        Long startTime = 1624640400000L; // June 26, 2021 00:00:00 GMT
-        Long endTime = 1624726799000L; // June 26, 2021 23:59:59 GMT
-        boolean latest = true;
+    @InjectMocks
+    private StopLineStopEventRepositoryImpl repository;
 
-        @BeforeEach
-        void setUp() {
-                MockitoAnnotations.openMocks(this);
-                repository = new StopLineStopEventRepositoryImpl(mongoTemplate);
-        }
+    Integer intersectionID = 123;
+    Long startTime = 1624640400000L; // June 26, 2021 00:00:00 GMT
+    Long endTime = 1624726799000L; // June 26, 2021 23:59:59 GMT
+    boolean latest = true;
 
-        @Test
-        public void testCount() {
-                long expectedCount = 10;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        repository = new StopLineStopEventRepositoryImpl(mongoTemplate, props);
+    }
 
-                when(mongoTemplate.count(any(),
-                                Mockito.<String>any())).thenReturn(expectedCount);
+    @Test
+    public void testCount() {
+        long expectedCount = 10;
 
-                long resultCount = repository.count(1, null, null);
+        when(mongoTemplate.count(any(),
+                Mockito.<String>any())).thenReturn(expectedCount);
 
-                assertThat(resultCount).isEqualTo(expectedCount);
-                verify(mongoTemplate).count(any(Query.class), anyString());
-        }
+        long resultCount = repository.count(1, null, null);
 
-        @Test
+        assertThat(resultCount).isEqualTo(expectedCount);
+        verify(mongoTemplate).count(any(Query.class), anyString());
+    }
 
-        public void testFind() {
-                StopLineStopEventRepositoryImpl repo = mock(StopLineStopEventRepositoryImpl.class);
+    @Test
 
-                when(repo.findPage(
-                                any(),
-                                any(),
-                                any(PageRequest.class),
-                                any(Criteria.class),
-                                any(Sort.class),
-                                any(),
-                                eq(StopLineStopEvent.class))).thenReturn(mockPage);
-                PageRequest pageRequest = PageRequest.of(0, 1);
-                doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+    public void testFind() {
+        StopLineStopEventRepositoryImpl repo = mock(StopLineStopEventRepositoryImpl.class);
 
-                Page<StopLineStopEvent> results = repo.find(1, null, null, pageRequest);
+        when(repo.findPage(
+                any(),
+                any(),
+                any(PageRequest.class),
+                any(Criteria.class),
+                any(Sort.class),
+                any(),
+                eq(StopLineStopEvent.class))).thenReturn(mockPage);
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
 
-                assertThat(results).isEqualTo(mockPage);
-        }
+        Page<StopLineStopEvent> results = repo.find(1, null, null, pageRequest);
 
-        @Test
-        public void testGetStopLineStopEventEventsByDay() {
+        assertThat(results).isEqualTo(mockPage);
+    }
 
-                List<IDCount> aggregatedResults = new ArrayList<>();
-                IDCount result1 = new IDCount();
-                result1.setId("2023-06-26");
-                result1.setCount(3600);
-                IDCount result2 = new IDCount();
-                result2.setId("2023-06-26");
-                result2.setCount(7200);
-                aggregatedResults.add(result1);
-                aggregatedResults.add(result2);
+    @Test
+    public void testGetStopLineStopEventEventsByDay() {
 
-                AggregationResults<IDCount> aggregationResults = new AggregationResults<>(aggregatedResults,
-                                new Document());
-                Mockito.when(
-                                mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(),
-                                                Mockito.eq(IDCount.class)))
-                                .thenReturn(aggregationResults);
+        List<IDCount> aggregatedResults = new ArrayList<>();
+        IDCount result1 = new IDCount();
+        result1.setId("2023-06-26");
+        result1.setCount(3600);
+        IDCount result2 = new IDCount();
+        result2.setId("2023-06-26");
+        result2.setCount(7200);
+        aggregatedResults.add(result1);
+        aggregatedResults.add(result2);
 
-                List<IDCount> actualResults = repository.getAggregatedDailyStopLineStopEventCounts(intersectionID,
-                                startTime,
-                                endTime);
+        AggregationResults<IDCount> aggregationResults = new AggregationResults<>(aggregatedResults,
+                new Document());
+        Mockito.when(
+                mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(),
+                        Mockito.eq(IDCount.class)))
+                .thenReturn(aggregationResults);
 
-                assertThat(actualResults.size()).isEqualTo(2);
-                assertThat(actualResults.get(0).getId()).isEqualTo("2023-06-26");
-                assertThat(actualResults.get(0).getCount()).isEqualTo(3600);
-                assertThat(actualResults.get(1).getId()).isEqualTo("2023-06-26");
-                assertThat(actualResults.get(1).getCount()).isEqualTo(7200);
-        }
+        List<IDCount> actualResults = repository.getAggregatedDailyStopLineStopEventCounts(intersectionID,
+                startTime,
+                endTime);
+
+        assertThat(actualResults.size()).isEqualTo(2);
+        assertThat(actualResults.get(0).getId()).isEqualTo("2023-06-26");
+        assertThat(actualResults.get(0).getCount()).isEqualTo(3600);
+        assertThat(actualResults.get(1).getId()).isEqualTo("2023-06-26");
+        assertThat(actualResults.get(1).getCount()).isEqualTo(7200);
+    }
 
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLineStopEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/StopLineStopEventRepositoryImplTest.java
@@ -29,12 +29,10 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.stop_line_stop_event.StopLineStopEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -50,9 +48,6 @@ public class StopLineStopEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private Page<StopLineStopEvent> mockPage;
 
@@ -67,7 +62,7 @@ public class StopLineStopEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLineStopEventRepositoryImpl(mongoTemplate, props);
+        repository = new StopLineStopEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -96,10 +91,9 @@ public class StopLineStopEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLineStopEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLineStopEvent> results = repo.find(1, null, null, pageRequest);
+        Page<StopLineStopEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
@@ -29,12 +29,10 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.time_change_details_event.TimeChangeDetailsEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -50,9 +48,6 @@ public class TimeChangeDetailsEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private Page<TimeChangeDetailsEvent> mockPage;
 
@@ -67,7 +62,7 @@ public class TimeChangeDetailsEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new TimeChangeDetailsEventRepositoryImpl(mongoTemplate, props);
+        repository = new TimeChangeDetailsEventRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -95,10 +90,9 @@ public class TimeChangeDetailsEventRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(TimeChangeDetailsEvent.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<TimeChangeDetailsEvent> results = repo.find(1, null, null, pageRequest);
+        Page<TimeChangeDetailsEvent> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/TimeChangeDetailsEventRepositoryImplTest.java
@@ -29,10 +29,12 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.events.time_change_details_event.TimeChangeDetailsEventRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.IDCount;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -48,6 +50,9 @@ public class TimeChangeDetailsEventRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private Page<TimeChangeDetailsEvent> mockPage;
 
@@ -62,7 +67,7 @@ public class TimeChangeDetailsEventRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new TimeChangeDetailsEventRepositoryImpl(mongoTemplate);
+        repository = new TimeChangeDetailsEventRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/haas/HaasLocationDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/haas/HaasLocationDataRepositoryImplTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.haas.HaasLocationDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocation;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocationResult;
@@ -30,136 +32,139 @@ import us.dot.its.jpo.ode.mockdata.MockHaasGenerator;
 @ExtendWith(MockitoExtension.class)
 public class HaasLocationDataRepositoryImplTest {
 
-        @Mock
-        private MongoTemplate mongoTemplate;
+    @Mock
+    private MongoTemplate mongoTemplate;
 
-        private HaasLocationDataRepositoryImpl repository;
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
-        @BeforeEach
-        void setUp() {
-                repository = new HaasLocationDataRepositoryImpl(mongoTemplate);
-        }
+    private HaasLocationDataRepositoryImpl repository;
 
-        @Test
-        void testFindWithLimit_ActiveOnly() {
-                boolean activeOnly = true;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                int limit = 10;
+    @BeforeEach
+    void setUp() {
+        repository = new HaasLocationDataRepositoryImpl(mongoTemplate, props);
+    }
 
-                List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
-                AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
-                                new Document());
-                AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
-                                new Document());
+    @Test
+    void testFindWithLimit_ActiveOnly() {
+        boolean activeOnly = true;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        int limit = 10;
 
-                // Stub both aggregate calls that happen when activeOnly = true
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
-                                .thenReturn(mockMainResults);
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
-                                .thenReturn(mockInactiveResults);
+        List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
+        AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
+                new Document());
+        AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
+                new Document());
 
-                HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
+        // Stub both aggregate calls that happen when activeOnly = true
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
+                .thenReturn(mockMainResults);
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
+                .thenReturn(mockInactiveResults);
 
-                assertNotNull(result);
-                assertEquals(mockLocations.size(), result.getLocations().size());
-                assertFalse(result.isHasMoreResults());
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
-                                eq(HaasLocation.class));
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
-        }
+        HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
 
-        @Test
-        void testFindWithLimit_NotActiveOnly() {
-                boolean activeOnly = false;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                int limit = 5;
+        assertNotNull(result);
+        assertEquals(mockLocations.size(), result.getLocations().size());
+        assertFalse(result.isHasMoreResults());
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
+                eq(HaasLocation.class));
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
+    }
 
-                List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
-                AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
-                                new Document());
+    @Test
+    void testFindWithLimit_NotActiveOnly() {
+        boolean activeOnly = false;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        int limit = 5;
 
-                // When activeOnly = false, only one aggregate call is made
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
-                                .thenReturn(mockMainResults);
+        List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
+        AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
+                new Document());
 
-                HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
+        // When activeOnly = false, only one aggregate call is made
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
+                .thenReturn(mockMainResults);
 
-                assertNotNull(result);
-                assertEquals(mockLocations.size(), result.getLocations().size());
-                assertFalse(result.isHasMoreResults());
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
-                                eq(HaasLocation.class));
-        }
+        HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
 
-        @Test
-        void testFindWithLimit_WithTruncation() {
-                boolean activeOnly = true;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                int limit = 1;
+        assertNotNull(result);
+        assertEquals(mockLocations.size(), result.getLocations().size());
+        assertFalse(result.isHasMoreResults());
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
+                eq(HaasLocation.class));
+    }
 
-                List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
-                // Add one more location than the limit to simulate truncation
-                mockLocations.add(MockHaasGenerator.getHaasLocations().get(0));
+    @Test
+    void testFindWithLimit_WithTruncation() {
+        boolean activeOnly = true;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        int limit = 1;
 
-                AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
-                                new Document());
-                AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
-                                new Document());
+        List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
+        // Add one more location than the limit to simulate truncation
+        mockLocations.add(MockHaasGenerator.getHaasLocations().get(0));
 
-                // Stub both aggregate calls that happen when activeOnly = true
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
-                                .thenReturn(mockMainResults);
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
-                                .thenReturn(mockInactiveResults);
+        AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
+                new Document());
+        AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
+                new Document());
 
-                HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
+        // Stub both aggregate calls that happen when activeOnly = true
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
+                .thenReturn(mockMainResults);
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
+                .thenReturn(mockInactiveResults);
 
-                assertNotNull(result);
-                assertEquals(limit, result.getLocations().size());
-                assertTrue(result.isHasMoreResults());
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
-                                eq(HaasLocation.class));
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
-        }
+        HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
 
-        @Test
-        void testAdd() {
-                HaasLocation location = MockHaasGenerator.getHaasLocations().getFirst();
+        assertNotNull(result);
+        assertEquals(limit, result.getLocations().size());
+        assertTrue(result.isHasMoreResults());
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
+                eq(HaasLocation.class));
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
+    }
 
-                repository.add(location);
+    @Test
+    void testAdd() {
+        HaasLocation location = MockHaasGenerator.getHaasLocations().getFirst();
 
-                verify(mongoTemplate).insert(location, "HaasAlertLocation");
-        }
+        repository.add(location);
 
-        @Test
-        void testFindWithLimit_NoTimeWindow() {
-                boolean activeOnly = true;
-                Long startTime = null;
-                Long endTime = null;
-                int limit = 10;
+        verify(mongoTemplate).insert(location, "HaasAlertLocation");
+    }
 
-                List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
-                AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
-                                new Document());
-                AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
-                                new Document());
+    @Test
+    void testFindWithLimit_NoTimeWindow() {
+        boolean activeOnly = true;
+        Long startTime = null;
+        Long endTime = null;
+        int limit = 10;
 
-                // Stub both aggregate calls that happen when activeOnly = true
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
-                                .thenReturn(mockMainResults);
-                when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
-                                .thenReturn(mockInactiveResults);
+        List<HaasLocation> mockLocations = MockHaasGenerator.getHaasLocations();
+        AggregationResults<HaasLocation> mockMainResults = new AggregationResults<>(mockLocations,
+                new Document());
+        AggregationResults<Document> mockInactiveResults = new AggregationResults<>(new ArrayList<>(),
+                new Document());
 
-                HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
+        // Stub both aggregate calls that happen when activeOnly = true
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(HaasLocation.class)))
+                .thenReturn(mockMainResults);
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class)))
+                .thenReturn(mockInactiveResults);
 
-                assertNotNull(result);
-                assertEquals(mockLocations.size(), result.getLocations().size());
-                assertFalse(result.isHasMoreResults());
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
-                                eq(HaasLocation.class));
-                verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
-        }
+        HaasLocationResult result = repository.findWithLimit(activeOnly, startTime, endTime, limit);
+
+        assertNotNull(result);
+        assertEquals(mockLocations.size(), result.getLocations().size());
+        assertFalse(result.isHasMoreResults());
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"),
+                eq(HaasLocation.class));
+        verify(mongoTemplate).aggregate(any(Aggregation.class), eq("HaasAlertLocation"), eq(Document.class));
+    }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/haas/HaasLocationDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/haas/HaasLocationDataRepositoryImplTest.java
@@ -18,12 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.haas.HaasLocationDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocation;
 import us.dot.its.jpo.ode.api.models.haas.HaasLocationResult;
@@ -35,14 +33,11 @@ public class HaasLocationDataRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     private HaasLocationDataRepositoryImpl repository;
 
     @BeforeEach
     void setUp() {
-        repository = new HaasLocationDataRepositoryImpl(mongoTemplate, props);
+        repository = new HaasLocationDataRepositoryImpl(mongoTemplate);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.map.OdeMapDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.model.OdeMapData;
@@ -44,6 +45,9 @@ public class OdeMapDataRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -66,7 +70,7 @@ public class OdeMapDataRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeMapDataRepositoryImpl(mongoTemplate);
+        repository = new OdeMapDataRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.map.OdeMapDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.model.OdeMapData;
@@ -45,9 +44,6 @@ public class OdeMapDataRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -70,7 +66,7 @@ public class OdeMapDataRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeMapDataRepositoryImpl(mongoTemplate, props);
+        repository = new OdeMapDataRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -98,10 +94,9 @@ public class OdeMapDataRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(OdeMapData.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<OdeMapData> results = repo.find(1, null, null, pageRequest);
+        Page<OdeMapData> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
@@ -13,7 +13,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Query;
@@ -35,7 +34,6 @@ import org.bson.Document;
 
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.map.ProcessedMapRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -60,9 +58,6 @@ public class ProcessedMapRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -81,7 +76,7 @@ public class ProcessedMapRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ProcessedMapRepositoryImpl(mongoTemplate, props);
+        repository = new ProcessedMapRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -127,9 +122,7 @@ public class ProcessedMapRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<ProcessedMap<LineString>> findResponse = repository.find(intersectionID, startTime, endTime,
-                false, pageRequest);
+        Page<ProcessedMap<LineString>> findResponse = repository.find(intersectionID, startTime, endTime, false, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
@@ -35,6 +35,7 @@ import org.bson.Document;
 
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.map.ProcessedMapRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -59,6 +60,9 @@ public class ProcessedMapRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -77,7 +81,7 @@ public class ProcessedMapRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ProcessedMapRepositoryImpl(mongoTemplate);
+        repository = new ProcessedMapRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -40,7 +39,6 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAl
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.app_health.KafkaStreamsAnomalyNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.active_notification.ActiveNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -52,9 +50,6 @@ public class ActiveNotificationRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @InjectMocks
     private ActiveNotificationRepositoryImpl repository;
 
@@ -65,7 +60,7 @@ public class ActiveNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ActiveNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new ActiveNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -84,7 +79,7 @@ public class ActiveNotificationRepositoryImplTest {
     @Test
     public void testFindWithAllNotificationTypes() {
         MongoTemplate mockMongoTemplate = mock(MongoTemplate.class);
-        ActiveNotificationRepositoryImpl repo = spy(new ActiveNotificationRepositoryImpl(mockMongoTemplate, props));
+        ActiveNotificationRepositoryImpl repo = spy(new ActiveNotificationRepositoryImpl(mockMongoTemplate));
 
         // Arrange
         PageRequest pageable = PageRequest.of(0, 10);
@@ -160,7 +155,7 @@ public class ActiveNotificationRepositoryImplTest {
                 any(), any(), any());
 
         // Act
-        Page<Notification> result = repo.find(null, null, null, pageable);
+        Page<Notification> result = repo.find(null, null, null, 0, 1);
 
         // Assert
         assertThat(result.getContent()).hasSize(7);

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -39,6 +40,7 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAl
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.app_health.KafkaStreamsAnomalyNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.active_notification.ActiveNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -50,6 +52,9 @@ public class ActiveNotificationRepositoryImplTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @InjectMocks
     private ActiveNotificationRepositoryImpl repository;
 
@@ -60,7 +65,7 @@ public class ActiveNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ActiveNotificationRepositoryImpl(mongoTemplate);
+        repository = new ActiveNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test
@@ -79,7 +84,7 @@ public class ActiveNotificationRepositoryImplTest {
     @Test
     public void testFindWithAllNotificationTypes() {
         MongoTemplate mockMongoTemplate = mock(MongoTemplate.class);
-        ActiveNotificationRepositoryImpl repo = spy(new ActiveNotificationRepositoryImpl(mockMongoTemplate));
+        ActiveNotificationRepositoryImpl repo = spy(new ActiveNotificationRepositoryImpl(mockMongoTemplate, props));
 
         // Arrange
         PageRequest pageable = PageRequest.of(0, 10);

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ActiveNotificationRepositoryImplTest.java
@@ -13,6 +13,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
@@ -151,7 +152,8 @@ public class ActiveNotificationRepositoryImplTest {
                 any(Document.class)))
                 .thenReturn(new KafkaStreamsAnomalyNotification());
 
-        doReturn(dbObjects).when(repo).findDocumentsWithPagination(eq(mockMongoTemplate), anyString(), eq(pageable),
+        doReturn(dbObjects).when(repo).findDocumentsWithPagination(eq(mockMongoTemplate), anyString(),
+                any(Pageable.class),
                 any(), any(), any());
 
         // Act
@@ -167,6 +169,6 @@ public class ActiveNotificationRepositoryImplTest {
         assertThat(result.getContent().get(5)).isInstanceOf(TimeChangeDetailsNotification.class);
         assertThat(result.getContent().get(6)).isInstanceOf(KafkaStreamsAnomalyNotification.class);
 
-        verify(repo).findDocumentsWithPagination(any(), any(), eq(pageable), any(), any(), any());
+        verify(repo).findDocumentsWithPagination(any(), any(), any(Pageable.class), any(), any(), any());
     }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.connection_of_travel_notification.ConnectionOfTravelNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -62,9 +61,6 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -87,7 +83,7 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new ConnectionOfTravelNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -115,10 +111,9 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(ConnectionOfTravelNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<ConnectionOfTravelNotification> results = repo.find(1, null, null, pageRequest);
+        Page<ConnectionOfTravelNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -153,9 +148,7 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<ConnectionOfTravelNotification> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<ConnectionOfTravelNotification> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/ConnectionOfTravelNotificationRepositoryImplTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.connection_of_travel_notification.ConnectionOfTravelNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -61,6 +62,9 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -83,7 +87,7 @@ public class ConnectionOfTravelNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        repository = new ConnectionOfTravelNotificationRepositoryImpl(mongoTemplate);
+        repository = new ConnectionOfTravelNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
@@ -22,10 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.intersection_reference_alignment_notification.IntersectionReferenceAlignmentNotificationRepositoryImpl;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.IntersectionReferenceAlignmentNotification;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -39,6 +41,9 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<IntersectionReferenceAlignmentNotification> mockPage;
@@ -54,7 +59,7 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new IntersectionReferenceAlignmentNotificationRepositoryImpl(mongoTemplate);
+        repository = new IntersectionReferenceAlignmentNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/IntersectionReferenceAlignmentNotificationRepositoryImplTest.java
@@ -22,12 +22,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.intersection_reference_alignment_notification.IntersectionReferenceAlignmentNotificationRepositoryImpl;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.IntersectionReferenceAlignmentNotification;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -41,9 +39,6 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<IntersectionReferenceAlignmentNotification> mockPage;
@@ -59,7 +54,7 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new IntersectionReferenceAlignmentNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new IntersectionReferenceAlignmentNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -88,10 +83,9 @@ public class IntersectionReferenceAlignmentNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(IntersectionReferenceAlignmentNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<IntersectionReferenceAlignmentNotification> results = repo.find(1, null, null, pageRequest);
+        Page<IntersectionReferenceAlignmentNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
@@ -23,9 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.LaneDirectionOfTravelNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.lane_direction_of_travel_notification.LaneDirectionOfTravelNotificationRepositoryImpl;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -39,6 +41,9 @@ public class LaneDirectionOfTravelNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<LaneDirectionOfTravelNotification> mockPage;
@@ -54,7 +59,7 @@ public class LaneDirectionOfTravelNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelNotificationRepositoryImpl(mongoTemplate);
+        repository = new LaneDirectionOfTravelNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/LaneDirectionOfTravelNotificationRepositoryImplTest.java
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.LaneDirectionOfTravelNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.lane_direction_of_travel_notification.LaneDirectionOfTravelNotificationRepositoryImpl;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -41,9 +39,6 @@ public class LaneDirectionOfTravelNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<LaneDirectionOfTravelNotification> mockPage;
@@ -59,7 +54,7 @@ public class LaneDirectionOfTravelNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new LaneDirectionOfTravelNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new LaneDirectionOfTravelNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -88,10 +83,9 @@ public class LaneDirectionOfTravelNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(LaneDirectionOfTravelNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<LaneDirectionOfTravelNotification> results = repo.find(1, null, null, pageRequest);
+        Page<LaneDirectionOfTravelNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
@@ -25,12 +25,10 @@ import static org.mockito.Mockito.when;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.MapBroadcastRateNotification;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.map_broadcast_rate_notification.MapBroadcastRateNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -41,9 +39,6 @@ public class MapBroadcastRateNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<MapBroadcastRateNotification> mockPage;
@@ -59,7 +54,7 @@ public class MapBroadcastRateNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapBroadcastRateNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new MapBroadcastRateNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -87,10 +82,9 @@ public class MapBroadcastRateNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(MapBroadcastRateNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<MapBroadcastRateNotification> results = repo.find(1, null, null, pageRequest);
+        Page<MapBroadcastRateNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/MapBroadcastRateNotificationRepositoryImplTest.java
@@ -25,10 +25,12 @@ import static org.mockito.Mockito.when;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.MapBroadcastRateNotification;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.map_broadcast_rate_notification.MapBroadcastRateNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -39,6 +41,9 @@ public class MapBroadcastRateNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<MapBroadcastRateNotification> mockPage;
@@ -54,7 +59,7 @@ public class MapBroadcastRateNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new MapBroadcastRateNotificationRepositoryImpl(mongoTemplate);
+        repository = new MapBroadcastRateNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
@@ -23,13 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAlignmentNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.signal_group_alignment_notification.SignalGroupAlignmentNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -40,9 +38,6 @@ public class SignalGroupAlignmentNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<SignalGroupAlignmentNotification> mockPage;
@@ -58,7 +53,7 @@ public class SignalGroupAlignmentNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalGroupAlignmentNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new SignalGroupAlignmentNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -87,10 +82,9 @@ public class SignalGroupAlignmentNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SignalGroupAlignmentNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SignalGroupAlignmentNotification> results = repo.find(1, null, null, pageRequest);
+        Page<SignalGroupAlignmentNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalGroupAlignmentNotificationRepositoryImplTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalGroupAlignmentNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.signal_group_alignment_notification.SignalGroupAlignmentNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -38,6 +40,9 @@ public class SignalGroupAlignmentNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<SignalGroupAlignmentNotification> mockPage;
@@ -53,7 +58,7 @@ public class SignalGroupAlignmentNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalGroupAlignmentNotificationRepositoryImpl(mongoTemplate);
+        repository = new SignalGroupAlignmentNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.signal_state_conflict_notification.SignalStateConflictNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -57,6 +58,9 @@ public class SignalStateConflictNotificationRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -80,7 +84,7 @@ public class SignalStateConflictNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalStateConflictNotificationRepositoryImpl(mongoTemplate);
+        repository = new SignalStateConflictNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 
 import org.bson.Document;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -45,7 +44,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.SignalStateConflictNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.signal_state_conflict_notification.SignalStateConflictNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -58,9 +56,6 @@ public class SignalStateConflictNotificationRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +79,7 @@ public class SignalStateConflictNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SignalStateConflictNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new SignalStateConflictNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -112,10 +107,9 @@ public class SignalStateConflictNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SignalStateConflictNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SignalStateConflictNotification> results = repo.find(1, null, null, pageRequest);
+        Page<SignalStateConflictNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -150,9 +144,7 @@ public class SignalStateConflictNotificationRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<SignalStateConflictNotification> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<SignalStateConflictNotification> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SignalStateConflictNotificationRepositoryImplTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.bson.Document;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.SpatBroadcastRateNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.spat_broadcast_rate_notification.SpatBroadcastRateNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -38,6 +40,9 @@ public class SpatBroadcastRateNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<SpatBroadcastRateNotification> mockPage;
@@ -53,7 +58,7 @@ public class SpatBroadcastRateNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatBroadcastRateNotificationRepositoryImpl(mongoTemplate);
+        repository = new SpatBroadcastRateNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/SpatBroadcastRateNotificationRepositoryImplTest.java
@@ -23,13 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.broadcast_rate.SpatBroadcastRateNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.spat_broadcast_rate_notification.SpatBroadcastRateNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -40,9 +38,6 @@ public class SpatBroadcastRateNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<SpatBroadcastRateNotification> mockPage;
@@ -58,7 +53,7 @@ public class SpatBroadcastRateNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new SpatBroadcastRateNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new SpatBroadcastRateNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -86,10 +81,9 @@ public class SpatBroadcastRateNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(SpatBroadcastRateNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<SpatBroadcastRateNotification> results = repo.find(1, null, null, pageRequest);
+        Page<SpatBroadcastRateNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLinePassageNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.stop_line_passage_notification.StopLinePassageNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -57,6 +58,9 @@ public class StopLinePassageNotificationRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -80,7 +84,7 @@ public class StopLinePassageNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLinePassageNotificationRepositoryImpl(mongoTemplate);
+        repository = new StopLinePassageNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLinePassageNotificationRepositoryImplTest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLinePassageNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.stop_line_passage_notification.StopLinePassageNotificationRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -58,9 +57,6 @@ public class StopLinePassageNotificationRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -84,7 +80,7 @@ public class StopLinePassageNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLinePassageNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new StopLinePassageNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -112,10 +108,9 @@ public class StopLinePassageNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLinePassageNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLinePassageNotification> results = repo.find(1, null, null, pageRequest);
+        Page<StopLinePassageNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -150,9 +145,7 @@ public class StopLinePassageNotificationRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<StopLinePassageNotification> findResponse = repository.find(intersectionID, startTime, endTime,
-                pageRequest);
+        Page<StopLinePassageNotification> findResponse = repository.find(intersectionID, startTime, endTime, 0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLineStopNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.stop_line_stop_notification.StopLineStopNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -38,6 +40,9 @@ public class StopLineStopNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<StopLineStopNotification> mockPage;
@@ -53,7 +58,7 @@ public class StopLineStopNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLineStopNotificationRepositoryImpl(mongoTemplate);
+        repository = new StopLineStopNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/StopLineStopNotificationRepositoryImplTest.java
@@ -23,13 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.StopLineStopNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.stop_line_stop_notification.StopLineStopNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -40,9 +38,6 @@ public class StopLineStopNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<StopLineStopNotification> mockPage;
@@ -58,7 +53,7 @@ public class StopLineStopNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new StopLineStopNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new StopLineStopNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -86,10 +81,9 @@ public class StopLineStopNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(StopLineStopNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<StopLineStopNotification> results = repo.find(1, null, null, pageRequest);
+        Page<StopLineStopNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
@@ -23,13 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.time_change_details_notification.TimeChangeDetailsNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -40,9 +38,6 @@ public class TimeChangeDetailsNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<TimeChangeDetailsNotification> mockPage;
@@ -58,7 +53,7 @@ public class TimeChangeDetailsNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new TimeChangeDetailsNotificationRepositoryImpl(mongoTemplate, props);
+        repository = new TimeChangeDetailsNotificationRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -86,10 +81,9 @@ public class TimeChangeDetailsNotificationRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(TimeChangeDetailsNotification.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, 0, 1);
 
-        Page<TimeChangeDetailsNotification> results = repo.find(1, null, null, pageRequest);
+        Page<TimeChangeDetailsNotification> results = repo.find(1, null, null, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/notifications/TimeChangeDetailsNotificationRepositoryImplTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.TimeChangeDetailsNotification;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.notifications.time_change_details_notification.TimeChangeDetailsNotificationRepositoryImpl;
 
 @SpringBootTest
@@ -38,6 +40,9 @@ public class TimeChangeDetailsNotificationRepositoryImplTest {
 
     @Mock
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private Page<TimeChangeDetailsNotification> mockPage;
@@ -53,7 +58,7 @@ public class TimeChangeDetailsNotificationRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new TimeChangeDetailsNotificationRepositoryImpl(mongoTemplate);
+        repository = new TimeChangeDetailsNotificationRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.bson.Document;
 
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.spat.OdeSpatDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.model.OdeSpatData;
@@ -38,6 +39,9 @@ public class OdeSpatDataRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
+
+    @SpyBean
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -60,7 +64,7 @@ public class OdeSpatDataRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeSpatDataRepositoryImpl(mongoTemplate);
+        repository = new OdeSpatDataRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 
 import org.bson.Document;
 
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.spat.OdeSpatDataRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.model.OdeSpatData;
@@ -39,9 +38,6 @@ public class OdeSpatDataRepositoryImplTest {
 
     @SpyBean
     private MongoTemplate mongoTemplate;
-
-    @SpyBean
-    private ConflictMonitorApiProperties props;
 
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
@@ -64,7 +60,7 @@ public class OdeSpatDataRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new OdeSpatDataRepositoryImpl(mongoTemplate, props);
+        repository = new OdeSpatDataRepositoryImpl(mongoTemplate);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.spat.ProcessedSpatRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -60,6 +61,9 @@ public class ProcessedSpatRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
+    @SpyBean
+    private ConflictMonitorApiProperties props;
+
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -81,7 +85,7 @@ public class ProcessedSpatRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ProcessedSpatRepositoryImpl(mongoTemplate);
+        repository = new ProcessedSpatRepositoryImpl(mongoTemplate, props);
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/ProcessedSpatRepositoryImplTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import org.bson.Document;
 
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
-import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.spat.ProcessedSpatRepositoryImpl;
 import us.dot.its.jpo.ode.api.models.AggregationResult;
 import us.dot.its.jpo.ode.api.models.AggregationResultCount;
@@ -61,9 +60,6 @@ public class ProcessedSpatRepositoryImplTest {
     @SpyBean
     private MongoTemplate mongoTemplate;
 
-    @SpyBean
-    private ConflictMonitorApiProperties props;
-
     @Mock
     private AggregationResults<AggregationResult> mockAggregationResult;
 
@@ -85,7 +81,7 @@ public class ProcessedSpatRepositoryImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        repository = new ProcessedSpatRepositoryImpl(mongoTemplate, props);
+        repository = new ProcessedSpatRepositoryImpl(mongoTemplate);
     }
 
     @Test
@@ -113,10 +109,9 @@ public class ProcessedSpatRepositoryImplTest {
                 any(Sort.class),
                 any(),
                 eq(ProcessedSpat.class))).thenReturn(mockPage);
-        PageRequest pageRequest = PageRequest.of(0, 1);
-        doCallRealMethod().when(repo).find(1, null, null, false, pageRequest);
+        doCallRealMethod().when(repo).find(1, null, null, false, 0, 1);
 
-        Page<ProcessedSpat> results = repo.find(1, null, null, false, pageRequest);
+        Page<ProcessedSpat> results = repo.find(1, null, null, false, 0, 1);
 
         assertThat(results).isEqualTo(mockPage);
     }
@@ -151,9 +146,8 @@ public class ProcessedSpatRepositoryImplTest {
                 eq(AggregationResult.class));
 
         // Call the repository find method
-        PageRequest pageRequest = PageRequest.of(0, 1);
         Page<ProcessedSpat> findResponse = repository.find(intersectionID, startTime, endTime, false,
-                pageRequest);
+                0, 1);
 
         // Extract the captured Aggregation
         Aggregation capturedAggregation = aggregationCaptor.getValue();

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/BsmControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/BsmControllerTest.java
@@ -55,10 +55,9 @@ public class BsmControllerTest {
 
         List<OdeBsmData> list = new ArrayList<>();
 
-        PageRequest page = PageRequest.of(0, 1);
         when(odeBsmJsonRepo.find(null, null, null, null, null, null, null,
-                PageRequest.of(0, 1)))
-                .thenReturn(new PageImpl<>(list, page, 1L));
+                0, 1))
+                .thenReturn(new PageImpl<>(list, PageRequest.of(0, 1), 1L));
 
         ResponseEntity<Page<OdeBsmData>> result = controller.findBSMs(null, null, null, null, null, null, null, 0, 1,
                 false);
@@ -88,7 +87,7 @@ public class BsmControllerTest {
 
         Page<OdeBsmData> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
         when(odeBsmJsonRepo.find(any(), any(), any(), any(), any(), any(), any(),
-                any(PageRequest.class)))
+                any(), any()))
                 .thenReturn(mockPage);
 
         ResponseEntity<Page<OdeBsmData>> response = controller
@@ -99,7 +98,7 @@ public class BsmControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getContent()).isEqualTo(events);
         verify(odeBsmJsonRepo, times(1))
-                .find(any(), any(), any(), any(), any(), any(), any(), any(PageRequest.class));
+                .find(any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/BsmControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/BsmControllerTest.java
@@ -3,6 +3,9 @@ package us.dot.its.jpo.ode.api.controllers.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,7 +90,7 @@ public class BsmControllerTest {
 
         Page<OdeBsmData> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
         when(odeBsmJsonRepo.find(any(), any(), any(), any(), any(), any(), any(),
-                any(), any()))
+                eq(0), eq(10)))
                 .thenReturn(mockPage);
 
         ResponseEntity<Page<OdeBsmData>> response = controller
@@ -98,7 +101,7 @@ public class BsmControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getContent()).isEqualTo(events);
         verify(odeBsmJsonRepo, times(1))
-                .find(any(), any(), any(), any(), any(), any(), any(), any(), any());
+                .find(any(), any(), any(), any(), any(), any(), any(), eq(0), eq(10));
     }
 
     @Test

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmAssessmentControllerTest.java
@@ -43,457 +43,457 @@ import us.dot.its.jpo.ode.mockdata.MockAssessmentGenerator;
 @AutoConfigureEmbeddedDatabase
 public class CmAssessmentControllerTest {
 
-        private final CmAssessmentController controller;
-
-        @MockBean
-        LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo;
+    private final CmAssessmentController controller;
+
+    @MockBean
+    LaneDirectionOfTravelAssessmentRepository laneDirectionOfTravelAssessmentRepo;
 
-        @MockBean
-        ConnectionOfTravelAssessmentRepository connectionOfTravelAssessmentRepo;
+    @MockBean
+    ConnectionOfTravelAssessmentRepository connectionOfTravelAssessmentRepo;
 
-        @MockBean
-        StopLineStopAssessmentRepository stopLineStopAssessmentRepo;
+    @MockBean
+    StopLineStopAssessmentRepository stopLineStopAssessmentRepo;
 
-        @MockBean
-        StopLinePassageAssessmentRepository stopLinePassageAssessmentRepo;
-
-        @MockBean
-        PermissionService permissionService;
-
-        @Autowired
-        public CmAssessmentControllerTest(CmAssessmentController controller) {
-                this.controller = controller;
-        }
-
-        @Test
-        void testFindConnectionOfTravelAssessmentWithTestData() {
-                ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
-
-                List<ConnectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
-                                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindConnectionOfTravelAssessmentsWithLatestFlag() {
-                ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
-
-                List<ConnectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<ConnectionOfTravelAssessment> mockPage = new PageImpl<>(events);
-                when(connectionOfTravelAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
-                                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindConnectionOfTravelAssessmentsWithPagination() {
-                ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
-
-                List<ConnectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<ConnectionOfTravelAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(connectionOfTravelAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
-                                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelAssessmentRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountConnectionOfTravelAssessmentsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelAssessments(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountConnectionOfTravelAssessments() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(connectionOfTravelAssessmentRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelAssessments(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(connectionOfTravelAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelAssessmentWithTestData() {
-                LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
-
-                List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
-                                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelAssessmentsWithLatestFlag() {
-                LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
-
-                List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<LaneDirectionOfTravelAssessment> mockPage = new PageImpl<>(events);
-                when(laneDirectionOfTravelAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
-                                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelAssessmentsWithPagination() {
-                LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
-
-                List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<LaneDirectionOfTravelAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(laneDirectionOfTravelAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
-                                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelAssessmentRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelAssessmentsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelAssessments(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelAssessments() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(laneDirectionOfTravelAssessmentRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelAssessments(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(laneDirectionOfTravelAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLineStopAssessmentWithTestData() {
-                StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
-
-                List<StopLineStopAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLineStopAssessment>> response = controller
-                                .findStopLineStopAssessments(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLineStopAssessmentsWithLatestFlag() {
-                StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
-
-                List<StopLineStopAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLineStopAssessment> mockPage = new PageImpl<>(events);
-                when(stopLineStopAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopAssessment>> response = controller
-                                .findStopLineStopAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLineStopAssessmentsWithPagination() {
-                StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
-
-                List<StopLineStopAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLineStopAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLineStopAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopAssessment>> response = controller
-                                .findStopLineStopAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopAssessmentRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLineStopAssessmentsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLineStopAssessments(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLineStopAssessments() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLineStopAssessmentRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLineStopAssessments(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLineStopAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLinePassageAssessmentWithTestData() {
-                StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
-
-                List<StopLinePassageAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLinePassageAssessment>> response = controller
-                                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLinePassageAssessmentsWithLatestFlag() {
-                StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
-
-                List<StopLinePassageAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLinePassageAssessment> mockPage = new PageImpl<>(events);
-                when(stopLinePassageAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageAssessment>> response = controller
-                                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLinePassageAssessmentsWithPagination() {
-                StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
-
-                List<StopLinePassageAssessment> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLinePassageAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLinePassageAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageAssessment>> response = controller
-                                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageAssessmentRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLinePassageAssessmentsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageAssessments(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLinePassageAssessments() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLinePassageAssessmentRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageAssessments(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLinePassageAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
+    @MockBean
+    StopLinePassageAssessmentRepository stopLinePassageAssessmentRepo;
+
+    @MockBean
+    PermissionService permissionService;
+
+    @Autowired
+    public CmAssessmentControllerTest(CmAssessmentController controller) {
+        this.controller = controller;
+    }
+
+    @Test
+    void testFindConnectionOfTravelAssessmentWithTestData() {
+        ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
+
+        List<ConnectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
+                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindConnectionOfTravelAssessmentsWithLatestFlag() {
+        ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
+
+        List<ConnectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<ConnectionOfTravelAssessment> mockPage = new PageImpl<>(events);
+        when(connectionOfTravelAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
+                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindConnectionOfTravelAssessmentsWithPagination() {
+        ConnectionOfTravelAssessment event = MockAssessmentGenerator.getConnectionOfTravelAssessment();
+
+        List<ConnectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<ConnectionOfTravelAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(connectionOfTravelAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelAssessment>> response = controller
+                .findConnectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelAssessmentRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountConnectionOfTravelAssessmentsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelAssessments(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountConnectionOfTravelAssessments() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(connectionOfTravelAssessmentRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelAssessments(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(connectionOfTravelAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelAssessmentWithTestData() {
+        LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
+
+        List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
+                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelAssessmentsWithLatestFlag() {
+        LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
+
+        List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<LaneDirectionOfTravelAssessment> mockPage = new PageImpl<>(events);
+        when(laneDirectionOfTravelAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
+                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelAssessmentsWithPagination() {
+        LaneDirectionOfTravelAssessment event = MockAssessmentGenerator.getLaneDirectionOfTravelAssessment();
+
+        List<LaneDirectionOfTravelAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<LaneDirectionOfTravelAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(laneDirectionOfTravelAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelAssessment>> response = controller
+                .findLaneDirectionOfTravelAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelAssessmentRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelAssessmentsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelAssessments(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelAssessments() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(laneDirectionOfTravelAssessmentRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelAssessments(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(laneDirectionOfTravelAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLineStopAssessmentWithTestData() {
+        StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
+
+        List<StopLineStopAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLineStopAssessment>> response = controller
+                .findStopLineStopAssessments(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLineStopAssessmentsWithLatestFlag() {
+        StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
+
+        List<StopLineStopAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLineStopAssessment> mockPage = new PageImpl<>(events);
+        when(stopLineStopAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopAssessment>> response = controller
+                .findStopLineStopAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLineStopAssessmentsWithPagination() {
+        StopLineStopAssessment event = MockAssessmentGenerator.getStopLineStopAssessment();
+
+        List<StopLineStopAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLineStopAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLineStopAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopAssessment>> response = controller
+                .findStopLineStopAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopAssessmentRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLineStopAssessmentsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLineStopAssessments(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLineStopAssessments() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLineStopAssessmentRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLineStopAssessments(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLineStopAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLinePassageAssessmentWithTestData() {
+        StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
+
+        List<StopLinePassageAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLinePassageAssessment>> response = controller
+                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLinePassageAssessmentsWithLatestFlag() {
+        StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
+
+        List<StopLinePassageAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLinePassageAssessment> mockPage = new PageImpl<>(events);
+        when(stopLinePassageAssessmentRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageAssessment>> response = controller
+                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageAssessmentRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLinePassageAssessmentsWithPagination() {
+        StopLinePassageAssessment event = MockAssessmentGenerator.getStopLinePassageAssessment();
+
+        List<StopLinePassageAssessment> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLinePassageAssessment> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLinePassageAssessmentRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageAssessment>> response = controller
+                .findStopLinePassageAssessments(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageAssessmentRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLinePassageAssessmentsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageAssessments(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLinePassageAssessments() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLinePassageAssessmentRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageAssessments(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLinePassageAssessmentRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmEventControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmEventControllerTest.java
@@ -67,7 +67,6 @@ import us.dot.its.jpo.ode.mockdata.MockEventGenerator;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 import us.dot.its.jpo.ode.model.OdeMsgMetadata;
 import us.dot.its.jpo.ode.model.OdeMsgPayload;
-import us.dot.its.jpo.ode.model.OdeObject;
 import us.dot.its.jpo.ode.plugin.j2735.J2735Bsm;
 import us.dot.its.jpo.ode.plugin.j2735.J2735BsmCoreData;
 
@@ -77,2159 +76,2159 @@ import us.dot.its.jpo.ode.plugin.j2735.J2735BsmCoreData;
 @AutoConfigureEmbeddedDatabase
 public class CmEventControllerTest {
 
-        private final CmEventController controller;
+    private final CmEventController controller;
 
-        @MockBean
-        ConnectionOfTravelEventRepository connectionOfTravelEventRepo;
+    @MockBean
+    ConnectionOfTravelEventRepository connectionOfTravelEventRepo;
 
-        @MockBean
-        IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo;
+    @MockBean
+    IntersectionReferenceAlignmentEventRepository intersectionReferenceAlignmentEventRepo;
 
-        @MockBean
-        LaneDirectionOfTravelEventRepository laneDirectionOfTravelRepo;
+    @MockBean
+    LaneDirectionOfTravelEventRepository laneDirectionOfTravelRepo;
 
-        @MockBean
-        SignalGroupAlignmentEventRepository signalGroupAlignmentEventRepo;
+    @MockBean
+    SignalGroupAlignmentEventRepository signalGroupAlignmentEventRepo;
 
-        @MockBean
-        SignalStateConflictEventRepository signalStateConflictEventRepo;
+    @MockBean
+    SignalStateConflictEventRepository signalStateConflictEventRepo;
 
-        @MockBean
-        StopLineStopEventRepository stopLineStopEventRepo;
+    @MockBean
+    StopLineStopEventRepository stopLineStopEventRepo;
 
-        @MockBean
-        StopLinePassageEventRepository stopLinePassageEventRepo;
+    @MockBean
+    StopLinePassageEventRepository stopLinePassageEventRepo;
 
-        @MockBean
-        TimeChangeDetailsEventRepository timeChangeDetailsEventRepo;
+    @MockBean
+    TimeChangeDetailsEventRepository timeChangeDetailsEventRepo;
 
-        @MockBean
-        SpatMinimumDataEventRepository spatMinimumDataEventRepo;
+    @MockBean
+    SpatMinimumDataEventRepository spatMinimumDataEventRepo;
 
-        @MockBean
-        MapMinimumDataEventRepository mapMinimumDataEventRepo;
+    @MockBean
+    MapMinimumDataEventRepository mapMinimumDataEventRepo;
 
-        @MockBean
-        SpatBroadcastRateEventRepository spatBroadcastRateEventRepo;
+    @MockBean
+    SpatBroadcastRateEventRepository spatBroadcastRateEventRepo;
 
-        @MockBean
-        MapBroadcastRateEventRepository mapBroadcastRateEventRepo;
+    @MockBean
+    MapBroadcastRateEventRepository mapBroadcastRateEventRepo;
 
-        @MockBean
-        SpatMessageCountProgressionEventRepository spatMessageCountProgressionEventRepo;
+    @MockBean
+    SpatMessageCountProgressionEventRepository spatMessageCountProgressionEventRepo;
 
-        @MockBean
-        MapMessageCountProgressionEventRepository mapMessageCountProgressionEventRepo;
+    @MockBean
+    MapMessageCountProgressionEventRepository mapMessageCountProgressionEventRepo;
 
-        @MockBean
-        BsmMessageCountProgressionEventRepository bsmMessageCountProgressionEventRepo;
+    @MockBean
+    BsmMessageCountProgressionEventRepository bsmMessageCountProgressionEventRepo;
 
-        @MockBean
-        BsmEventRepository bsmEventRepo;
+    @MockBean
+    BsmEventRepository bsmEventRepo;
 
-        @MockBean
-        PostgresService postgresService;
+    @MockBean
+    PostgresService postgresService;
 
-        @MockBean
-        PermissionService permissionService;
+    @MockBean
+    PermissionService permissionService;
 
-        @Autowired
-        public CmEventControllerTest(CmEventController controller) {
-                this.controller = controller;
-        }
+    @Autowired
+    public CmEventControllerTest(CmEventController controller) {
+        this.controller = controller;
+    }
 
-        @Test
-        public void testIntersectionReferenceAlignmentEvents() {
+    @Test
+    public void testIntersectionReferenceAlignmentEvents() {
 
-                IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
+        IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
 
-                List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
+        List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
 
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
 
-                PageRequest page = PageRequest.of(1, 1);
-                when(intersectionReferenceAlignmentEventRepo.find(event.getIntersectionID(),
-                                event.getEventGeneratedAt() - 1,
-                                event.getEventGeneratedAt() + 1, PageRequest.of(1, 1)))
-                                .thenReturn(new PageImpl<>(events, page, 1L));
+        PageRequest page = PageRequest.of(1, 1);
+        when(intersectionReferenceAlignmentEventRepo.find(event.getIntersectionID(),
+                event.getEventGeneratedAt() - 1,
+                event.getEventGeneratedAt() + 1, 1, 1))
+                .thenReturn(new PageImpl<>(events, page, 1L));
 
-                ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> result = controller
-                                .findIntersectionReferenceAlignmentEvents(
-                                                event.getIntersectionID(),
-                                                event.getEventGeneratedAt() - 1,
-                                                event.getEventGeneratedAt() + 1, false, 1, 1, false);
-                assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(result.getBody().getContent()).isEqualTo(events);
-        }
+        ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> result = controller
+                .findIntersectionReferenceAlignmentEvents(
+                        event.getIntersectionID(),
+                        event.getEventGeneratedAt() - 1,
+                        event.getEventGeneratedAt() + 1, false, 1, 1, false);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().getContent()).isEqualTo(events);
+    }
 
-        @Test
-        void testFindIntersectionReferenceAlignmentEventsWithTestData() {
-                IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
+    @Test
+    void testFindIntersectionReferenceAlignmentEventsWithTestData() {
+        IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
 
-                List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
+        List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
 
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
 
-                ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
-                                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindIntersectionReferenceAlignmentEventsWithLatestFlag() {
-                IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
-
-                List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<IntersectionReferenceAlignmentEvent> mockPage = new PageImpl<>(events);
-                when(intersectionReferenceAlignmentEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
-                                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(intersectionReferenceAlignmentEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindIntersectionReferenceAlignmentEventsWithPagination() {
-                IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
-
-                List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<IntersectionReferenceAlignmentEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(intersectionReferenceAlignmentEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
-                                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(intersectionReferenceAlignmentEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountIntersectionReferenceAlignmentEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountIntersectionReferenceAlignmentEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(intersectionReferenceAlignmentEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(intersectionReferenceAlignmentEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindConnectionOfTravelEventWithTestData() {
-                ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
-
-                List<ConnectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
-                                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindConnectionOfTravelEventsWithLatestFlag() {
-                ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
-
-                List<ConnectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<ConnectionOfTravelEvent> mockPage = new PageImpl<>(events);
-                when(connectionOfTravelEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
-                                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindConnectionOfTravelEventsWithPagination() {
-                ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
-
-                List<ConnectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<ConnectionOfTravelEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(connectionOfTravelEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
-                                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountConnectionOfTravelEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountConnectionOfTravelEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(connectionOfTravelEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(connectionOfTravelEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailyConnectionOfTravelEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyConnectionOfTravelEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailyConnectionOfTravelEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(connectionOfTravelEventRepo.getAggregatedDailyConnectionOfTravelEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyConnectionOfTravelEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(connectionOfTravelEventRepo, times(1))
-                                .getAggregatedDailyConnectionOfTravelEventCounts(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelEventWithTestData() {
-                LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
-
-                List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
-                                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelEventsWithLatestFlag() {
-                LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
-
-                List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<LaneDirectionOfTravelEvent> mockPage = new PageImpl<>(events);
-                when(laneDirectionOfTravelRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
-                                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelEventsWithPagination() {
-                LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
-
-                List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<LaneDirectionOfTravelEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(laneDirectionOfTravelRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
-                                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(laneDirectionOfTravelRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(laneDirectionOfTravelRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailyLaneDirectionOfTravelEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyLaneDirectionOfTravelEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailyLaneDirectionOfTravelEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(laneDirectionOfTravelRepo.getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyLaneDirectionOfTravelEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(laneDirectionOfTravelRepo, times(1))
-                                .getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentEventWithTestData() {
-                SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
-
-                List<SignalGroupAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
-                                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentEventsWithLatestFlag() {
-                SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
-
-                List<SignalGroupAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SignalGroupAlignmentEvent> mockPage = new PageImpl<>(events);
-                when(signalGroupAlignmentEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
-                                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalGroupAlignmentEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentEventsWithPagination() {
-                SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
-
-                List<SignalGroupAlignmentEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SignalGroupAlignmentEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(signalGroupAlignmentEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
-                                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalGroupAlignmentEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSignalGroupAlignmentEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSignalGroupAlignmentEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSignalGroupAlignmentEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalGroupAlignmentEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSignalGroupAlignmentEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(signalGroupAlignmentEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailySignalGroupAlignmentEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailySignalGroupAlignmentEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailySignalGroupAlignmentEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalGroupAlignmentEventRepo.getAggregatedDailySignalGroupAlignmentEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailySignalGroupAlignmentEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(signalGroupAlignmentEventRepo, times(1))
-                                .getAggregatedDailySignalGroupAlignmentEventCounts(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSignalStateConflictEventWithTestData() {
-                SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
-
-                List<SignalStateConflictEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SignalStateConflictEvent>> response = controller
-                                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSignalStateConflictEventsWithLatestFlag() {
-                SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
-
-                List<SignalStateConflictEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SignalStateConflictEvent> mockPage = new PageImpl<>(events);
-                when(signalStateConflictEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalStateConflictEvent>> response = controller
-                                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalStateConflictEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSignalStateConflictEventsWithPagination() {
-                SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
-
-                List<SignalStateConflictEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SignalStateConflictEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(signalStateConflictEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalStateConflictEvent>> response = controller
-                                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalStateConflictEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSignalStateConflictEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSignalStateConflictEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSignalStateConflictEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalStateConflictEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSignalStateConflictEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(signalStateConflictEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailySignalStateConflictEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailySignalStateConflictEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailySignalStateConflictEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalStateConflictEventRepo.getAggregatedDailySignalStateConflictEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailySignalStateConflictEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(signalStateConflictEventRepo, times(1))
-                                .getAggregatedDailySignalStateConflictEventCounts(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLinePassageEventWithTestData() {
-                StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
-
-                List<StopLinePassageEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLinePassageEvent>> response = controller
-                                .findStopLinePassageEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLinePassageEventsWithLatestFlag() {
-                StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
-
-                List<StopLinePassageEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLinePassageEvent> mockPage = new PageImpl<>(events);
-                when(stopLinePassageEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageEvent>> response = controller
-                                .findStopLinePassageEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLinePassageEventsWithPagination() {
-                StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
-
-                List<StopLinePassageEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLinePassageEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLinePassageEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageEvent>> response = controller
-                                .findStopLinePassageEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLinePassageEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLinePassageEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLinePassageEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLinePassageEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailyStopLinePassageEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyStopLinePassageEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailyStopLinePassageEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLinePassageEventRepo.getAggregatedDailyStopLinePassageEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyStopLinePassageEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(stopLinePassageEventRepo, times(1)).getAggregatedDailyStopLinePassageEventCounts(intersectionID,
-                                startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLineStopEventWithTestData() {
-                StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
-
-                List<StopLineStopEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLineStopEvent>> response = controller
-                                .findStopLineStopEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLineStopEventsWithLatestFlag() {
-                StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
-
-                List<StopLineStopEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLineStopEvent> mockPage = new PageImpl<>(events);
-                when(stopLineStopEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopEvent>> response = controller
-                                .findStopLineStopEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLineStopEventsWithPagination() {
-                StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
-
-                List<StopLineStopEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLineStopEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLineStopEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopEvent>> response = controller
-                                .findStopLineStopEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLineStopEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLineStopEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLineStopEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLineStopEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLineStopEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLineStopEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailyStopLineStopEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyStopLineStopEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailyStopLineStopEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLineStopEventRepo.getAggregatedDailyStopLineStopEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyStopLineStopEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(stopLineStopEventRepo, times(1)).getAggregatedDailyStopLineStopEventCounts(intersectionID,
-                                startTime, endTime);
-        }
-
-        @Test
-        void testFindTimeChangeDetailsEventWithTestData() {
-                TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
-
-                List<TimeChangeDetailsEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
-                                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindTimeChangeDetailsEventsWithLatestFlag() {
-                TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
-
-                List<TimeChangeDetailsEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<TimeChangeDetailsEvent> mockPage = new PageImpl<>(events);
-                when(timeChangeDetailsEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
-                                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(timeChangeDetailsEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindTimeChangeDetailsEventsWithPagination() {
-                TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
-
-                List<TimeChangeDetailsEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<TimeChangeDetailsEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(timeChangeDetailsEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
-                                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(timeChangeDetailsEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountTimeChangeDetailsEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countTimeChangeDetailsEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountTimeChangeDetailsEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(timeChangeDetailsEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countTimeChangeDetailsEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(timeChangeDetailsEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        public void testGetDailyTimeChangeDetailsEventCountsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyTimeChangeDetailsEventCounts(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
-        }
-
-        @Test
-        public void testGetDailyTimeChangeDetailsEventCounts() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(timeChangeDetailsEventRepo.getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID,
-                                startTime, endTime))
-                                .thenReturn(expectedCounts);
-
-                ResponseEntity<List<IDCount>> response = controller.getDailyTimeChangeDetailsEventCounts(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCounts);
-                verify(timeChangeDetailsEventRepo, times(1))
-                                .getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSpatMinimumDataEventWithTestData() {
-                SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
-
-                List<SpatMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
-                                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertTrue(response.getBody().getContent().isEmpty()); // Test data should return empty
-        }
-
-        @Test
-        void testFindSpatMinimumDataEventsWithLatestFlag() {
-                SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
-
-                List<SpatMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SpatMinimumDataEvent> mockPage = new PageImpl<>(events);
-                when(spatMinimumDataEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
-                                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatMinimumDataEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSpatMinimumDataEventsWithPagination() {
-                SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
-
-                List<SpatMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SpatMinimumDataEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(spatMinimumDataEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
-                                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatMinimumDataEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSpatMinimumDataEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSpatMinimumDataEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSpatMinimumDataEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(spatMinimumDataEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSpatMinimumDataEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(spatMinimumDataEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindMapMinimumDataEventWithTestData() {
-                MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
-
-                List<MapMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<MapMinimumDataEvent>> response = controller
-                                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertTrue(response.getBody().getContent().isEmpty()); // Test data should return empty
-        }
-
-        @Test
-        void testFindMapMinimumDataEventsWithLatestFlag() {
-                MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
-
-                List<MapMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<MapMinimumDataEvent> mockPage = new PageImpl<>(events);
-                when(mapMinimumDataEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapMinimumDataEvent>> response = controller
-                                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapMinimumDataEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindMapMinimumDataEventsWithPagination() {
-                MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
-
-                List<MapMinimumDataEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<MapMinimumDataEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(mapMinimumDataEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapMinimumDataEvent>> response = controller
-                                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapMinimumDataEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountMapMinimumDataEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countMapMinimumDataEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountMapMinimumDataEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(mapMinimumDataEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countMapMinimumDataEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(mapMinimumDataEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindMapBroadcastRateEventWithTestData() {
-                MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
-
-                List<MapBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
-                                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindMapBroadcastRateEventsWithLatestFlag() {
-                MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
-
-                List<MapBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<MapBroadcastRateEvent> mockPage = new PageImpl<>(events);
-                when(mapBroadcastRateEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
-                                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapBroadcastRateEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindMapBroadcastRateEventsWithPagination() {
-                MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
-
-                List<MapBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<MapBroadcastRateEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(mapBroadcastRateEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
-                                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapBroadcastRateEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountMapBroadcastRateEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countMapBroadcastRateEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountMapBroadcastRateEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(mapBroadcastRateEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countMapBroadcastRateEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(mapBroadcastRateEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSpatBroadcastRateEventWithTestData() {
-                SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
-
-                List<SpatBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
-                                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSpatBroadcastRateEventsWithLatestFlag() {
-                SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
-
-                List<SpatBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SpatBroadcastRateEvent> mockPage = new PageImpl<>(events);
-                when(spatBroadcastRateEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
-                                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatBroadcastRateEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSpatBroadcastRateEventsWithPagination() {
-                SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
-
-                List<SpatBroadcastRateEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SpatBroadcastRateEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(spatBroadcastRateEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
-                                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatBroadcastRateEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSpatBroadcastRateEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSpatBroadcastRateEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSpatBroadcastRateEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(spatBroadcastRateEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSpatBroadcastRateEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(spatBroadcastRateEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSpatMessageCountProgressionEventWithTestData() {
-                SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
-
-                List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
-                                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSpatMessageCountProgressionEventsWithLatestFlag() {
-                SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
-
-                List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SpatMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
-                when(spatMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
-                                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSpatMessageCountProgressionEventsWithPagination() {
-                SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
-
-                List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SpatMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(spatMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
-                                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatMessageCountProgressionEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSpatMessageCountProgressionEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSpatMessageCountProgressionEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSpatMessageCountProgressionEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(spatMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSpatMessageCountProgressionEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(spatMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        void testFindMapMessageCountProgressionEventWithTestData() {
-                MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
-
-                List<MapMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
-                                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindMapMessageCountProgressionEventsWithLatestFlag() {
-                MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
-
-                List<MapMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<MapMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
-                when(mapMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
-                                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindMapMessageCountProgressionEventsWithPagination() {
-                MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
-
-                List<MapMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<MapMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(mapMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
-                                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapMessageCountProgressionEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountMapMessageCountProgressionEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countMapMessageCountProgressionEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountMapMessageCountProgressionEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(mapMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countMapMessageCountProgressionEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(mapMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindBsmMessageCountProgressionEventWithTestData() {
-                BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
-
-                List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
-                                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindBsmMessageCountProgressionEventsWithLatestFlag() {
-                BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
-
-                List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<BsmMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
-                when(bsmMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
-                                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(bsmMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindBsmMessageCountProgressionEventsWithPagination() {
-                BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
-
-                List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<BsmMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(bsmMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
-                                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(bsmMessageCountProgressionEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountBsmMessageCountProgressionEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countBsmMessageCountProgressionEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountBsmMessageCountProgressionEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(bsmMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countBsmMessageCountProgressionEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(bsmMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindBsmEventWithTestData() {
-                BsmEvent event = MockEventGenerator.getBsmEvent();
-
-                List<BsmEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<BsmEvent>> response = controller
-                                .findBsmEvents(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindBsmEventsWithLatestFlag() {
-                BsmEvent event = MockEventGenerator.getBsmEvent();
-
-                List<BsmEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<BsmEvent> mockPage = new PageImpl<>(events);
-                when(bsmEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<BsmEvent>> response = controller
-                                .findBsmEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(bsmEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindBsmEventsWithPagination() {
-                BsmEvent event = MockEventGenerator.getBsmEvent();
-
-                List<BsmEvent> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<BsmEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(bsmEventRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<BsmEvent>> response = controller
-                                .findBsmEvents(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(bsmEventRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountBsmEventsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countBsmEvents(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountBsmEvents() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(bsmEventRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countBsmEvents(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(bsmEventRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testGetBsmActivityByMinuteInRangeWithTestData() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
-                                intersectionID, startTime, endTime, false, 0, 10, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isNotEmpty();
-                assertThat(response.getBody().getContent().size()).isEqualTo(10); // Test data generates 10 items
-        }
-
-        @Test
-        void testGetBsmActivityByMinuteInRangeWithLatestFlag() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                boolean latest = true;
-                boolean testData = false;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                Page<BsmEvent> mockPage = new PageImpl<>(Collections.emptyList());
-                when(bsmEventRepo.findLatest(intersectionID, startTime, endTime)).thenReturn(mockPage);
-
-                ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
-                                intersectionID, startTime, endTime, latest, 0, 10, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEmpty(); // No events in the mock repository
-                verify(bsmEventRepo, times(1)).findLatest(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testGetBsmActivityByMinuteInRangeWithPagination() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                boolean latest = false;
-                boolean testData = false;
-                J2735Bsm bsm = new J2735Bsm();
-                J2735BsmCoreData coreData = new J2735BsmCoreData();
-                coreData.setId("id");
-                bsm.setCoreData(coreData);
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                BsmEvent mockEvent = new BsmEvent();
-                mockEvent.setStartingBsm(new OdeBsmData(new OdeMsgMetadata(), new OdeMsgPayload(bsm)));
-                mockEvent.setEndingBsm(new OdeBsmData(new OdeMsgMetadata(), new OdeMsgPayload()));
-                Page<BsmEvent> mockPage = new PageImpl<>(Collections.singletonList(mockEvent), PageRequest.of(0, 10),
-                                1);
-                when(bsmEventRepo.find(intersectionID, startTime, endTime, PageRequest.of(0, 10))).thenReturn(mockPage);
-
-                ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
-                                intersectionID, startTime, endTime, latest, 0, 10, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isNotEmpty();
-                verify(bsmEventRepo, times(1)).find(intersectionID, startTime, endTime, PageRequest.of(0, 10));
-        }
+        ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
+                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindIntersectionReferenceAlignmentEventsWithLatestFlag() {
+        IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
+
+        List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<IntersectionReferenceAlignmentEvent> mockPage = new PageImpl<>(events);
+        when(intersectionReferenceAlignmentEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
+                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(intersectionReferenceAlignmentEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindIntersectionReferenceAlignmentEventsWithPagination() {
+        IntersectionReferenceAlignmentEvent event = MockEventGenerator.getIntersectionReferenceAlignmentEvent();
+
+        List<IntersectionReferenceAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<IntersectionReferenceAlignmentEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(intersectionReferenceAlignmentEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<IntersectionReferenceAlignmentEvent>> response = controller
+                .findIntersectionReferenceAlignmentEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(intersectionReferenceAlignmentEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountIntersectionReferenceAlignmentEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountIntersectionReferenceAlignmentEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(intersectionReferenceAlignmentEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(intersectionReferenceAlignmentEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindConnectionOfTravelEventWithTestData() {
+        ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
+
+        List<ConnectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
+                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindConnectionOfTravelEventsWithLatestFlag() {
+        ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
+
+        List<ConnectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<ConnectionOfTravelEvent> mockPage = new PageImpl<>(events);
+        when(connectionOfTravelEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
+                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindConnectionOfTravelEventsWithPagination() {
+        ConnectionOfTravelEvent event = MockEventGenerator.getConnectionOfTravelEvent();
+
+        List<ConnectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<ConnectionOfTravelEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(connectionOfTravelEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelEvent>> response = controller
+                .findConnectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountConnectionOfTravelEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountConnectionOfTravelEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(connectionOfTravelEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(connectionOfTravelEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailyConnectionOfTravelEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyConnectionOfTravelEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailyConnectionOfTravelEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(connectionOfTravelEventRepo.getAggregatedDailyConnectionOfTravelEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyConnectionOfTravelEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(connectionOfTravelEventRepo, times(1))
+                .getAggregatedDailyConnectionOfTravelEventCounts(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelEventWithTestData() {
+        LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
+
+        List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
+                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelEventsWithLatestFlag() {
+        LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
+
+        List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<LaneDirectionOfTravelEvent> mockPage = new PageImpl<>(events);
+        when(laneDirectionOfTravelRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
+                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelEventsWithPagination() {
+        LaneDirectionOfTravelEvent event = MockEventGenerator.getLaneDirectionOfTravelEvent();
+
+        List<LaneDirectionOfTravelEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<LaneDirectionOfTravelEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(laneDirectionOfTravelRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelEvent>> response = controller
+                .findLaneDirectionOfTravelEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(laneDirectionOfTravelRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(laneDirectionOfTravelRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailyLaneDirectionOfTravelEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyLaneDirectionOfTravelEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailyLaneDirectionOfTravelEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(laneDirectionOfTravelRepo.getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyLaneDirectionOfTravelEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(laneDirectionOfTravelRepo, times(1))
+                .getAggregatedDailyLaneDirectionOfTravelEventCounts(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentEventWithTestData() {
+        SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
+
+        List<SignalGroupAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
+                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentEventsWithLatestFlag() {
+        SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
+
+        List<SignalGroupAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SignalGroupAlignmentEvent> mockPage = new PageImpl<>(events);
+        when(signalGroupAlignmentEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
+                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalGroupAlignmentEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentEventsWithPagination() {
+        SignalGroupAlignmentEvent event = MockEventGenerator.getSignalGroupAlignmentEvent();
+
+        List<SignalGroupAlignmentEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SignalGroupAlignmentEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(signalGroupAlignmentEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalGroupAlignmentEvent>> response = controller
+                .findSignalGroupAlignmentEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalGroupAlignmentEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSignalGroupAlignmentEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSignalGroupAlignmentEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSignalGroupAlignmentEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalGroupAlignmentEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSignalGroupAlignmentEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(signalGroupAlignmentEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailySignalGroupAlignmentEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailySignalGroupAlignmentEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailySignalGroupAlignmentEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalGroupAlignmentEventRepo.getAggregatedDailySignalGroupAlignmentEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailySignalGroupAlignmentEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(signalGroupAlignmentEventRepo, times(1))
+                .getAggregatedDailySignalGroupAlignmentEventCounts(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSignalStateConflictEventWithTestData() {
+        SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
+
+        List<SignalStateConflictEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SignalStateConflictEvent>> response = controller
+                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSignalStateConflictEventsWithLatestFlag() {
+        SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
+
+        List<SignalStateConflictEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SignalStateConflictEvent> mockPage = new PageImpl<>(events);
+        when(signalStateConflictEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalStateConflictEvent>> response = controller
+                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalStateConflictEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSignalStateConflictEventsWithPagination() {
+        SignalStateConflictEvent event = MockEventGenerator.getSignalStateConflictEvent();
+
+        List<SignalStateConflictEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SignalStateConflictEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(signalStateConflictEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalStateConflictEvent>> response = controller
+                .findSignalStateConflictEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalStateConflictEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSignalStateConflictEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSignalStateConflictEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSignalStateConflictEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalStateConflictEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSignalStateConflictEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(signalStateConflictEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailySignalStateConflictEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailySignalStateConflictEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailySignalStateConflictEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalStateConflictEventRepo.getAggregatedDailySignalStateConflictEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailySignalStateConflictEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(signalStateConflictEventRepo, times(1))
+                .getAggregatedDailySignalStateConflictEventCounts(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLinePassageEventWithTestData() {
+        StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
+
+        List<StopLinePassageEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLinePassageEvent>> response = controller
+                .findStopLinePassageEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLinePassageEventsWithLatestFlag() {
+        StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
+
+        List<StopLinePassageEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLinePassageEvent> mockPage = new PageImpl<>(events);
+        when(stopLinePassageEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageEvent>> response = controller
+                .findStopLinePassageEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLinePassageEventsWithPagination() {
+        StopLinePassageEvent event = MockEventGenerator.getStopLinePassageEvent();
+
+        List<StopLinePassageEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLinePassageEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLinePassageEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageEvent>> response = controller
+                .findStopLinePassageEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLinePassageEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLinePassageEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLinePassageEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLinePassageEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailyStopLinePassageEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyStopLinePassageEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailyStopLinePassageEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLinePassageEventRepo.getAggregatedDailyStopLinePassageEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyStopLinePassageEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(stopLinePassageEventRepo, times(1)).getAggregatedDailyStopLinePassageEventCounts(intersectionID,
+                startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLineStopEventWithTestData() {
+        StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
+
+        List<StopLineStopEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLineStopEvent>> response = controller
+                .findStopLineStopEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLineStopEventsWithLatestFlag() {
+        StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
+
+        List<StopLineStopEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLineStopEvent> mockPage = new PageImpl<>(events);
+        when(stopLineStopEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopEvent>> response = controller
+                .findStopLineStopEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLineStopEventsWithPagination() {
+        StopLineStopEvent event = MockEventGenerator.getStopLineStopEvent();
+
+        List<StopLineStopEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLineStopEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLineStopEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopEvent>> response = controller
+                .findStopLineStopEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLineStopEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLineStopEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLineStopEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLineStopEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLineStopEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLineStopEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailyStopLineStopEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyStopLineStopEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailyStopLineStopEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLineStopEventRepo.getAggregatedDailyStopLineStopEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyStopLineStopEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(stopLineStopEventRepo, times(1)).getAggregatedDailyStopLineStopEventCounts(intersectionID,
+                startTime, endTime);
+    }
+
+    @Test
+    void testFindTimeChangeDetailsEventWithTestData() {
+        TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
+
+        List<TimeChangeDetailsEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
+                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindTimeChangeDetailsEventsWithLatestFlag() {
+        TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
+
+        List<TimeChangeDetailsEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<TimeChangeDetailsEvent> mockPage = new PageImpl<>(events);
+        when(timeChangeDetailsEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
+                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(timeChangeDetailsEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindTimeChangeDetailsEventsWithPagination() {
+        TimeChangeDetailsEvent event = MockEventGenerator.getTimeChangeDetailsEvent();
+
+        List<TimeChangeDetailsEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<TimeChangeDetailsEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(timeChangeDetailsEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<TimeChangeDetailsEvent>> response = controller
+                .findTimeChangeDetailsEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(timeChangeDetailsEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountTimeChangeDetailsEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countTimeChangeDetailsEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountTimeChangeDetailsEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(timeChangeDetailsEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countTimeChangeDetailsEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(timeChangeDetailsEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    public void testGetDailyTimeChangeDetailsEventCountsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyTimeChangeDetailsEventCounts(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().size()).isEqualTo(3); // Test data should return 1L
+    }
+
+    @Test
+    public void testGetDailyTimeChangeDetailsEventCounts() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        List<IDCount> expectedCounts = List.of(new IDCount("1", 5.0));
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(timeChangeDetailsEventRepo.getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID,
+                startTime, endTime))
+                .thenReturn(expectedCounts);
+
+        ResponseEntity<List<IDCount>> response = controller.getDailyTimeChangeDetailsEventCounts(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCounts);
+        verify(timeChangeDetailsEventRepo, times(1))
+                .getAggregatedDailyTimeChangeDetailsEventCounts(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSpatMinimumDataEventWithTestData() {
+        SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
+
+        List<SpatMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
+                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertTrue(response.getBody().getContent().isEmpty()); // Test data should return empty
+    }
+
+    @Test
+    void testFindSpatMinimumDataEventsWithLatestFlag() {
+        SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
+
+        List<SpatMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SpatMinimumDataEvent> mockPage = new PageImpl<>(events);
+        when(spatMinimumDataEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
+                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatMinimumDataEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSpatMinimumDataEventsWithPagination() {
+        SpatMinimumDataEvent event = MockEventGenerator.getSpatMinimumDataEvent();
+
+        List<SpatMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SpatMinimumDataEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(spatMinimumDataEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatMinimumDataEvent>> response = controller
+                .findSpatMinimumDataEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatMinimumDataEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSpatMinimumDataEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSpatMinimumDataEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSpatMinimumDataEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(spatMinimumDataEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSpatMinimumDataEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(spatMinimumDataEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindMapMinimumDataEventWithTestData() {
+        MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
+
+        List<MapMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<MapMinimumDataEvent>> response = controller
+                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertTrue(response.getBody().getContent().isEmpty()); // Test data should return empty
+    }
+
+    @Test
+    void testFindMapMinimumDataEventsWithLatestFlag() {
+        MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
+
+        List<MapMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<MapMinimumDataEvent> mockPage = new PageImpl<>(events);
+        when(mapMinimumDataEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapMinimumDataEvent>> response = controller
+                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapMinimumDataEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindMapMinimumDataEventsWithPagination() {
+        MapMinimumDataEvent event = MockEventGenerator.getMapMinimumDataEvent();
+
+        List<MapMinimumDataEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<MapMinimumDataEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(mapMinimumDataEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapMinimumDataEvent>> response = controller
+                .findMapMinimumDataEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapMinimumDataEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountMapMinimumDataEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countMapMinimumDataEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountMapMinimumDataEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(mapMinimumDataEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countMapMinimumDataEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(mapMinimumDataEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindMapBroadcastRateEventWithTestData() {
+        MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
+
+        List<MapBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
+                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindMapBroadcastRateEventsWithLatestFlag() {
+        MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
+
+        List<MapBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<MapBroadcastRateEvent> mockPage = new PageImpl<>(events);
+        when(mapBroadcastRateEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
+                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapBroadcastRateEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindMapBroadcastRateEventsWithPagination() {
+        MapBroadcastRateEvent event = MockEventGenerator.getMapBroadcastRateEvent();
+
+        List<MapBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<MapBroadcastRateEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(mapBroadcastRateEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapBroadcastRateEvent>> response = controller
+                .findMapBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapBroadcastRateEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountMapBroadcastRateEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countMapBroadcastRateEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountMapBroadcastRateEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(mapBroadcastRateEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countMapBroadcastRateEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(mapBroadcastRateEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSpatBroadcastRateEventWithTestData() {
+        SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
+
+        List<SpatBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
+                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSpatBroadcastRateEventsWithLatestFlag() {
+        SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
+
+        List<SpatBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SpatBroadcastRateEvent> mockPage = new PageImpl<>(events);
+        when(spatBroadcastRateEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
+                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatBroadcastRateEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSpatBroadcastRateEventsWithPagination() {
+        SpatBroadcastRateEvent event = MockEventGenerator.getSpatBroadcastRateEvent();
+
+        List<SpatBroadcastRateEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SpatBroadcastRateEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(spatBroadcastRateEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatBroadcastRateEvent>> response = controller
+                .findSpatBroadcastRateEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatBroadcastRateEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSpatBroadcastRateEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSpatBroadcastRateEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSpatBroadcastRateEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(spatBroadcastRateEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSpatBroadcastRateEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(spatBroadcastRateEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSpatMessageCountProgressionEventWithTestData() {
+        SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
+
+        List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
+                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSpatMessageCountProgressionEventsWithLatestFlag() {
+        SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
+
+        List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SpatMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
+        when(spatMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
+                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSpatMessageCountProgressionEventsWithPagination() {
+        SpatMessageCountProgressionEvent event = MockEventGenerator.getSpatMessageCountProgressionEvent();
+
+        List<SpatMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SpatMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(spatMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatMessageCountProgressionEvent>> response = controller
+                .findSpatMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatMessageCountProgressionEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSpatMessageCountProgressionEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSpatMessageCountProgressionEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSpatMessageCountProgressionEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(spatMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSpatMessageCountProgressionEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(spatMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    void testFindMapMessageCountProgressionEventWithTestData() {
+        MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
+
+        List<MapMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
+                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindMapMessageCountProgressionEventsWithLatestFlag() {
+        MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
+
+        List<MapMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<MapMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
+        when(mapMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
+                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindMapMessageCountProgressionEventsWithPagination() {
+        MapMessageCountProgressionEvent event = MockEventGenerator.getMapMessageCountProgressionEvent();
+
+        List<MapMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<MapMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(mapMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapMessageCountProgressionEvent>> response = controller
+                .findMapMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapMessageCountProgressionEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountMapMessageCountProgressionEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countMapMessageCountProgressionEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountMapMessageCountProgressionEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(mapMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countMapMessageCountProgressionEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(mapMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindBsmMessageCountProgressionEventWithTestData() {
+        BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
+
+        List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
+                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindBsmMessageCountProgressionEventsWithLatestFlag() {
+        BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
+
+        List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<BsmMessageCountProgressionEvent> mockPage = new PageImpl<>(events);
+        when(bsmMessageCountProgressionEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
+                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(bsmMessageCountProgressionEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindBsmMessageCountProgressionEventsWithPagination() {
+        BsmMessageCountProgressionEvent event = MockEventGenerator.getBsmMessageCountProgressionEvent();
+
+        List<BsmMessageCountProgressionEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<BsmMessageCountProgressionEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(bsmMessageCountProgressionEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<BsmMessageCountProgressionEvent>> response = controller
+                .findBsmMessageCountProgressionEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(bsmMessageCountProgressionEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountBsmMessageCountProgressionEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countBsmMessageCountProgressionEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountBsmMessageCountProgressionEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(bsmMessageCountProgressionEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countBsmMessageCountProgressionEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(bsmMessageCountProgressionEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindBsmEventWithTestData() {
+        BsmEvent event = MockEventGenerator.getBsmEvent();
+
+        List<BsmEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<BsmEvent>> response = controller
+                .findBsmEvents(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindBsmEventsWithLatestFlag() {
+        BsmEvent event = MockEventGenerator.getBsmEvent();
+
+        List<BsmEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<BsmEvent> mockPage = new PageImpl<>(events);
+        when(bsmEventRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<BsmEvent>> response = controller
+                .findBsmEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(bsmEventRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindBsmEventsWithPagination() {
+        BsmEvent event = MockEventGenerator.getBsmEvent();
+
+        List<BsmEvent> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<BsmEvent> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(bsmEventRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<BsmEvent>> response = controller
+                .findBsmEvents(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(bsmEventRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountBsmEventsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countBsmEvents(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountBsmEvents() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(bsmEventRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countBsmEvents(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(bsmEventRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testGetBsmActivityByMinuteInRangeWithTestData() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
+                intersectionID, startTime, endTime, false, 0, 10, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isNotEmpty();
+        assertThat(response.getBody().getContent().size()).isEqualTo(10); // Test data generates 10 items
+    }
+
+    @Test
+    void testGetBsmActivityByMinuteInRangeWithLatestFlag() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        boolean latest = true;
+        boolean testData = false;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        Page<BsmEvent> mockPage = new PageImpl<>(Collections.emptyList());
+        when(bsmEventRepo.findLatest(intersectionID, startTime, endTime)).thenReturn(mockPage);
+
+        ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
+                intersectionID, startTime, endTime, latest, 0, 10, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEmpty(); // No events in the mock repository
+        verify(bsmEventRepo, times(1)).findLatest(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testGetBsmActivityByMinuteInRangeWithPagination() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        boolean latest = false;
+        boolean testData = false;
+        J2735Bsm bsm = new J2735Bsm();
+        J2735BsmCoreData coreData = new J2735BsmCoreData();
+        coreData.setId("id");
+        bsm.setCoreData(coreData);
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        BsmEvent mockEvent = new BsmEvent();
+        mockEvent.setStartingBsm(new OdeBsmData(new OdeMsgMetadata(), new OdeMsgPayload(bsm)));
+        mockEvent.setEndingBsm(new OdeBsmData(new OdeMsgMetadata(), new OdeMsgPayload()));
+        Page<BsmEvent> mockPage = new PageImpl<>(Collections.singletonList(mockEvent), PageRequest.of(0, 10),
+                1);
+        when(bsmEventRepo.find(intersectionID, startTime, endTime, 0, 10)).thenReturn(mockPage);
+
+        ResponseEntity<Page<MinuteCount>> response = controller.getBsmActivityByMinuteInRange(
+                intersectionID, startTime, endTime, latest, 0, 10, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isNotEmpty();
+        verify(bsmEventRepo, times(1)).find(intersectionID, startTime, endTime, 0, 10);
+    }
 
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/CmNotificationControllerTest.java
@@ -54,1141 +54,1141 @@ import us.dot.its.jpo.ode.mockdata.MockNotificationGenerator;
 @AutoConfigureEmbeddedDatabase
 public class CmNotificationControllerTest {
 
-        private final CmNotificationController controller;
+    private final CmNotificationController controller;
 
-        @MockBean
-        IntersectionReferenceAlignmentNotificationRepository intersectionReferenceAlignmentNotificationRepo;
+    @MockBean
+    IntersectionReferenceAlignmentNotificationRepository intersectionReferenceAlignmentNotificationRepo;
 
-        @MockBean
-        LaneDirectionOfTravelNotificationRepository laneDirectionOfTravelNotificationRepo;
+    @MockBean
+    LaneDirectionOfTravelNotificationRepository laneDirectionOfTravelNotificationRepo;
 
-        @MockBean
-        MapBroadcastRateNotificationRepository mapBroadcastRateNotificationRepo;
+    @MockBean
+    MapBroadcastRateNotificationRepository mapBroadcastRateNotificationRepo;
 
-        @MockBean
-        SignalGroupAlignmentNotificationRepository signalGroupAlignmentNotificationRepo;
+    @MockBean
+    SignalGroupAlignmentNotificationRepository signalGroupAlignmentNotificationRepo;
 
-        @MockBean
-        SignalStateConflictNotificationRepository signalStateConflictNotificationRepo;
+    @MockBean
+    SignalStateConflictNotificationRepository signalStateConflictNotificationRepo;
 
-        @MockBean
-        SpatBroadcastRateNotificationRepository spatBroadcastRateNotificationRepo;
+    @MockBean
+    SpatBroadcastRateNotificationRepository spatBroadcastRateNotificationRepo;
 
-        @MockBean
-        ConnectionOfTravelNotificationRepository connectionOfTravelNotificationRepo;
+    @MockBean
+    ConnectionOfTravelNotificationRepository connectionOfTravelNotificationRepo;
 
-        @MockBean
-        StopLineStopNotificationRepository stopLineStopNotificationRepo;
+    @MockBean
+    StopLineStopNotificationRepository stopLineStopNotificationRepo;
 
-        @MockBean
-        StopLinePassageNotificationRepository stopLinePassageNotificationRepo;
+    @MockBean
+    StopLinePassageNotificationRepository stopLinePassageNotificationRepo;
 
-        @MockBean
-        TimeChangeDetailsNotificationRepository timeChangeDetailsNotificationRepo;
+    @MockBean
+    TimeChangeDetailsNotificationRepository timeChangeDetailsNotificationRepo;
 
-        @MockBean
-        PermissionService permissionService;
+    @MockBean
+    PermissionService permissionService;
 
-        @Autowired
-        public CmNotificationControllerTest(CmNotificationController controller) {
-                this.controller = controller;
-        }
+    @Autowired
+    public CmNotificationControllerTest(CmNotificationController controller) {
+        this.controller = controller;
+    }
 
-        @Test
-        void testFindConnectionOfTravelNotificationWithTestData() {
-                ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
+    @Test
+    void testFindConnectionOfTravelNotificationWithTestData() {
+        ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
 
-                List<ConnectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
+        List<ConnectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
 
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
 
-                ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
-                                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
+        ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
+                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
 
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
 
-        @Test
-        void testFindConnectionOfTravelNotificationsWithLatestFlag() {
-                ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
+    @Test
+    void testFindConnectionOfTravelNotificationsWithLatestFlag() {
+        ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
 
-                List<ConnectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
+        List<ConnectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
 
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
 
-                Page<ConnectionOfTravelNotification> mockPage = new PageImpl<>(events);
-                when(connectionOfTravelNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
-                                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
+        Page<ConnectionOfTravelNotification> mockPage = new PageImpl<>(events);
+        when(connectionOfTravelNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
+                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
 
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindConnectionOfTravelNotificationsWithPagination() {
-                ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
-
-                List<ConnectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<ConnectionOfTravelNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(connectionOfTravelNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
-                                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(connectionOfTravelNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountConnectionOfTravelNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountConnectionOfTravelNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(connectionOfTravelNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countConnectionOfTravelNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(connectionOfTravelNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindIntersectionReferenceAlignmentNotificationWithTestData() {
-                IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
-                                .getIntersectionReferenceAlignmentNotification();
-
-                List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
-                                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
-                                                false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindIntersectionReferenceAlignmentNotificationsWithLatestFlag() {
-                IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
-                                .getIntersectionReferenceAlignmentNotification();
-
-                List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<IntersectionReferenceAlignmentNotification> mockPage = new PageImpl<>(events);
-                when(intersectionReferenceAlignmentNotificationRepo.findLatest(eq(event.getIntersectionID()), any(),
-                                any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
-                                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
-                                                latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(intersectionReferenceAlignmentNotificationRepo, times(1)).findLatest(
-                                eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindIntersectionReferenceAlignmentNotificationsWithPagination() {
-                IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
-                                .getIntersectionReferenceAlignmentNotification();
-
-                List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<IntersectionReferenceAlignmentNotification> mockPage = new PageImpl<>(events,
-                                PageRequest.of(0, 10), 1);
-                when(intersectionReferenceAlignmentNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
-                                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
-                                                latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(intersectionReferenceAlignmentNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountIntersectionReferenceAlignmentNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentNotifications(
-                                intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountIntersectionReferenceAlignmentNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(intersectionReferenceAlignmentNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentNotifications(
-                                intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(intersectionReferenceAlignmentNotificationRepo, times(1)).count(intersectionID, startTime,
-                                endTime);
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelNotificationWithTestData() {
-                LaneDirectionOfTravelNotification event = MockNotificationGenerator
-                                .getLaneDirectionOfTravelNotification();
-
-                List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
-                                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelNotificationsWithLatestFlag() {
-                LaneDirectionOfTravelNotification event = MockNotificationGenerator
-                                .getLaneDirectionOfTravelNotification();
-
-                List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<LaneDirectionOfTravelNotification> mockPage = new PageImpl<>(events);
-                when(laneDirectionOfTravelNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
-                                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindLaneDirectionOfTravelNotificationsWithPagination() {
-                LaneDirectionOfTravelNotification event = MockNotificationGenerator
-                                .getLaneDirectionOfTravelNotification();
-
-                List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<LaneDirectionOfTravelNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(laneDirectionOfTravelNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
-                                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(laneDirectionOfTravelNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountLaneDirectionOfTravelNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(laneDirectionOfTravelNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countLaneDirectionOfTravelNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(laneDirectionOfTravelNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindMapBroadcastRateNotificationWithTestData() {
-                MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
-
-                List<MapBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
-                                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindMapBroadcastRateNotificationsWithLatestFlag() {
-                MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
-
-                List<MapBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<MapBroadcastRateNotification> mockPage = new PageImpl<>(events);
-                when(mapBroadcastRateNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
-                                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapBroadcastRateNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindMapBroadcastRateNotificationsWithPagination() {
-                MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
-
-                List<MapBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<MapBroadcastRateNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(mapBroadcastRateNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
-                                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(mapBroadcastRateNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountMapBroadcastRateNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countMapBroadcastRateNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountMapBroadcastRateNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(mapBroadcastRateNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countMapBroadcastRateNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(mapBroadcastRateNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentNotificationWithTestData() {
-                SignalGroupAlignmentNotification event = MockNotificationGenerator
-                                .getSignalGroupAlignmentNotification();
-
-                List<SignalGroupAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
-                                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentNotificationsWithLatestFlag() {
-                SignalGroupAlignmentNotification event = MockNotificationGenerator
-                                .getSignalGroupAlignmentNotification();
-
-                List<SignalGroupAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SignalGroupAlignmentNotification> mockPage = new PageImpl<>(events);
-                when(signalGroupAlignmentNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
-                                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalGroupAlignmentNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSignalGroupAlignmentNotificationsWithPagination() {
-                SignalGroupAlignmentNotification event = MockNotificationGenerator
-                                .getSignalGroupAlignmentNotification();
-
-                List<SignalGroupAlignmentNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SignalGroupAlignmentNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(signalGroupAlignmentNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
-                                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalGroupAlignmentNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSignalGroupAlignmentNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSignalGroupAlignmentNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSignalGroupAlignmentNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalGroupAlignmentNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSignalGroupAlignmentNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(signalGroupAlignmentNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSignalStateConflictNotificationWithTestData() {
-                SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
-
-                List<SignalStateConflictNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SignalStateConflictNotification>> response = controller
-                                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSignalStateConflictNotificationsWithLatestFlag() {
-                SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
-
-                List<SignalStateConflictNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SignalStateConflictNotification> mockPage = new PageImpl<>(events);
-                when(signalStateConflictNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalStateConflictNotification>> response = controller
-                                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalStateConflictNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSignalStateConflictNotificationsWithPagination() {
-                SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
-
-                List<SignalStateConflictNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SignalStateConflictNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(signalStateConflictNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SignalStateConflictNotification>> response = controller
-                                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(signalStateConflictNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSignalStateConflictNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSignalStateConflictNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSignalStateConflictNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(signalStateConflictNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSignalStateConflictNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(signalStateConflictNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindSpatBroadcastRateNotificationWithTestData() {
-                SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
-
-                List<SpatBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
-                                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindSpatBroadcastRateNotificationsWithLatestFlag() {
-                SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
-
-                List<SpatBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<SpatBroadcastRateNotification> mockPage = new PageImpl<>(events);
-                when(spatBroadcastRateNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
-                                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatBroadcastRateNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindSpatBroadcastRateNotificationsWithPagination() {
-                SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
-
-                List<SpatBroadcastRateNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<SpatBroadcastRateNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(spatBroadcastRateNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
-                                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(spatBroadcastRateNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountSpatBroadcastRateNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countSpatBroadcastRateNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountSpatBroadcastRateNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(spatBroadcastRateNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countSpatBroadcastRateNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(spatBroadcastRateNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLineStopNotificationWithTestData() {
-                StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
-
-                List<StopLineStopNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLineStopNotification>> response = controller
-                                .findStopLineStopNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLineStopNotificationsWithLatestFlag() {
-                StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
-
-                List<StopLineStopNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLineStopNotification> mockPage = new PageImpl<>(events);
-                when(stopLineStopNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopNotification>> response = controller
-                                .findStopLineStopNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLineStopNotificationsWithPagination() {
-                StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
-
-                List<StopLineStopNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLineStopNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLineStopNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLineStopNotification>> response = controller
-                                .findStopLineStopNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLineStopNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLineStopNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLineStopNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLineStopNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLineStopNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLineStopNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLineStopNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindStopLinePassageNotificationWithTestData() {
-                StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
-
-                List<StopLinePassageNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<StopLinePassageNotification>> response = controller
-                                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindStopLinePassageNotificationsWithLatestFlag() {
-                StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
-
-                List<StopLinePassageNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<StopLinePassageNotification> mockPage = new PageImpl<>(events);
-                when(stopLinePassageNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageNotification>> response = controller
-                                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindStopLinePassageNotificationsWithPagination() {
-                StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
-
-                List<StopLinePassageNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<StopLinePassageNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(stopLinePassageNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<StopLinePassageNotification>> response = controller
-                                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(stopLinePassageNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountStopLinePassageNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountStopLinePassageNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(stopLinePassageNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countStopLinePassageNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(stopLinePassageNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
-
-        @Test
-        void testFindTimeChangeDetailsNotificationWithTestData() {
-                TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
-
-                List<TimeChangeDetailsNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean testData = true;
-
-                ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
-                                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, false,
-                                                0, 10,
-                                                testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertFalse(response.getBody().getContent().isEmpty());
-        }
-
-        @Test
-        void testFindTimeChangeDetailsNotificationsWithLatestFlag() {
-                TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
-
-                List<TimeChangeDetailsNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = true;
-
-                Page<TimeChangeDetailsNotification> mockPage = new PageImpl<>(events);
-                when(timeChangeDetailsNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
-                                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(timeChangeDetailsNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
-                                any(), any());
-        }
-
-        @Test
-        void testFindTimeChangeDetailsNotificationsWithPagination() {
-                TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
-
-                List<TimeChangeDetailsNotification> events = new ArrayList<>();
-                events.add(event);
-
-                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                boolean latest = false;
-
-                Page<TimeChangeDetailsNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-                when(timeChangeDetailsNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                                any(PageRequest.class)))
-                                .thenReturn(mockPage);
-
-                ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
-                                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, latest,
-                                                0, 10,
-                                                false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody().getContent()).isEqualTo(events);
-                verify(timeChangeDetailsNotificationRepo, times(1))
-                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-        }
-
-        @Test
-        public void testCountTimeChangeDetailsNotificationsWithTestData() {
-                Integer intersectionID = 1;
-                boolean testData = true;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-
-                ResponseEntity<Long> response = controller.countTimeChangeDetailsNotifications(intersectionID,
-                                null, null, testData);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-        }
-
-        @Test
-        public void testCountTimeChangeDetailsNotifications() {
-                Integer intersectionID = 1;
-                Long startTime = 1000L;
-                Long endTime = 2000L;
-                Long expectedCount = 5L;
-
-                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
-                when(timeChangeDetailsNotificationRepo.count(intersectionID, startTime, endTime))
-                                .thenReturn(expectedCount);
-
-                ResponseEntity<Long> response = controller.countTimeChangeDetailsNotifications(intersectionID,
-                                startTime, endTime, false);
-
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(response.getBody()).isEqualTo(expectedCount);
-                verify(timeChangeDetailsNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
-        }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindConnectionOfTravelNotificationsWithPagination() {
+        ConnectionOfTravelNotification event = MockNotificationGenerator.getConnectionOfTravelNotification();
+
+        List<ConnectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<ConnectionOfTravelNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(connectionOfTravelNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<ConnectionOfTravelNotification>> response = controller
+                .findConnectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(connectionOfTravelNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountConnectionOfTravelNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountConnectionOfTravelNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(connectionOfTravelNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countConnectionOfTravelNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(connectionOfTravelNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindIntersectionReferenceAlignmentNotificationWithTestData() {
+        IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
+                .getIntersectionReferenceAlignmentNotification();
+
+        List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
+                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
+                        false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindIntersectionReferenceAlignmentNotificationsWithLatestFlag() {
+        IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
+                .getIntersectionReferenceAlignmentNotification();
+
+        List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<IntersectionReferenceAlignmentNotification> mockPage = new PageImpl<>(events);
+        when(intersectionReferenceAlignmentNotificationRepo.findLatest(eq(event.getIntersectionID()), any(),
+                any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
+                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
+                        latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(intersectionReferenceAlignmentNotificationRepo, times(1)).findLatest(
+                eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindIntersectionReferenceAlignmentNotificationsWithPagination() {
+        IntersectionReferenceAlignmentNotification event = MockNotificationGenerator
+                .getIntersectionReferenceAlignmentNotification();
+
+        List<IntersectionReferenceAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<IntersectionReferenceAlignmentNotification> mockPage = new PageImpl<>(events,
+                PageRequest.of(0, 10), 1);
+        when(intersectionReferenceAlignmentNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<IntersectionReferenceAlignmentNotification>> response = controller
+                .findIntersectionReferenceAlignmentNotifications(event.getIntersectionID(), null, null,
+                        latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(intersectionReferenceAlignmentNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountIntersectionReferenceAlignmentNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentNotifications(
+                intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountIntersectionReferenceAlignmentNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(intersectionReferenceAlignmentNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countIntersectionReferenceAlignmentNotifications(
+                intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(intersectionReferenceAlignmentNotificationRepo, times(1)).count(intersectionID, startTime,
+                endTime);
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelNotificationWithTestData() {
+        LaneDirectionOfTravelNotification event = MockNotificationGenerator
+                .getLaneDirectionOfTravelNotification();
+
+        List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
+                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelNotificationsWithLatestFlag() {
+        LaneDirectionOfTravelNotification event = MockNotificationGenerator
+                .getLaneDirectionOfTravelNotification();
+
+        List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<LaneDirectionOfTravelNotification> mockPage = new PageImpl<>(events);
+        when(laneDirectionOfTravelNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
+                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindLaneDirectionOfTravelNotificationsWithPagination() {
+        LaneDirectionOfTravelNotification event = MockNotificationGenerator
+                .getLaneDirectionOfTravelNotification();
+
+        List<LaneDirectionOfTravelNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<LaneDirectionOfTravelNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(laneDirectionOfTravelNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<LaneDirectionOfTravelNotification>> response = controller
+                .findLaneDirectionOfTravelNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(laneDirectionOfTravelNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountLaneDirectionOfTravelNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(laneDirectionOfTravelNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countLaneDirectionOfTravelNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(laneDirectionOfTravelNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindMapBroadcastRateNotificationWithTestData() {
+        MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
+
+        List<MapBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
+                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindMapBroadcastRateNotificationsWithLatestFlag() {
+        MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
+
+        List<MapBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<MapBroadcastRateNotification> mockPage = new PageImpl<>(events);
+        when(mapBroadcastRateNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
+                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapBroadcastRateNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindMapBroadcastRateNotificationsWithPagination() {
+        MapBroadcastRateNotification event = MockNotificationGenerator.getMapBroadcastRateNotification();
+
+        List<MapBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<MapBroadcastRateNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(mapBroadcastRateNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<MapBroadcastRateNotification>> response = controller
+                .findMapBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(mapBroadcastRateNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountMapBroadcastRateNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countMapBroadcastRateNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountMapBroadcastRateNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(mapBroadcastRateNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countMapBroadcastRateNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(mapBroadcastRateNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentNotificationWithTestData() {
+        SignalGroupAlignmentNotification event = MockNotificationGenerator
+                .getSignalGroupAlignmentNotification();
+
+        List<SignalGroupAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
+                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentNotificationsWithLatestFlag() {
+        SignalGroupAlignmentNotification event = MockNotificationGenerator
+                .getSignalGroupAlignmentNotification();
+
+        List<SignalGroupAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SignalGroupAlignmentNotification> mockPage = new PageImpl<>(events);
+        when(signalGroupAlignmentNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
+                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalGroupAlignmentNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSignalGroupAlignmentNotificationsWithPagination() {
+        SignalGroupAlignmentNotification event = MockNotificationGenerator
+                .getSignalGroupAlignmentNotification();
+
+        List<SignalGroupAlignmentNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SignalGroupAlignmentNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(signalGroupAlignmentNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalGroupAlignmentNotification>> response = controller
+                .findSignalGroupAlignmentNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalGroupAlignmentNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSignalGroupAlignmentNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSignalGroupAlignmentNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSignalGroupAlignmentNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalGroupAlignmentNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSignalGroupAlignmentNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(signalGroupAlignmentNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSignalStateConflictNotificationWithTestData() {
+        SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
+
+        List<SignalStateConflictNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SignalStateConflictNotification>> response = controller
+                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSignalStateConflictNotificationsWithLatestFlag() {
+        SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
+
+        List<SignalStateConflictNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SignalStateConflictNotification> mockPage = new PageImpl<>(events);
+        when(signalStateConflictNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalStateConflictNotification>> response = controller
+                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalStateConflictNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSignalStateConflictNotificationsWithPagination() {
+        SignalStateConflictNotification event = MockNotificationGenerator.getSignalStateConflictNotification();
+
+        List<SignalStateConflictNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SignalStateConflictNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(signalStateConflictNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SignalStateConflictNotification>> response = controller
+                .findSignalStateConflictNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(signalStateConflictNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSignalStateConflictNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSignalStateConflictNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSignalStateConflictNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(signalStateConflictNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSignalStateConflictNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(signalStateConflictNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindSpatBroadcastRateNotificationWithTestData() {
+        SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
+
+        List<SpatBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
+                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindSpatBroadcastRateNotificationsWithLatestFlag() {
+        SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
+
+        List<SpatBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<SpatBroadcastRateNotification> mockPage = new PageImpl<>(events);
+        when(spatBroadcastRateNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
+                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatBroadcastRateNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindSpatBroadcastRateNotificationsWithPagination() {
+        SpatBroadcastRateNotification event = MockNotificationGenerator.getSpatBroadcastRateNotification();
+
+        List<SpatBroadcastRateNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<SpatBroadcastRateNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(spatBroadcastRateNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<SpatBroadcastRateNotification>> response = controller
+                .findSpatBroadcastRateNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(spatBroadcastRateNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountSpatBroadcastRateNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countSpatBroadcastRateNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountSpatBroadcastRateNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(spatBroadcastRateNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countSpatBroadcastRateNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(spatBroadcastRateNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLineStopNotificationWithTestData() {
+        StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
+
+        List<StopLineStopNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLineStopNotification>> response = controller
+                .findStopLineStopNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLineStopNotificationsWithLatestFlag() {
+        StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
+
+        List<StopLineStopNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLineStopNotification> mockPage = new PageImpl<>(events);
+        when(stopLineStopNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopNotification>> response = controller
+                .findStopLineStopNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLineStopNotificationsWithPagination() {
+        StopLineStopNotification event = MockNotificationGenerator.getStopLineStopNotification();
+
+        List<StopLineStopNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLineStopNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLineStopNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLineStopNotification>> response = controller
+                .findStopLineStopNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLineStopNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLineStopNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLineStopNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLineStopNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLineStopNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLineStopNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLineStopNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindStopLinePassageNotificationWithTestData() {
+        StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
+
+        List<StopLinePassageNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<StopLinePassageNotification>> response = controller
+                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindStopLinePassageNotificationsWithLatestFlag() {
+        StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
+
+        List<StopLinePassageNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<StopLinePassageNotification> mockPage = new PageImpl<>(events);
+        when(stopLinePassageNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageNotification>> response = controller
+                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindStopLinePassageNotificationsWithPagination() {
+        StopLinePassageNotification event = MockNotificationGenerator.getStopLinePassageNotification();
+
+        List<StopLinePassageNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<StopLinePassageNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(stopLinePassageNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<StopLinePassageNotification>> response = controller
+                .findStopLinePassageNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(stopLinePassageNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountStopLinePassageNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountStopLinePassageNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(stopLinePassageNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countStopLinePassageNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(stopLinePassageNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
+
+    @Test
+    void testFindTimeChangeDetailsNotificationWithTestData() {
+        TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
+
+        List<TimeChangeDetailsNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean testData = true;
+
+        ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
+                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, false,
+                        0, 10,
+                        testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertFalse(response.getBody().getContent().isEmpty());
+    }
+
+    @Test
+    void testFindTimeChangeDetailsNotificationsWithLatestFlag() {
+        TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
+
+        List<TimeChangeDetailsNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = true;
+
+        Page<TimeChangeDetailsNotification> mockPage = new PageImpl<>(events);
+        when(timeChangeDetailsNotificationRepo.findLatest(eq(event.getIntersectionID()), any(), any()))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
+                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(timeChangeDetailsNotificationRepo, times(1)).findLatest(eq(event.getIntersectionID()),
+                any(), any());
+    }
+
+    @Test
+    void testFindTimeChangeDetailsNotificationsWithPagination() {
+        TimeChangeDetailsNotification event = MockNotificationGenerator.getTimeChangeDetailsNotification();
+
+        List<TimeChangeDetailsNotification> events = new ArrayList<>();
+        events.add(event);
+
+        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        boolean latest = false;
+
+        Page<TimeChangeDetailsNotification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+        when(timeChangeDetailsNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                eq(0), eq(10)))
+                .thenReturn(mockPage);
+
+        ResponseEntity<Page<TimeChangeDetailsNotification>> response = controller
+                .findTimeChangeDetailsNotifications(event.getIntersectionID(), null, null, latest,
+                        0, 10,
+                        false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent()).isEqualTo(events);
+        verify(timeChangeDetailsNotificationRepo, times(1))
+                .find(eq(event.getIntersectionID()), any(), any(), eq(0), eq(10));
+    }
+
+    @Test
+    public void testCountTimeChangeDetailsNotificationsWithTestData() {
+        Integer intersectionID = 1;
+        boolean testData = true;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+
+        ResponseEntity<Long> response = controller.countTimeChangeDetailsNotifications(intersectionID,
+                null, null, testData);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+    }
+
+    @Test
+    public void testCountTimeChangeDetailsNotifications() {
+        Integer intersectionID = 1;
+        Long startTime = 1000L;
+        Long endTime = 2000L;
+        Long expectedCount = 5L;
+
+        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
+        when(timeChangeDetailsNotificationRepo.count(intersectionID, startTime, endTime))
+                .thenReturn(expectedCount);
+
+        ResponseEntity<Long> response = controller.countTimeChangeDetailsNotifications(intersectionID,
+                startTime, endTime, false);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedCount);
+        verify(timeChangeDetailsNotificationRepo, times(1)).count(intersectionID, startTime, endTime);
+    }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/MapControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/MapControllerTest.java
@@ -58,7 +58,7 @@ public class MapControllerTest {
         PageRequest page = PageRequest.of(1, 1);
         when(processedMapRepo.find(map.getProperties().getIntersectionId(),
                 map.getProperties().getTimeStamp().toEpochSecond() - 1,
-                map.getProperties().getTimeStamp().toEpochSecond() + 1, false, PageRequest.of(1, 1)))
+                map.getProperties().getTimeStamp().toEpochSecond() + 1, false, 1, 1))
                 .thenReturn(new PageImpl<>(maps, page, 1L));
 
         ResponseEntity<Page<ProcessedMap<LineString>>> result = controller

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/SpatControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/data/SpatControllerTest.java
@@ -57,7 +57,7 @@ public class SpatControllerTest {
         PageRequest page = PageRequest.of(1, 1);
         when(processedSpatRepo.find(spat.getIntersectionId(),
                 spat.getUtcTimeStamp().toEpochSecond() - 1,
-                spat.getUtcTimeStamp().toEpochSecond() + 1, false, PageRequest.of(1, 1)))
+                spat.getUtcTimeStamp().toEpochSecond() + 1, false, 1, 1))
                 .thenReturn(new PageImpl<>(spats, page, 1L));
 
         ResponseEntity<Page<ProcessedSpat>> result = controller

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
@@ -37,59 +37,59 @@ import us.dot.its.jpo.ode.mockdata.MockNotificationGenerator;
 @AutoConfigureEmbeddedDatabase
 public class ActiveNotificationControllerTest {
 
-        private final ActiveNotificationController controller;
+    private final ActiveNotificationController controller;
 
-        @MockBean
-        ActiveNotificationRepository activeNotificationRepo;
+    @MockBean
+    ActiveNotificationRepository activeNotificationRepo;
 
-        @MockBean
-        PermissionService permissionService;
+    @MockBean
+    PermissionService permissionService;
 
-        @Autowired
-        public ActiveNotificationControllerTest(ActiveNotificationController controller) {
-                this.controller = controller;
-        }
+    @Autowired
+    public ActiveNotificationControllerTest(ActiveNotificationController controller) {
+        this.controller = controller;
+    }
 
-        @Test
-        public void testActiveNotification() {
-                List<Integer> allowedInteresections = new ArrayList<>();
-                allowedInteresections.add(null);
+    @Test
+    public void testActiveNotification() {
+        List<Integer> allowedInteresections = new ArrayList<>();
+        allowedInteresections.add(null);
 
-                when(permissionService.hasIntersection(null, "USER")).thenReturn(true);
-                when(permissionService.hasRole("USER")).thenReturn(true);
+        when(permissionService.hasIntersection(null, "USER")).thenReturn(true);
+        when(permissionService.hasRole("USER")).thenReturn(true);
 
-                SpatBroadcastRateNotification spatBroadcastRateNotification = MockNotificationGenerator
-                                .getSpatBroadcastRateNotification();
-                SignalStateConflictNotification signalStateConflictNotification = MockNotificationGenerator
-                                .getSignalStateConflictNotification();
-                SignalGroupAlignmentNotification signalGroupAlignmentNotification = MockNotificationGenerator
-                                .getSignalGroupAlignmentNotification();
-                MapBroadcastRateNotification mapBroadcastRateNotification = MockNotificationGenerator
-                                .getMapBroadcastRateNotification();
-                LaneDirectionOfTravelNotification laneDirectionOfTravelNotification = MockNotificationGenerator
-                                .getLaneDirectionOfTravelNotification();
-                ConnectionOfTravelNotification connectionOfTravelNotification = MockNotificationGenerator
-                                .getConnectionOfTravelNotification();
+        SpatBroadcastRateNotification spatBroadcastRateNotification = MockNotificationGenerator
+                .getSpatBroadcastRateNotification();
+        SignalStateConflictNotification signalStateConflictNotification = MockNotificationGenerator
+                .getSignalStateConflictNotification();
+        SignalGroupAlignmentNotification signalGroupAlignmentNotification = MockNotificationGenerator
+                .getSignalGroupAlignmentNotification();
+        MapBroadcastRateNotification mapBroadcastRateNotification = MockNotificationGenerator
+                .getMapBroadcastRateNotification();
+        LaneDirectionOfTravelNotification laneDirectionOfTravelNotification = MockNotificationGenerator
+                .getLaneDirectionOfTravelNotification();
+        ConnectionOfTravelNotification connectionOfTravelNotification = MockNotificationGenerator
+                .getConnectionOfTravelNotification();
 
-                List<Notification> notifications = new ArrayList<>();
-                notifications.add(spatBroadcastRateNotification);
-                notifications.add(signalStateConflictNotification);
-                notifications.add(signalGroupAlignmentNotification);
-                notifications.add(mapBroadcastRateNotification);
-                notifications.add(laneDirectionOfTravelNotification);
-                notifications.add(connectionOfTravelNotification);
+        List<Notification> notifications = new ArrayList<>();
+        notifications.add(spatBroadcastRateNotification);
+        notifications.add(signalStateConflictNotification);
+        notifications.add(signalGroupAlignmentNotification);
+        notifications.add(mapBroadcastRateNotification);
+        notifications.add(laneDirectionOfTravelNotification);
+        notifications.add(connectionOfTravelNotification);
 
-                PageRequest page = PageRequest.of(1, 1);
-                when(activeNotificationRepo.find(null,
-                                null,
-                                null, PageRequest.of(1, 1)))
-                                .thenReturn(new PageImpl<>(notifications, page, 1L));
+        PageRequest page = PageRequest.of(1, 1);
+        when(activeNotificationRepo.find(null,
+                null,
+                null, 1, 1))
+                .thenReturn(new PageImpl<>(notifications, page, 1L));
 
-                ResponseEntity<Page<Notification>> result = controller
-                                .findActiveNotifications(
-                                                null, null, null, 1, 1, false);
-                assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-                assertThat(result.getBody().getContent()).isEqualTo(notifications);
-        }
+        ResponseEntity<Page<Notification>> result = controller
+                .findActiveNotifications(
+                        null, null, null, 1, 1, false);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().getContent()).isEqualTo(notifications);
+    }
 
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/ReportServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/ReportServiceTest.java
@@ -14,6 +14,7 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MapMini
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
 import us.dot.its.jpo.ode.api.accessors.assessments.lane_direction_of_travel_assessment.LaneDirectionOfTravelAssessmentRepository;
 import us.dot.its.jpo.ode.api.accessors.events.connection_of_travel_event.ConnectionOfTravelEventRepository;
 import us.dot.its.jpo.ode.api.accessors.events.intersection_reference_alignment_event.IntersectionReferenceAlignmentEventRepository;
@@ -41,9 +42,13 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 class ReportServiceTest {
+
+    @Mock
+    private ConflictMonitorApiProperties props;
 
     @Mock
     private ProcessedMapRepository processedMapRepo;
@@ -93,6 +98,8 @@ class ReportServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
+        when(props.getMaximumResponseSize()).thenReturn(1000);
+
         // Manually instantiate ReportService with mocked dependencies
         reportService = new ReportService(
                 processedMapRepo,
@@ -109,8 +116,7 @@ class ReportServiceTest {
                 spatBroadcastRateEventRepo,
                 mapBroadcastRateEventRepo,
                 reportRepo,
-                1000 // Example value for maximumResponseSize
-        );
+                props);
     }
 
     @Test
@@ -163,12 +169,12 @@ class ReportServiceTest {
 
         // Mock StopLineStopEventRepository
         Page<StopLineStopEvent> stopLineStopEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
+        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), isNull(), eq(1000)))
                 .thenReturn(stopLineStopEventsPage);
 
         // Mock StopLinePassageEventRepository
         Page<StopLinePassageEvent> stopLinePassageEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
+        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), isNull(), eq(1000)))
                 .thenReturn(stopLinePassageEventsPage);
 
         // Mock ReportRepository
@@ -237,12 +243,12 @@ class ReportServiceTest {
 
         // Mock StopLineStopEventRepository
         Page<StopLineStopEvent> stopLineStopEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
+        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), isNull(), eq(1000)))
                 .thenReturn(stopLineStopEventsPage);
 
         // Mock StopLinePassageEventRepository
         Page<StopLinePassageEvent> stopLinePassageEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
+        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), isNull(), eq(1000)))
                 .thenReturn(stopLinePassageEventsPage);
 
         // Act

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/ReportServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/ReportServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessment;
 import us.dot.its.jpo.conflictmonitor.monitor.models.assessments.LaneDirectionOfTravelAssessmentGroup;
@@ -164,12 +163,12 @@ class ReportServiceTest {
 
         // Mock StopLineStopEventRepository
         Page<StopLineStopEvent> stopLineStopEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(PageRequest.class)))
+        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
                 .thenReturn(stopLineStopEventsPage);
 
         // Mock StopLinePassageEventRepository
         Page<StopLinePassageEvent> stopLinePassageEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(PageRequest.class)))
+        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
                 .thenReturn(stopLinePassageEventsPage);
 
         // Mock ReportRepository
@@ -238,12 +237,12 @@ class ReportServiceTest {
 
         // Mock StopLineStopEventRepository
         Page<StopLineStopEvent> stopLineStopEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(PageRequest.class)))
+        when(stopLineStopEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
                 .thenReturn(stopLineStopEventsPage);
 
         // Mock StopLinePassageEventRepository
         Page<StopLinePassageEvent> stopLinePassageEventsPage = new PageImpl<>(Collections.emptyList());
-        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(PageRequest.class)))
+        when(stopLinePassageEventRepo.find(eq(intersectionID), eq(startTime), eq(endTime), any(), any()))
                 .thenReturn(stopLinePassageEventsPage);
 
         // Act


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

After completing some performance testing comparing a simple "find" query with the paged aggregation queries now implemented in much of the Intersection API, I found the following results:
| Elements in collection | Elements matching query | Limit | Exec Time Aggregation | Exec Time Find |
|--|--|--|--|--|
| 500 | 20 | 100 | 3 ms | 1 ms |
| 56k | 1818 | 1 | 56 ms | 3 ms |
| 56k | 1818 | 100 | 126 ms | 9 ms |
| 56k | 1818 | 2000 | 133 ms | 122 ms |
| 56k | 7272 | 100 | 65 ms | 9 ms |
| 56k | 7272 | 1000 | 90 ms | 70 ms |
| 56k | 7272 | 5000 | 220 ms | 220 ms |
| 56k | 30300 | 100 | 80 ms | 8 ms |
| 56k | 30300 | 1000 | 160 ms | 68 ms |
| 56k | 30300 | 5000 | 350 ms | 250 ms |

As expected, the query times are similar when the limit does not impact the result (limit is higher than result count). But when the result count is extremely large and a limit is applied, the find query significantly outperfoms the aggregation query. This is because the aggregation query looks over all results to generate a total count, whereas the find query stops at the desired limit.

These results led the conflusion that running paginated aggregation queries should be avoided when possible. My solution is to run the simpler find queries by default and only run paginated queries when the request specifies a page number (0 for first page). This was managed by making page a nullable Integer without a default value and having accessors choose whether to aggregate or find based on whether pageNumber is null. This update was applied to all accessors and controllers.

For reference, here are the two general queries I was testing with:
1. Aggregation Query
```json
{
  "aggregate": "OdeBsmJson",
  "pipeline": [
    {
      "$match": {
        "metadata.odeReceivedAt": {
          "$gte": "2024-08-20T16:17:38.205Z",
          "$lte": "2024-08-20T16:19:38.205Z"
        },
        "payload.data.coreData.position.latitude": {
          "$gte": 39.58353787808079,
          "$lte": 39.59254471841856
        },
        "payload.data.coreData.position.longitude": {
          "$gte": -105.09670579647285,
          "$lte": -105.08506500352716
        }
      }
    },
    { "$sort": { "metadata.odeReceivedAt": -1 } },
    { "$project": { "recordGeneratedAt": 0 } },
    {
      "$facet": {
        "metadata": [{ "$count": "count" }],
        "results": [{ "$skip": 0 }, { "$limit": 100 }]
      }
    }
  ]
}

```
2. Find Query
```json
{
  "metadata.odeReceivedAt": {
    "$gte": "2024-08-20T16:17:38.205Z",
    "$lte": "2024-08-20T16:19:38.205Z"
  },
  "payload.data.coreData.position.latitude": {
    "$gte": 39.58353787808079,
    "$lte": 39.59254471841856
  },
  "payload.data.coreData.position.longitude": {
    "$gte": -105.09670579647285,
    "$lte": -105.08506500352716
  }
}
```
**Note**
There are a lot of files changed - I tried to avoid unnecessary changes, while still keeping the accessors as similar as I could. I also fixed some variability in the VSCode java formatting tab size, previously it could be 4 or 8

## How Has This Been Tested?

The following results were generated by running the actual queries and aggregations in a MongoSH shell. 

The code changes were tested through Postman requests confirming that paged and non-paged queries are executed when the page query parameter is null or specified. They were also tested through the local webapp, where all intersection features performed as expected

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [x] My changes require updates to the documentation:
  - [x] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
