### PR TITLE
Auto-fetch RSU 'last online' status in DisplayRsuErrors component

### DIFF
--- a/webapp/src/features/menu/DisplayRsuErrors.tsx
+++ b/webapp/src/features/menu/DisplayRsuErrors.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
-import { getIssScmsStatus, selectRsuData } from '../../generalSlices/rsuSlice'
+import { getIssScmsStatus, getRsuLastOnline, selectRsuData } from '../../generalSlices/rsuSlice'
 
 import '../../components/css/SnmpwalkMenu.css'
 import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
@@ -46,7 +46,14 @@ const DisplayRsuErrors = ({ initialSelectedRsu }: { initialSelectedRsu?: RsuInfo
   // UseEffect to pull SCMS status data on first load
   useEffect(() => {
     dispatch(getIssScmsStatus())
-  }, [])
+  }, [dispatch])
+
+  // Fetch RSU online status data when an RSU is selected to ensure 'last online' is populated
+  useEffect(() => {
+    if (selectedRSU) {
+      dispatch(getRsuLastOnline(selectedRSU.properties.ipv4_address))
+    }
+  }, [selectedRSU, dispatch])
 
   const getRSUOnlineStatus = (rsuIpv4: string) => {
     return rsuIpv4 in rsuOnlineStatus &&


### PR DESCRIPTION
# PR Details

## Description
### Problem
Previously, the getRsuLastOnline action was only dispatched by the Map component when an RSU marker was clicked. This led to a "No Data" status for 'last online' when users accessed the DisplayRsuErrors view directly and selected an RSU through the table, as the necessary data was not being fetched.

### Solution
Updated the DisplayRsuErrors component to automatically fetch an RSU's 'last online' status upon selection.

## How Has This Been Tested?
Verified that selecting an RSU from the table in the DisplayRsuErrors view now correctly populates the 'last online' status without requiring a map marker click.

### Process
1. Spin up necessary components:
    ```
    docker compose up --build -d cvmanager_api cvmanager_webapp cvmanager_postgres cvmanager_keycloak
    ```
3. Insert a fresh ping result into the database for one of the sample RSUs
    ```
    INSERT INTO public.ping (timestamp, result, rsu_id)
    SELECT NOW() AT TIME ZONE 'UTC', '1', rsu_id 
    FROM public.rsus WHERE ipv4_address = '10.0.0.180';
    ```
4. Select RSU from the tabular view on the right (without clicking on the RSU on the map first):
    <img width="540" height="461" alt="image" src="https://github.com/user-attachments/assets/2c06bbf8-d71f-45c4-9b8c-cccf68b0825a" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
