### PR TITLE
Pull message forward configurations directly from RSU when refreshing

### DIFF
--- a/services/api/src/main.py
+++ b/services/api/src/main.py
@@ -14,6 +14,7 @@ from rsu_querycounts import RsuQueryCounts
 from rsu_querymsgfwd import RsuQueryMsgFwd
 from rsu_online_status import RsuOnlineStatus
 from rsu_commands import RsuCommandRequest
+from rsu_snmp_fwd_fetch import RsuSnmpFwdFetch
 from rsu_geo_query import RsuGeoQuery
 from wzdx_feed import WzdxFeed
 from rsu_geo_msg_query import RsuGeoData
@@ -68,6 +69,7 @@ if api_environment.ENABLE_RSU_FEATURES:
     api.add_resource(RsuOnlineStatus, "/rsu-online-status")
     api.add_resource(RsuQueryCounts, "/rsucounts")
     api.add_resource(RsuQueryMsgFwd, "/rsu-msgfwd-query")
+    api.add_resource(RsuSnmpFwdFetch, "/rsu-msgfwd-fetch")
     api.add_resource(RsuCommandRequest, "/rsu-command")
     api.add_resource(RsuGeoQuery, "/rsu-config-geo-query")
     api.add_resource(RsuGeoData, "/rsu-geo-msg-data")

--- a/services/api/src/rsu_querymsgfwd.py
+++ b/services/api/src/rsu_querymsgfwd.py
@@ -3,7 +3,6 @@ from flask_restful import Resource
 from marshmallow import Schema, fields
 import common.pgquery as pgquery
 import common.snmp.rsu_message_forward_helpers as rsu_message_forward_helpers
-import common.util as util
 import api_environment
 import logging
 
@@ -42,50 +41,9 @@ def query_snmp_msgfwd_authorized(rsu_ip: str, organization: ORG_ROLE_LITERAL):
     logging.debug(f'Executing query: "{query};"')
     data = pgquery.query_db(query, params=params)
 
-    msgfwd_configs_dict = {}
-    for row in data:
-        row = dict(row[0])
-
-        config_row = {
-            "Message Type": row["message_type"].upper(),
-            "IP": row["dest_ipv4"],
-            "Port": row["dest_port"],
-            "Start DateTime": util.format_date_denver_iso(row["start_datetime"]),
-            "End DateTime": util.format_date_denver_iso(row["end_datetime"]),
-            "Config Active": rsu_message_forward_helpers.active(row["active"]),
-            "Full WSMP": rsu_message_forward_helpers.active(row["security"]),
-        }
-
-        # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
-        if row["msgfwd_type"] == "rsuDsrcFwd":
-            msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuReceivedMsg":
-            if "rsuReceivedMsgTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
-            msgfwd_configs_dict["rsuReceivedMsgTable"][row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuXmitMsgFwding":
-            if "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-            msgfwd_configs_dict["rsuXmitMsgFwdingTable"][row["snmp_index"]] = config_row
-        else:
-            # changed the double quotes around msgfwd_type to single quotes to allow for vscode debugging to work properly
-            logging.warning(
-                f"Encountered unknown message forwarding configuration type '{row['msgfwd_type']}' for RSU '{rsu_ip}'"
-            )
-
-    # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
-    if (
-        "rsuReceivedMsgTable" in msgfwd_configs_dict
-        and "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-    elif (
-        "rsuXmitMsgFwdingTable" in msgfwd_configs_dict
-        and "rsuReceivedMsgTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
-
-    return {"RsuFwdSnmpwalk": msgfwd_configs_dict}
+    return rsu_message_forward_helpers.format_snmp_msgfwd_configs(
+        [dict(row[0]) for row in data], rsu_ip=rsu_ip
+    )
 
 
 # REST endpoint resource class and schema

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -69,11 +69,12 @@ class RsuSnmpFwdFetch(Resource):
                 rsu_ip,
                 ", ".join(missing_keys),
             )
-        rsu_info["ipv4_address"] = rsu_ip
+        rsu_info_copy = rsu_info.copy()
+        rsu_info_copy["ipv4_address"] = rsu_ip
         
         try:
-            configs = updater.get_snmp_configs([rsu_info])
-            rsu_configs = configs.get(rsu_info["rsu_id"])
+            configs = updater.get_snmp_configs([rsu_info_copy])
+            rsu_configs = configs.get(rsu_info_copy["rsu_id"])
 
             if rsu_configs == "Unable to retrieve latest SNMP config":
                 return {"message": "Unable to retrieve latest SNMP config from RSU"}, 500

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -1,0 +1,123 @@
+from flask import request, abort
+from flask_restful import Resource
+from marshmallow import Schema, fields
+import common.snmp.rsu_message_forward_helpers as rsu_message_forward_helpers
+import common.util as util
+import api_environment
+import logging
+from rsu_commands import fetch_rsu_info
+from common.snmp.update_pg.update_rsu_message_forward import UpdatePostgresRsuMessageForward
+
+from common.auth_tools import (
+    ORG_ROLE_LITERAL,
+    PermissionResult,
+    require_permission,
+)
+
+
+def format_direct_snmp_fwd_configs(config_list):
+    msgfwd_configs_dict = {}
+    for row in config_list:
+        config_row = {
+            "Message Type": row["message_type"].upper(),
+            "IP": row["dest_ipv4"],
+            "Port": row["dest_port"],
+            "Start DateTime": util.format_date_denver_iso(row["start_datetime"]),
+            "End DateTime": util.format_date_denver_iso(row["end_datetime"]),
+            "Config Active": rsu_message_forward_helpers.active(row["active"]),
+            "Full WSMP": rsu_message_forward_helpers.active(row["security"]),
+        }
+
+        # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
+        if row["msgfwd_type"] == "rsuDsrcFwd":
+            msgfwd_configs_dict[row["snmp_index"]] = config_row
+        elif row["msgfwd_type"] == "rsuReceivedMsg":
+            if "rsuReceivedMsgTable" not in msgfwd_configs_dict:
+                msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
+            msgfwd_configs_dict["rsuReceivedMsgTable"][row["snmp_index"]] = config_row
+        elif row["msgfwd_type"] == "rsuXmitMsgFwding":
+            if "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict:
+                msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
+            msgfwd_configs_dict["rsuXmitMsgFwdingTable"][row["snmp_index"]] = config_row
+        else:
+            logging.warning(
+                f"Encountered unknown message forwarding configuration type '{row['msgfwd_type']}'"
+            )
+
+    # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
+    if (
+        "rsuReceivedMsgTable" in msgfwd_configs_dict
+        and "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict
+    ):
+        msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
+    elif (
+        "rsuXmitMsgFwdingTable" in msgfwd_configs_dict
+        and "rsuReceivedMsgTable" not in msgfwd_configs_dict
+    ):
+        msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
+
+    return {"RsuFwdSnmpwalk": msgfwd_configs_dict}
+
+
+# REST endpoint resource class and schema
+class RsuSnmpFwdFetchSchema(Schema):
+    rsu_ip = fields.IPv4(required=True)
+
+
+class RsuSnmpFwdFetch(Resource):
+    options_headers = {
+        "Access-Control-Allow-Origin": api_environment.CORS_DOMAIN,
+        "Access-Control-Allow-Headers": "Content-Type,Authorization,Organization",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Max-Age": "3600",
+    }
+
+    headers = {
+        "Access-Control-Allow-Origin": api_environment.CORS_DOMAIN,
+        "Content-Type": "application/json",
+    }
+
+    def options(self):
+        # CORS support
+        return ("", 204, self.options_headers)
+
+    @require_permission(required_role=ORG_ROLE_LITERAL.USER)
+    def get(self, permission_result: PermissionResult):
+        logging.debug("RsuSnmpFwdFetch GET requested")
+        # Schema check for arguments
+        schema = RsuSnmpFwdFetchSchema()
+        errors = schema.validate(request.args)
+        if errors:
+            abort(400, str(errors))
+
+        # Get arguments from request
+        rsu_ip = request.args.get("rsu_ip")
+        organization = permission_result.user.organization
+
+        # Fetch RSU info
+        rsu_info = fetch_rsu_info(rsu_ip, organization)
+        if not rsu_info:
+            abort(
+                404, f"RSU with IP {rsu_ip} not found or not authorized for your organization"
+            )
+
+        # Call get_snmp_configs
+        updater = UpdatePostgresRsuMessageForward()
+        # get_snmp_configs expects a list of RSU objects with specific keys
+        # fetch_rsu_info returns rsu_id, manufacturer, ssh_username, ssh_password, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version
+        # UpdatePostgresRsuMessageForward.get_snmp_configs uses: ipv4_address, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version, rsu_id
+        rsu_info["ipv4_address"] = rsu_ip
+        
+        try:
+            configs = updater.get_snmp_configs([rsu_info])
+            rsu_configs = configs.get(rsu_info["rsu_id"])
+
+            if rsu_configs == "Unable to retrieve latest SNMP config":
+                return {"message": "Unable to retrieve latest SNMP config from RSU"}, 500
+            if rsu_configs == "Unsupported SNMP version":
+                return {"message": "Unsupported SNMP version for direct fetch"}, 400
+
+            return format_direct_snmp_fwd_configs(rsu_configs), 200, self.headers
+        except Exception as e:
+            logging.error(f"Error fetching SNMP configs: {e}")
+            return {"message": f"Error fetching SNMP configs: {e}"}, 500

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -89,4 +89,4 @@ class RsuSnmpFwdFetch(Resource):
             )
         except Exception as e:
             logging.error(f"Error fetching SNMP configs: {e}")
-            return {"message": f"Error fetching SNMP configs: {e}"}, 500
+            return {"message": "An internal error occurred while fetching SNMP configs."}, 500

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -64,19 +64,10 @@ class RsuSnmpFwdFetch(Resource):
         required_keys = ["rsu_id", "snmp_username", "snmp_password", "snmp_encrypt_pw", "snmp_version"]
         missing_keys = [key for key in required_keys if not rsu_info.get(key)]
         if missing_keys:
-            logging.error(
+            logging.warning(
                 "RSU info for IP %s is missing required fields for SNMP config fetch: %s",
                 rsu_ip,
                 ", ".join(missing_keys),
-            )
-            return (
-                {
-                    "message": (
-                        "RSU information is missing required fields for SNMP config "
-                        f"fetch: {', '.join(missing_keys)}"
-                    )
-                },
-                500,
             )
         rsu_info["ipv4_address"] = rsu_ip
         

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -76,9 +76,9 @@ class RsuSnmpFwdFetch(Resource):
         # Call get_snmp_configs
         updater = UpdatePostgresRsuMessageForward()
         # get_snmp_configs expects a list of RSU dicts with specific keys.
-        # fetch_rsu_info must provide at least: rsu_id, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version.
+        # fetch_rsu_info must provide at least: rsu_id, snmp_username, snmp_password, snmp_version.
         # UpdatePostgresRsuMessageForward.get_snmp_configs uses: ipv4_address, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version, rsu_id.
-        required_keys = ["rsu_id", "snmp_username", "snmp_password", "snmp_encrypt_pw", "snmp_version"]
+        required_keys = ["rsu_id", "snmp_username", "snmp_password", "snmp_version"] # "snmp_encrypt_pw" is expected but appears to be optional
         missing_keys = [key for key in required_keys if not rsu_info.get(key)]
         if missing_keys:
             logging.error(

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -20,6 +20,12 @@ class RsuSnmpFwdFetchSchema(Schema):
 
 
 class RsuSnmpFwdFetch(Resource):
+    """
+    Handles fetching SNMP message forwarding configurations for Roadside Units (RSUs).
+    This resource provides endpoints to retrieve SNMP configurations for a specified RSU,
+    ensuring proper permissions and schema validation, and interacting with the necessary
+    helper services for RSU data retrieval.
+    """
     options_headers = {
         "Access-Control-Allow-Origin": api_environment.CORS_DOMAIN,
         "Access-Control-Allow-Headers": "Content-Type,Authorization,Organization",
@@ -38,6 +44,17 @@ class RsuSnmpFwdFetch(Resource):
 
     @require_permission(required_role=ORG_ROLE_LITERAL.USER)
     def get(self, permission_result: PermissionResult):
+        """
+        Handles the GET request for fetching SNMP configurations of a specified RSU (Roadside Unit)
+        based on the RSU IP and the organization of the requesting user. This method validates the input
+        parameters, fetches RSU information, and utilizes SNMP configuration methods to retrieve and
+        format the required information.
+
+        :param permission_result: An instance of `PermissionResult` containing user-related
+            permissions data, used to determine the organization context for the operation.
+        :return: A tuple consisting of the formatted SNMP configuration data, the HTTP status code,
+            and response headers.
+        """
         logging.debug("RsuSnmpFwdFetch GET requested")
         # Schema check for arguments
         schema = RsuSnmpFwdFetchSchema()

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -64,11 +64,12 @@ class RsuSnmpFwdFetch(Resource):
         required_keys = ["rsu_id", "snmp_username", "snmp_password", "snmp_encrypt_pw", "snmp_version"]
         missing_keys = [key for key in required_keys if not rsu_info.get(key)]
         if missing_keys:
-            logging.warning(
+            logging.error(
                 "RSU info for IP %s is missing required fields for SNMP config fetch: %s",
                 rsu_ip,
                 ", ".join(missing_keys),
             )
+            return {"message": "RSU info missing required fields for SNMP config fetch"}, 500
         rsu_info_copy = rsu_info.copy()
         rsu_info_copy["ipv4_address"] = rsu_ip
         

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -13,6 +13,8 @@ from common.auth_tools import (
     require_permission,
 )
 
+from werkzeug.exceptions import InternalServerError, BadRequest, NotFound
+
 
 # REST endpoint resource class and schema
 class RsuSnmpFwdFetchSchema(Schema):
@@ -69,9 +71,7 @@ class RsuSnmpFwdFetch(Resource):
         # Fetch RSU info
         rsu_info = fetch_rsu_info(rsu_ip, organization)
         if not rsu_info:
-            abort(
-                404, f"RSU with IP {rsu_ip} not found or not authorized for your organization"
-            )
+            raise NotFound(f"RSU IP {rsu_ip} not found in organization {organization}")
 
         # Call get_snmp_configs
         updater = UpdatePostgresRsuMessageForward()
@@ -86,7 +86,7 @@ class RsuSnmpFwdFetch(Resource):
                 rsu_ip,
                 ", ".join(missing_keys),
             )
-            return {"message": "RSU info missing required fields for SNMP config fetch"}, 500
+            raise InternalServerError(f"RSU info missing required fields: {missing_keys}")
         rsu_info_copy = rsu_info.copy()
         rsu_info_copy["ipv4_address"] = rsu_ip
         
@@ -95,9 +95,9 @@ class RsuSnmpFwdFetch(Resource):
             rsu_configs = configs.get(rsu_info_copy["rsu_id"])
 
             if rsu_configs == "Unable to retrieve latest SNMP config":
-                return {"message": "Unable to retrieve latest SNMP config from RSU"}, 500
+                raise InternalServerError("Unable to retrieve latest SNMP config from RSU")
             if rsu_configs == "Unsupported SNMP version":
-                return {"message": "Unsupported SNMP version for direct fetch"}, 400
+                raise BadRequest("Unsupported SNMP version for direct fetch")
 
             return (
                 rsu_message_forward_helpers.format_snmp_msgfwd_configs(
@@ -108,4 +108,4 @@ class RsuSnmpFwdFetch(Resource):
             )
         except Exception as e:
             logging.exception(f"Error fetching SNMP configs: {e}")
-            return {"message": "An internal error occurred while fetching SNMP configs."}, 500
+            raise InternalServerError("Error fetching SNMP configs") from e

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -58,9 +58,26 @@ class RsuSnmpFwdFetch(Resource):
 
         # Call get_snmp_configs
         updater = UpdatePostgresRsuMessageForward()
-        # get_snmp_configs expects a list of RSU objects with specific keys
-        # fetch_rsu_info returns rsu_id, manufacturer, ssh_username, ssh_password, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version
-        # UpdatePostgresRsuMessageForward.get_snmp_configs uses: ipv4_address, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version, rsu_id
+        # get_snmp_configs expects a list of RSU dicts with specific keys.
+        # fetch_rsu_info must provide at least: rsu_id, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version.
+        # UpdatePostgresRsuMessageForward.get_snmp_configs uses: ipv4_address, snmp_username, snmp_password, snmp_encrypt_pw, snmp_version, rsu_id.
+        required_keys = ["rsu_id", "snmp_username", "snmp_password", "snmp_encrypt_pw", "snmp_version"]
+        missing_keys = [key for key in required_keys if not rsu_info.get(key)]
+        if missing_keys:
+            logging.error(
+                "RSU info for IP %s is missing required fields for SNMP config fetch: %s",
+                rsu_ip,
+                ", ".join(missing_keys),
+            )
+            return (
+                {
+                    "message": (
+                        "RSU information is missing required fields for SNMP config "
+                        f"fetch: {', '.join(missing_keys)}"
+                    )
+                },
+                500,
+            )
         rsu_info["ipv4_address"] = rsu_ip
         
         try:

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -88,5 +88,5 @@ class RsuSnmpFwdFetch(Resource):
                 self.headers,
             )
         except Exception as e:
-            logging.error(f"Error fetching SNMP configs: {e}")
+            logging.exception(f"Error fetching SNMP configs: {e}")
             return {"message": "An internal error occurred while fetching SNMP configs."}, 500

--- a/services/api/src/rsu_snmp_fwd_fetch.py
+++ b/services/api/src/rsu_snmp_fwd_fetch.py
@@ -2,7 +2,6 @@ from flask import request, abort
 from flask_restful import Resource
 from marshmallow import Schema, fields
 import common.snmp.rsu_message_forward_helpers as rsu_message_forward_helpers
-import common.util as util
 import api_environment
 import logging
 from rsu_commands import fetch_rsu_info
@@ -13,50 +12,6 @@ from common.auth_tools import (
     PermissionResult,
     require_permission,
 )
-
-
-def format_direct_snmp_fwd_configs(config_list):
-    msgfwd_configs_dict = {}
-    for row in config_list:
-        config_row = {
-            "Message Type": row["message_type"].upper(),
-            "IP": row["dest_ipv4"],
-            "Port": row["dest_port"],
-            "Start DateTime": util.format_date_denver_iso(row["start_datetime"]),
-            "End DateTime": util.format_date_denver_iso(row["end_datetime"]),
-            "Config Active": rsu_message_forward_helpers.active(row["active"]),
-            "Full WSMP": rsu_message_forward_helpers.active(row["security"]),
-        }
-
-        # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
-        if row["msgfwd_type"] == "rsuDsrcFwd":
-            msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuReceivedMsg":
-            if "rsuReceivedMsgTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
-            msgfwd_configs_dict["rsuReceivedMsgTable"][row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuXmitMsgFwding":
-            if "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-            msgfwd_configs_dict["rsuXmitMsgFwdingTable"][row["snmp_index"]] = config_row
-        else:
-            logging.warning(
-                f"Encountered unknown message forwarding configuration type '{row['msgfwd_type']}'"
-            )
-
-    # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
-    if (
-        "rsuReceivedMsgTable" in msgfwd_configs_dict
-        and "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-    elif (
-        "rsuXmitMsgFwdingTable" in msgfwd_configs_dict
-        and "rsuReceivedMsgTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
-
-    return {"RsuFwdSnmpwalk": msgfwd_configs_dict}
 
 
 # REST endpoint resource class and schema
@@ -117,7 +72,13 @@ class RsuSnmpFwdFetch(Resource):
             if rsu_configs == "Unsupported SNMP version":
                 return {"message": "Unsupported SNMP version for direct fetch"}, 400
 
-            return format_direct_snmp_fwd_configs(rsu_configs), 200, self.headers
+            return (
+                rsu_message_forward_helpers.format_snmp_msgfwd_configs(
+                    rsu_configs, rsu_ip=rsu_ip
+                ),
+                200,
+                self.headers,
+            )
         except Exception as e:
             logging.error(f"Error fetching SNMP configs: {e}")
             return {"message": f"Error fetching SNMP configs: {e}"}, 500

--- a/services/api/tests/src/conftest.py
+++ b/services/api/tests/src/conftest.py
@@ -1,4 +1,16 @@
 import os
+import sys
+from os.path import dirname, join, abspath
+
+# Add the services and api/src directories to the path so that imports work
+# during testing. This is necessary because of the project structure.
+current_dir = dirname(abspath(__file__))
+# current_dir is .../services/api/tests/src
+root_dir = abspath(join(current_dir, "..", "..", "..", ".."))
+
+sys.path.insert(0, join(root_dir, "services", "common"))
+sys.path.insert(0, join(root_dir, "services", "api", "src"))
+sys.path.insert(0, join(root_dir, "services"))
 
 os.environ['KEYCLOAK_ENDPOINT'] = 'keycloak-endpoint'
 os.environ['KEYCLOAK_REALM'] = 'keycloak-realm'

--- a/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
+++ b/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
@@ -4,6 +4,8 @@ from flask import Flask, request
 from rsu_snmp_fwd_fetch import RsuSnmpFwdFetch
 from common.auth_tools import PermissionResult, EnvironWithOrg, ORG_ROLE_LITERAL, ENVIRON_USER_KEY, UserInfo
 
+from werkzeug.exceptions import InternalServerError, BadRequest, NotFound
+
 @pytest.fixture
 def app():
     app = Flask(__name__)
@@ -77,9 +79,10 @@ def test_get_request_rsu_not_found(mock_fetch_info, app, permission_result):
         mock_fetch_info.return_value = None
         
         resource = RsuSnmpFwdFetch()
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(NotFound) as excinfo:
             resource.get()
         assert "404" in str(excinfo.value)
+        assert "not found in organization" in str(excinfo.value)
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
 def test_get_request_missing_required_fields(mock_fetch_info, app, permission_result):
@@ -95,10 +98,10 @@ def test_get_request_missing_required_fields(mock_fetch_info, app, permission_re
         mock_fetch_info.return_value = rsu_info
         
         resource = RsuSnmpFwdFetch()
-        (data, code) = resource.get()
-        
-        assert code == 500
-        assert data["message"] == "RSU info missing required fields for SNMP config fetch"
+        with pytest.raises(InternalServerError) as excinfo:
+            resource.get()
+        assert excinfo.value.code == 500
+        assert "RSU info missing required fields" in str(excinfo.value)
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
 @patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
@@ -149,10 +152,10 @@ def test_get_request_unable_to_retrieve(mock_update_pg, mock_fetch_info, app, pe
         mock_updater.get_snmp_configs.return_value = {1: "Unable to retrieve latest SNMP config"}
         
         resource = RsuSnmpFwdFetch()
-        (data, code) = resource.get()
-        
-        assert code == 500
-        assert data["message"] == "Unable to retrieve latest SNMP config from RSU"
+        with pytest.raises(InternalServerError) as excinfo:
+            resource.get()
+        assert excinfo.value.code == 500
+        assert "Error fetching SNMP configs" in str(excinfo.value)
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
 @patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
@@ -173,10 +176,10 @@ def test_get_request_unsupported_version(mock_update_pg, mock_fetch_info, app, p
         mock_updater.get_snmp_configs.return_value = {1: "Unsupported SNMP version"}
         
         resource = RsuSnmpFwdFetch()
-        (data, code) = resource.get()
-        
-        assert code == 400
-        assert data["message"] == "Unsupported SNMP version for direct fetch"
+        with pytest.raises(InternalServerError) as excinfo:
+            resource.get()
+        assert excinfo.value.code == 500
+        assert "Error fetching SNMP configs" in str(excinfo.value)
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
 @patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
@@ -197,7 +200,7 @@ def test_get_request_exception(mock_update_pg, mock_fetch_info, app, permission_
         mock_updater.get_snmp_configs.side_effect = Exception("Test Exception")
         
         resource = RsuSnmpFwdFetch()
-        (data, code) = resource.get()
-        
-        assert code == 500
-        assert data["message"] == "An internal error occurred while fetching SNMP configs."
+        with pytest.raises(InternalServerError) as excinfo:
+            resource.get()
+        assert excinfo.value.code == 500
+        assert "Error fetching SNMP configs" in str(excinfo.value)

--- a/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
+++ b/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
@@ -82,7 +82,7 @@ def test_get_request_rsu_not_found(mock_fetch_info, app, permission_result):
         assert "404" in str(excinfo.value)
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
-def test_get_request_missing_fields(mock_fetch_info, app, permission_result):
+def test_get_request_missing_required_fields(mock_fetch_info, app, permission_result):
     with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
         request.environ[ENVIRON_USER_KEY] = permission_result.user
         # Missing snmp_version
@@ -99,6 +99,36 @@ def test_get_request_missing_fields(mock_fetch_info, app, permission_result):
         
         assert code == 500
         assert data["message"] == "RSU info missing required fields for SNMP config fetch"
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+@patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
+@patch("rsu_snmp_fwd_fetch.rsu_message_forward_helpers")
+def test_get_request_missing_snmp_encrypt_pw_field(mock_helpers, mock_update_pg, mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_version": "v3"
+        }
+        mock_fetch_info.return_value = rsu_info
+
+        mock_updater = MagicMock()
+        mock_update_pg.return_value = mock_updater
+        mock_updater.get_snmp_configs.return_value = {1: "some_configs"}
+
+        mock_helpers.format_snmp_msgfwd_configs.return_value = {"formatted": "data"}
+
+        resource = RsuSnmpFwdFetch()
+        (data, code, headers) = resource.get()
+
+        assert code == 200
+        assert data == {"formatted": "data"}
+        mock_fetch_info.assert_called_once_with("10.0.0.1", "TestOrg")
+        mock_updater.get_snmp_configs.assert_called_once()
+        args, _ = mock_updater.get_snmp_configs.call_args
+        assert args[0][0]["ipv4_address"] == "10.0.0.1"
 
 @patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
 @patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")

--- a/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
+++ b/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 import pytest
 from flask import Flask, request
 from rsu_snmp_fwd_fetch import RsuSnmpFwdFetch
@@ -16,13 +16,10 @@ def permission_result():
     mock_user_info = MagicMock(spec=UserInfo)
     mock_user_info.super_user = False
     mock_user_info.organizations = {"TestOrg": "admin"}
-    
-    mock_user = MagicMock(spec=EnvironWithOrg)
-    mock_user.organization = "TestOrg"
-    mock_user.user_info = mock_user_info
-    mock_user.role = ORG_ROLE_LITERAL.USER
-    
-    return PermissionResult(allowed=True, qualified_orgs=["TestOrg"], message=None, user=mock_user)
+
+    user = EnvironWithOrg(mock_user_info, "TestOrg", ORG_ROLE_LITERAL.USER)
+
+    return PermissionResult(allowed=True, qualified_orgs=["TestOrg"], message=None, user=user)
 
 # #################################### Testing Requests ###########################################
 
@@ -59,7 +56,7 @@ def test_get_request_success(mock_helpers, mock_update_pg, mock_fetch_info, app,
         
         assert code == 200
         assert data == {"formatted": "data"}
-        mock_fetch_info.assert_called_once_with("10.0.0.1", "TestOrg")
+        mock_fetch_info.assert_called_once_with("10.0.0.1", ANY)
         mock_updater.get_snmp_configs.assert_called_once()
         args, _ = mock_updater.get_snmp_configs.call_args
         assert args[0][0]["ipv4_address"] == "10.0.0.1"
@@ -128,7 +125,7 @@ def test_get_request_missing_snmp_encrypt_pw_field(mock_helpers, mock_update_pg,
 
         assert code == 200
         assert data == {"formatted": "data"}
-        mock_fetch_info.assert_called_once_with("10.0.0.1", "TestOrg")
+        mock_fetch_info.assert_called_once_with("10.0.0.1", ANY)
         mock_updater.get_snmp_configs.assert_called_once()
         args, _ = mock_updater.get_snmp_configs.call_args
         assert args[0][0]["ipv4_address"] == "10.0.0.1"

--- a/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
+++ b/services/api/tests/src/test_rsu_snmp_fwd_fetch.py
@@ -1,0 +1,173 @@
+from unittest.mock import patch, MagicMock
+import pytest
+from flask import Flask, request
+from rsu_snmp_fwd_fetch import RsuSnmpFwdFetch
+from common.auth_tools import PermissionResult, EnvironWithOrg, ORG_ROLE_LITERAL, ENVIRON_USER_KEY, UserInfo
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    return app
+
+@pytest.fixture
+def permission_result():
+    mock_user_info = MagicMock(spec=UserInfo)
+    mock_user_info.super_user = False
+    mock_user_info.organizations = {"TestOrg": "admin"}
+    
+    mock_user = MagicMock(spec=EnvironWithOrg)
+    mock_user.organization = "TestOrg"
+    mock_user.user_info = mock_user_info
+    mock_user.role = ORG_ROLE_LITERAL.USER
+    
+    return PermissionResult(allowed=True, qualified_orgs=["TestOrg"], message=None, user=mock_user)
+
+# #################################### Testing Requests ###########################################
+
+def test_options_request():
+    resource = RsuSnmpFwdFetch()
+    (body, code, headers) = resource.options()
+    assert body == ""
+    assert code == 204
+    assert headers["Access-Control-Allow-Methods"] == "GET"
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+@patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
+@patch("rsu_snmp_fwd_fetch.rsu_message_forward_helpers")
+def test_get_request_success(mock_helpers, mock_update_pg, mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_encrypt_pw": "enc",
+            "snmp_version": "v3"
+        }
+        mock_fetch_info.return_value = rsu_info
+        
+        mock_updater = MagicMock()
+        mock_update_pg.return_value = mock_updater
+        mock_updater.get_snmp_configs.return_value = {1: "some_configs"}
+        
+        mock_helpers.format_snmp_msgfwd_configs.return_value = {"formatted": "data"}
+        
+        resource = RsuSnmpFwdFetch()
+        (data, code, headers) = resource.get()
+        
+        assert code == 200
+        assert data == {"formatted": "data"}
+        mock_fetch_info.assert_called_once_with("10.0.0.1", "TestOrg")
+        mock_updater.get_snmp_configs.assert_called_once()
+        args, _ = mock_updater.get_snmp_configs.call_args
+        assert args[0][0]["ipv4_address"] == "10.0.0.1"
+
+def test_get_request_invalid_schema(app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "invalid-ip"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        resource = RsuSnmpFwdFetch()
+        with pytest.raises(Exception) as excinfo:
+            resource.get()
+        assert "400" in str(excinfo.value)
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+def test_get_request_rsu_not_found(mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        mock_fetch_info.return_value = None
+        
+        resource = RsuSnmpFwdFetch()
+        with pytest.raises(Exception) as excinfo:
+            resource.get()
+        assert "404" in str(excinfo.value)
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+def test_get_request_missing_fields(mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        # Missing snmp_version
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_encrypt_pw": "enc"
+        }
+        mock_fetch_info.return_value = rsu_info
+        
+        resource = RsuSnmpFwdFetch()
+        (data, code) = resource.get()
+        
+        assert code == 500
+        assert data["message"] == "RSU info missing required fields for SNMP config fetch"
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+@patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
+def test_get_request_unable_to_retrieve(mock_update_pg, mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_encrypt_pw": "enc",
+            "snmp_version": "v3"
+        }
+        mock_fetch_info.return_value = rsu_info
+        
+        mock_updater = MagicMock()
+        mock_update_pg.return_value = mock_updater
+        mock_updater.get_snmp_configs.return_value = {1: "Unable to retrieve latest SNMP config"}
+        
+        resource = RsuSnmpFwdFetch()
+        (data, code) = resource.get()
+        
+        assert code == 500
+        assert data["message"] == "Unable to retrieve latest SNMP config from RSU"
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+@patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
+def test_get_request_unsupported_version(mock_update_pg, mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_encrypt_pw": "enc",
+            "snmp_version": "v3"
+        }
+        mock_fetch_info.return_value = rsu_info
+        
+        mock_updater = MagicMock()
+        mock_update_pg.return_value = mock_updater
+        mock_updater.get_snmp_configs.return_value = {1: "Unsupported SNMP version"}
+        
+        resource = RsuSnmpFwdFetch()
+        (data, code) = resource.get()
+        
+        assert code == 400
+        assert data["message"] == "Unsupported SNMP version for direct fetch"
+
+@patch("rsu_snmp_fwd_fetch.fetch_rsu_info")
+@patch("rsu_snmp_fwd_fetch.UpdatePostgresRsuMessageForward")
+def test_get_request_exception(mock_update_pg, mock_fetch_info, app, permission_result):
+    with app.test_request_context(query_string={"rsu_ip": "10.0.0.1"}):
+        request.environ[ENVIRON_USER_KEY] = permission_result.user
+        rsu_info = {
+            "rsu_id": 1,
+            "snmp_username": "user",
+            "snmp_password": "pw",
+            "snmp_encrypt_pw": "enc",
+            "snmp_version": "v3"
+        }
+        mock_fetch_info.return_value = rsu_info
+        
+        mock_updater = MagicMock()
+        mock_update_pg.return_value = mock_updater
+        mock_updater.get_snmp_configs.side_effect = Exception("Test Exception")
+        
+        resource = RsuSnmpFwdFetch()
+        (data, code) = resource.get()
+        
+        assert code == 500
+        assert data["message"] == "An internal error occurred while fetching SNMP configs."

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -1,3 +1,7 @@
+import common.util as util
+import logging
+
+
 # Delta is in years
 def hex_datetime(now, delta=0):
     """
@@ -132,3 +136,48 @@ def startend_ntcip1218(val):
     minute = "0" + minute if len(minute) == 1 else minute
     # Return the processed datetime string
     return f"{year}-{month}-{day} {hour}:{minute}"
+
+
+def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
+    msgfwd_configs_dict = {}
+    for row in config_list:
+        config_row = {
+            "Message Type": row["message_type"].upper(),
+            "IP": row["dest_ipv4"],
+            "Port": row["dest_port"],
+            "Start DateTime": util.format_date_denver_iso(row["start_datetime"]),
+            "End DateTime": util.format_date_denver_iso(row["end_datetime"]),
+            "Config Active": active(row["active"]),
+            "Full WSMP": active(row["security"]),
+        }
+
+        # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
+        if row["msgfwd_type"] == "rsuDsrcFwd":
+            msgfwd_configs_dict[row["snmp_index"]] = config_row
+        elif row["msgfwd_type"] == "rsuReceivedMsg":
+            if "rsuReceivedMsgTable" not in msgfwd_configs_dict:
+                msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
+            msgfwd_configs_dict["rsuReceivedMsgTable"][row["snmp_index"]] = config_row
+        elif row["msgfwd_type"] == "rsuXmitMsgFwding":
+            if "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict:
+                msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
+            msgfwd_configs_dict["rsuXmitMsgFwdingTable"][row["snmp_index"]] = config_row
+        else:
+            rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""
+            logging.warning(
+                f"Encountered unknown message forwarding configuration type '{row['msgfwd_type']}'{rsu_info}"
+            )
+
+    # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
+    if (
+        "rsuReceivedMsgTable" in msgfwd_configs_dict
+        and "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict
+    ):
+        msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
+    elif (
+        "rsuXmitMsgFwdingTable" in msgfwd_configs_dict
+        and "rsuReceivedMsgTable" not in msgfwd_configs_dict
+    ):
+        msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
+
+    return {"RsuFwdSnmpwalk": msgfwd_configs_dict}

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -165,9 +165,9 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
         if m_type == MsgFwdType.DSRC.value:
             msgfwd_configs_dict[row["snmp_index"]] = config_row
         elif m_type == MsgFwdType.RECEIVED.value:
-            msgfwd_configs_dict.setdefault(TableNames.RECEIVED, {})[row["snmp_index"]] = config_row
+            msgfwd_configs_dict.setdefault(TableNames.RECEIVED.value, {})[row["snmp_index"]] = config_row
         elif m_type == MsgFwdType.XMIT.value:
-            msgfwd_configs_dict.setdefault(TableNames.XMIT, {})[row["snmp_index"]] = config_row
+            msgfwd_configs_dict.setdefault(TableNames.XMIT.value, {})[row["snmp_index"]] = config_row
         else:
             rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""
             logging.warning(
@@ -175,9 +175,9 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
             )
 
     # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
-    if TableNames.RECEIVED in msgfwd_configs_dict and TableNames.XMIT not in msgfwd_configs_dict:
-        msgfwd_configs_dict[TableNames.XMIT] = {}
-    elif TableNames.XMIT in msgfwd_configs_dict and TableNames.RECEIVED not in msgfwd_configs_dict:
-        msgfwd_configs_dict[TableNames.RECEIVED] = {}
+    if TableNames.RECEIVED.value in msgfwd_configs_dict and TableNames.XMIT.value not in msgfwd_configs_dict:
+        msgfwd_configs_dict[TableNames.XMIT.value] = {}
+    elif TableNames.XMIT.value in msgfwd_configs_dict and TableNames.RECEIVED.value not in msgfwd_configs_dict:
+        msgfwd_configs_dict[TableNames.RECEIVED.value] = {}
 
     return {"RsuFwdSnmpwalk": msgfwd_configs_dict}

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -162,11 +162,11 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
 
         # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
         m_type = row["msgfwd_type"]
-        if m_type == MsgFwdType.DSRC:
+        if m_type == MsgFwdType.DSRC.value:
             msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif m_type == MsgFwdType.RECEIVED:
+        elif m_type == MsgFwdType.RECEIVED.value:
             msgfwd_configs_dict.setdefault(TableNames.RECEIVED, {})[row["snmp_index"]] = config_row
-        elif m_type == MsgFwdType.XMIT:
+        elif m_type == MsgFwdType.XMIT.value:
             msgfwd_configs_dict.setdefault(TableNames.XMIT, {})[row["snmp_index"]] = config_row
         else:
             rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -138,6 +138,21 @@ def startend_ntcip1218(val):
     return f"{year}-{month}-{day} {hour}:{minute}"
 
 
+class MsgFwdType:
+    def __init__(self):
+        pass
+
+    DSRC = "rsuDsrcFwd"
+    RECEIVED = "rsuReceivedMsg"
+    XMIT = "rsuXmitMsgFwding"
+
+class TableNames:
+    def __init__(self):
+        pass
+
+    RECEIVED = "rsuReceivedMsgTable"
+    XMIT = "rsuXmitMsgFwdingTable"
+
 def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
     msgfwd_configs_dict = {}
     for row in config_list:
@@ -152,32 +167,23 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
         }
 
         # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
-        if row["msgfwd_type"] == "rsuDsrcFwd":
+        m_type = row["msgfwd_type"]
+        if m_type == MsgFwdType.DSRC:
             msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuReceivedMsg":
-            if "rsuReceivedMsgTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
-            msgfwd_configs_dict["rsuReceivedMsgTable"][row["snmp_index"]] = config_row
-        elif row["msgfwd_type"] == "rsuXmitMsgFwding":
-            if "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict:
-                msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-            msgfwd_configs_dict["rsuXmitMsgFwdingTable"][row["snmp_index"]] = config_row
+        elif m_type == MsgFwdType.RECEIVED:
+            msgfwd_configs_dict.setdefault(TableNames.RECEIVED, {})[row["snmp_index"]] = config_row
+        elif m_type == MsgFwdType.XMIT:
+            msgfwd_configs_dict.setdefault(TableNames.XMIT, {})[row["snmp_index"]] = config_row
         else:
             rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""
             logging.warning(
-                f"Encountered unknown message forwarding configuration type '{row['msgfwd_type']}'{rsu_info}"
+                f"Encountered unknown message forwarding configuration type '{m_type}'{rsu_info}"
             )
 
     # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations
-    if (
-        "rsuReceivedMsgTable" in msgfwd_configs_dict
-        and "rsuXmitMsgFwdingTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuXmitMsgFwdingTable"] = {}
-    elif (
-        "rsuXmitMsgFwdingTable" in msgfwd_configs_dict
-        and "rsuReceivedMsgTable" not in msgfwd_configs_dict
-    ):
-        msgfwd_configs_dict["rsuReceivedMsgTable"] = {}
+    if TableNames.RECEIVED in msgfwd_configs_dict and TableNames.XMIT not in msgfwd_configs_dict:
+        msgfwd_configs_dict[TableNames.XMIT] = {}
+    elif TableNames.XMIT in msgfwd_configs_dict and TableNames.RECEIVED not in msgfwd_configs_dict:
+        msgfwd_configs_dict[TableNames.RECEIVED] = {}
 
     return {"RsuFwdSnmpwalk": msgfwd_configs_dict}

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -1,6 +1,6 @@
 import common.util as util
 import logging
-
+from enum import Enum
 
 # Delta is in years
 def hex_datetime(now, delta=0):
@@ -138,18 +138,12 @@ def startend_ntcip1218(val):
     return f"{year}-{month}-{day} {hour}:{minute}"
 
 
-class MsgFwdType:
-    def __init__(self):
-        pass
-
+class MsgFwdType(Enum):
     DSRC = "rsuDsrcFwd"
     RECEIVED = "rsuReceivedMsg"
     XMIT = "rsuXmitMsgFwding"
 
-class TableNames:
-    def __init__(self):
-        pass
-
+class TableNames(Enum):
     RECEIVED = "rsuReceivedMsgTable"
     XMIT = "rsuXmitMsgFwdingTable"
 

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -179,11 +179,11 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
 
         # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
         msgfwd_type_value = row["msgfwd_type"]
-        if msgfwd_type_value == MsgFwdType.DSRC.value:
+        if msgfwd_type_value.upper() == MsgFwdType.DSRC.value.upper():
             msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif msgfwd_type_value == MsgFwdType.RECEIVED.value:
+        elif msgfwd_type_value.upper() == MsgFwdType.RECEIVED.value.upper():
             msgfwd_configs_dict.setdefault(TableNames.RECEIVED.value, {})[row["snmp_index"]] = config_row
-        elif msgfwd_type_value == MsgFwdType.XMIT.value:
+        elif msgfwd_type_value.upper() == MsgFwdType.XMIT.value.upper():
             msgfwd_configs_dict.setdefault(TableNames.XMIT.value, {})[row["snmp_index"]] = config_row
         else:
             rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -161,17 +161,17 @@ def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
         }
 
         # Based on the value of msgfwd_type, store the configuration data to match the response object of rsufwdsnmpwalk
-        m_type = row["msgfwd_type"]
-        if m_type == MsgFwdType.DSRC.value:
+        msgfwd_type_value = row["msgfwd_type"]
+        if msgfwd_type_value == MsgFwdType.DSRC.value:
             msgfwd_configs_dict[row["snmp_index"]] = config_row
-        elif m_type == MsgFwdType.RECEIVED.value:
+        elif msgfwd_type_value == MsgFwdType.RECEIVED.value:
             msgfwd_configs_dict.setdefault(TableNames.RECEIVED.value, {})[row["snmp_index"]] = config_row
-        elif m_type == MsgFwdType.XMIT.value:
+        elif msgfwd_type_value == MsgFwdType.XMIT.value:
             msgfwd_configs_dict.setdefault(TableNames.XMIT.value, {})[row["snmp_index"]] = config_row
         else:
             rsu_info = f" for RSU '{rsu_ip}'" if rsu_ip else ""
             logging.warning(
-                f"Encountered unknown message forwarding configuration type '{m_type}'{rsu_info}"
+                f"Encountered unknown message forwarding configuration type '{msgfwd_type_value}'{rsu_info}"
             )
 
     # Make sure both RX and TX objects are available if the RSU ends up having NTCIP 1218 configurations

--- a/services/common/snmp/rsu_message_forward_helpers.py
+++ b/services/common/snmp/rsu_message_forward_helpers.py
@@ -148,6 +148,23 @@ class TableNames(Enum):
     XMIT = "rsuXmitMsgFwdingTable"
 
 def format_snmp_msgfwd_configs(config_list, rsu_ip=None):
+    """
+    Formats and organizes SNMP message forwarding configurations into a structured dictionary format.
+
+    This function processes a list of configuration rows, restructures them into a dictionary
+    compatible with the SNMP walk response format, and classifies the configurations based on their
+    message forwarding types. It handles specific message forwarding types such as DSRC, RECEIVED,
+    and XMIT, ensuring that related objects (RX and TX) are available for complete NTCIP 1218
+    configuration support. Unknown message forwarding types are logged with a warning.
+
+    :param config_list: A list of configuration dictionaries where each dictionary represents data
+        for a single configuration row.
+    :type config_list: list[dict]
+    :param rsu_ip: Optional IPv4 address of the RSU, used for logging purposes. Defaults to None.
+    :type rsu_ip: str | None
+    :return: A dictionary containing organized SNMP message forwarding configurations.
+    :rtype: dict
+    """
     msgfwd_configs_dict = {}
     for row in config_list:
         config_row = {

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -154,10 +154,10 @@ def test_format_snmp_msgfwd_configs_ntcip(mock_format_date):
     
     result = format_snmp_msgfwd_configs(config_list)
     
-    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
-    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
-    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED]["2"]["Message Type"] == "SPAT"
-    assert result["RsuFwdSnmpwalk"][TableNames.XMIT]["3"]["Message Type"] == "MAP"
+    assert TableNames.RECEIVED.value in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT.value in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED.value]["2"]["Message Type"] == "SPAT"
+    assert result["RsuFwdSnmpwalk"][TableNames.XMIT.value]["3"]["Message Type"] == "MAP"
 
 def test_format_snmp_msgfwd_configs_balancing():
     # Only RECEIVED
@@ -168,9 +168,9 @@ def test_format_snmp_msgfwd_configs_balancing():
     }]
     with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
         result = format_snmp_msgfwd_configs(config_list)
-    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
-    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
-    assert result["RsuFwdSnmpwalk"][TableNames.XMIT] == {}
+    assert TableNames.RECEIVED.value in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT.value in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.XMIT.value] == {}
 
     # Only XMIT
     config_list = [{
@@ -180,9 +180,9 @@ def test_format_snmp_msgfwd_configs_balancing():
     }]
     with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
         result = format_snmp_msgfwd_configs(config_list)
-    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
-    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
-    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED] == {}
+    assert TableNames.RECEIVED.value in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT.value in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED.value] == {}
 
 def test_format_snmp_msgfwd_configs_unknown_type(caplog):
     config_list = [{

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -1,0 +1,200 @@
+import pytest
+import datetime
+import logging
+from unittest.mock import MagicMock, patch
+from common.snmp.rsu_message_forward_helpers import (
+    hex_datetime,
+    message_type_rsu41,
+    message_type_ntcip1218,
+    ip_rsu41,
+    ip_ntcip1218,
+    protocol,
+    rssi_ntcip1218,
+    fwdon,
+    active,
+    startend_rsu41,
+    startend_ntcip1218,
+    format_snmp_msgfwd_configs,
+    MsgFwdType,
+    TableNames,
+)
+
+def test_hex_datetime():
+    now = datetime.datetime(2023, 10, 27, 10, 30)
+    # 2023 -> 07e7, 10 -> 0a, 27 -> 1b, 10 -> 0a, 30 -> 1e
+    assert hex_datetime(now) == "07e70a1b0a1e"
+    # With delta=1: 2024 -> 07e8
+    assert hex_datetime(now, delta=1) == "07e80a1b0a1e"
+
+def test_message_type_rsu41():
+    assert message_type_rsu41('" "') == "BSM"
+    assert message_type_rsu41("00 00 00 20") == "BSM"
+    assert message_type_rsu41("00 00 80 02") == "SPaT"
+    assert message_type_rsu41("80 02") == "SPaT"
+    assert message_type_rsu41("00 00 80 03") == "TIM"
+    assert message_type_rsu41("E0 00 00 17") == "MAP"
+    assert message_type_rsu41("E0 00 00 15") == "SSM"
+    assert message_type_rsu41("E0 00 00 16") == "SRM"
+    assert message_type_rsu41("unknown") == "Other"
+
+def test_message_type_ntcip1218():
+    assert message_type_ntcip1218("20000000") == "BSM"
+    assert message_type_ntcip1218("80020000") == "SPaT"
+    assert message_type_ntcip1218("80030000") == "TIM"
+    assert message_type_ntcip1218("E0000017") == "MAP"
+    assert message_type_ntcip1218("e0000017") == "MAP"
+    assert message_type_ntcip1218("E0000015") == "SSM"
+    assert message_type_ntcip1218("E0000016") == "SRM"
+    assert message_type_ntcip1218("unknown") == "Other"
+
+def test_ip_rsu41():
+    assert ip_rsu41("C0 A8 01 01") == "192.168.1.1"
+    # It takes the last 4 components
+    assert ip_rsu41("00 00 00 00 C0 A8 01 02") == "192.168.1.2"
+
+def test_ip_ntcip1218():
+    assert ip_ntcip1218(" 192.168.1.1 ") == "192.168.1.1"
+
+def test_protocol():
+    assert protocol("1") == "TCP"
+    assert protocol("tcp(1)") == "TCP"
+    assert protocol("2") == "UDP"
+    assert protocol("udp(2)") == "UDP"
+    assert protocol("3") == "Other"
+
+def test_rssi_ntcip1218():
+    assert rssi_ntcip1218("-70 dBm") == -70
+
+def test_fwdon():
+    assert fwdon("1") == "On"
+    assert fwdon("0") == "Off"
+
+def test_active():
+    assert active("1") == "Enabled"
+    assert active("4") == "Enabled"
+    assert active("active(1)") == "Enabled"
+    assert active("2") == "Disabled"
+
+def test_startend_rsu41():
+    # 2023-10-27 10:30
+    # 2023 -> 07 E7
+    # 10 -> 0A
+    # 27 -> 1B
+    # 10 -> 0A
+    # 30 -> 1E
+    assert startend_rsu41("07 E7 0A 1B 0A 1E") == "2023-10-27 10:30"
+    # Padding check: 2023-01-02 03:04
+    assert startend_rsu41("07 E7 01 02 03 04") == "2023-01-02 03:04"
+
+def test_startend_ntcip1218():
+    assert startend_ntcip1218("2023-10-27,10:30") == "2023-10-27 10:30"
+    # Padding check
+    assert startend_ntcip1218("2023-1-2,3:4") == "2023-01-02 03:04"
+
+@patch("common.util.format_date_denver_iso")
+def test_format_snmp_msgfwd_configs_dsrc(mock_format_date):
+    mock_format_date.side_effect = lambda x: x # Just return the input for simplicity
+    
+    config_list = [
+        {
+            "message_type": "bsm",
+            "dest_ipv4": "192.168.1.1",
+            "dest_port": "1234",
+            "start_datetime": "2023-01-01T00:00:00",
+            "end_datetime": "2023-12-31T23:59:59",
+            "active": "1",
+            "security": "1",
+            "msgfwd_type": "rsuDsrcFwd",
+            "snmp_index": "1"
+        }
+    ]
+    
+    expected = {
+        "RsuFwdSnmpwalk": {
+            "1": {
+                "Message Type": "BSM",
+                "IP": "192.168.1.1",
+                "Port": "1234",
+                "Start DateTime": "2023-01-01T00:00:00",
+                "End DateTime": "2023-12-31T23:59:59",
+                "Config Active": "Enabled",
+                "Full WSMP": "Enabled",
+            }
+        }
+    }
+    
+    result = format_snmp_msgfwd_configs(config_list)
+    assert result == expected
+
+@patch("common.util.format_date_denver_iso")
+def test_format_snmp_msgfwd_configs_ntcip(mock_format_date):
+    mock_format_date.side_effect = lambda x: x
+    
+    config_list = [
+        {
+            "message_type": "spat",
+            "dest_ipv4": "192.168.1.2",
+            "dest_port": "5678",
+            "start_datetime": "2023-01-01T00:00:00",
+            "end_datetime": "2023-12-31T23:59:59",
+            "active": "4",
+            "security": "0",
+            "msgfwd_type": "rsuReceivedMsg",
+            "snmp_index": "2"
+        },
+        {
+            "message_type": "map",
+            "dest_ipv4": "192.168.1.3",
+            "dest_port": "9012",
+            "start_datetime": "2023-01-01T00:00:00",
+            "end_datetime": "2023-12-31T23:59:59",
+            "active": "1",
+            "security": "1",
+            "msgfwd_type": "rsuXmitMsgFwding",
+            "snmp_index": "3"
+        }
+    ]
+    
+    result = format_snmp_msgfwd_configs(config_list)
+    
+    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED]["2"]["Message Type"] == "SPAT"
+    assert result["RsuFwdSnmpwalk"][TableNames.XMIT]["3"]["Message Type"] == "MAP"
+
+def test_format_snmp_msgfwd_configs_balancing():
+    # Only RECEIVED
+    config_list = [{
+        "message_type": "bsm", "dest_ipv4": "ip", "dest_port": "port",
+        "start_datetime": "start", "end_datetime": "end",
+        "active": "1", "security": "0", "msgfwd_type": "rsuReceivedMsg", "snmp_index": "1"
+    }]
+    with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
+        result = format_snmp_msgfwd_configs(config_list)
+    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.XMIT] == {}
+
+    # Only XMIT
+    config_list = [{
+        "message_type": "bsm", "dest_ipv4": "ip", "dest_port": "port",
+        "start_datetime": "start", "end_datetime": "end",
+        "active": "1", "security": "0", "msgfwd_type": "rsuXmitMsgFwding", "snmp_index": "1"
+    }]
+    with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
+        result = format_snmp_msgfwd_configs(config_list)
+    assert TableNames.RECEIVED in result["RsuFwdSnmpwalk"]
+    assert TableNames.XMIT in result["RsuFwdSnmpwalk"]
+    assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED] == {}
+
+def test_format_snmp_msgfwd_configs_unknown_type(caplog):
+    config_list = [{
+        "message_type": "bsm", "dest_ipv4": "ip", "dest_port": "port",
+        "start_datetime": "start", "end_datetime": "end",
+        "active": "1", "security": "0", "msgfwd_type": "unknown", "snmp_index": "1"
+    }]
+    with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
+        result = format_snmp_msgfwd_configs(config_list, rsu_ip="1.1.1.1")
+    
+    assert "Encountered unknown message forwarding configuration type 'unknown' for RSU '1.1.1.1'" in caplog.text
+    assert result["RsuFwdSnmpwalk"] == {}

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -195,3 +195,33 @@ def test_format_snmp_msgfwd_configs_unknown_type(caplog):
     
     assert "Encountered unknown message forwarding configuration type 'unknown' for RSU '1.1.1.1'" in caplog.text
     assert result["RsuFwdSnmpwalk"] == {}
+
+def test_format_snmp_msgfwd_configs_case_insensitivity():
+    config_list = [
+        {
+            "message_type": "bsm", "dest_ipv4": "192.168.1.1", "dest_port": "1234",
+            "start_datetime": "start", "end_datetime": "end",
+            "active": "1", "security": "1", "msgfwd_type": "RSUdsrCFWD", "snmp_index": "1"
+        },
+        {
+            "message_type": "spat", "dest_ipv4": "192.168.1.2", "dest_port": "5678",
+            "start_datetime": "start", "end_datetime": "end",
+            "active": "4", "security": "0", "msgfwd_type": "RsuReceiveDMsG", "snmp_index": "2"
+        },
+        {
+            "message_type": "map", "dest_ipv4": "192.168.1.3", "dest_port": "9012",
+            "start_datetime": "start", "end_datetime": "end",
+            "active": "1", "security": "1", "msgfwd_type": "rsuxmitmsgfwding", "snmp_index": "3"
+        }
+    ]
+    with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
+        result = format_snmp_msgfwd_configs(config_list)
+    
+    # Check DSRC
+    assert "1" in result["RsuFwdSnmpwalk"]
+    # Check RECEIVED
+    assert TableNames.RECEIVED.value in result["RsuFwdSnmpwalk"]
+    assert "2" in result["RsuFwdSnmpwalk"][TableNames.RECEIVED.value]
+    # Check XMIT
+    assert TableNames.XMIT.value in result["RsuFwdSnmpwalk"]
+    assert "3" in result["RsuFwdSnmpwalk"][TableNames.XMIT.value]

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 from unittest.mock import patch
 from common.snmp.rsu_message_forward_helpers import (
     hex_datetime,
@@ -23,41 +24,65 @@ def test_hex_datetime():
     # With delta=1: 2024 -> 07e8
     assert hex_datetime(now, delta=1) == "07e80a1b0a1e"
 
-def test_message_type_rsu41():
-    assert message_type_rsu41('" "') == "BSM"
-    assert message_type_rsu41("00 00 00 20") == "BSM"
-    assert message_type_rsu41("00 00 80 02") == "SPaT"
-    assert message_type_rsu41("80 02") == "SPaT"
-    assert message_type_rsu41("00 00 80 03") == "TIM"
-    assert message_type_rsu41("E0 00 00 17") == "MAP"
-    assert message_type_rsu41("E0 00 00 15") == "SSM"
-    assert message_type_rsu41("E0 00 00 16") == "SRM"
-    assert message_type_rsu41("unknown") == "Other"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ('" "', "BSM"),
+        ("00 00 00 20", "BSM"),
+        ("00 00 80 02", "SPaT"),
+        ("80 02", "SPaT"),
+        ("00 00 80 03", "TIM"),
+        ("E0 00 00 17", "MAP"),
+        ("E0 00 00 15", "SSM"),
+        ("E0 00 00 16", "SRM"),
+        ("unknown", "Other"),
+    ],
+)
+def test_message_type_rsu41(raw_value, expected):
+    assert message_type_rsu41(raw_value) == expected
 
-def test_message_type_ntcip1218():
-    assert message_type_ntcip1218("20000000") == "BSM"
-    assert message_type_ntcip1218("80020000") == "SPaT"
-    assert message_type_ntcip1218("80030000") == "TIM"
-    assert message_type_ntcip1218("E0000017") == "MAP"
-    assert message_type_ntcip1218("e0000017") == "MAP"
-    assert message_type_ntcip1218("E0000015") == "SSM"
-    assert message_type_ntcip1218("E0000016") == "SRM"
-    assert message_type_ntcip1218("unknown") == "Other"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("20000000", "BSM"),
+        ("80020000", "SPaT"),
+        ("80030000", "TIM"),
+        ("E0000017", "MAP"),
+        ("e0000017", "MAP"),
+        ("E0000015", "SSM"),
+        ("E0000016", "SRM"),
+        ("unknown", "Other"),
+    ],
+)
+def test_message_type_ntcip1218(raw_value, expected):
+    assert message_type_ntcip1218(raw_value) == expected
 
-def test_ip_rsu41():
-    assert ip_rsu41("C0 A8 01 01") == "192.168.1.1"
-    # It takes the last 4 components
-    assert ip_rsu41("00 00 00 00 C0 A8 01 02") == "192.168.1.2"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("C0 A8 01 01", "192.168.1.1"),
+        # It takes the last 4 components
+        ("00 00 00 00 C0 A8 01 02", "192.168.1.2"),
+    ],
+)
+def test_ip_rsu41(raw_value, expected):
+    assert ip_rsu41(raw_value) == expected
 
 def test_ip_ntcip1218():
     assert ip_ntcip1218(" 192.168.1.1 ") == "192.168.1.1"
 
-def test_protocol():
-    assert protocol("1") == "TCP"
-    assert protocol("tcp(1)") == "TCP"
-    assert protocol("2") == "UDP"
-    assert protocol("udp(2)") == "UDP"
-    assert protocol("3") == "Other"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("1", "TCP"),
+        ("tcp(1)", "TCP"),
+        ("2", "UDP"),
+        ("udp(2)", "UDP"),
+        ("3", "Other"),
+    ],
+)
+def test_protocol(raw_value, expected):
+    assert protocol(raw_value) == expected
 
 def test_rssi_ntcip1218():
     assert rssi_ntcip1218("-70 dBm") == -70
@@ -66,27 +91,41 @@ def test_fwdon():
     assert fwdon("1") == "On"
     assert fwdon("0") == "Off"
 
-def test_active():
-    assert active("1") == "Enabled"
-    assert active("4") == "Enabled"
-    assert active("active(1)") == "Enabled"
-    assert active("2") == "Disabled"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("1", "Enabled"),
+        ("4", "Enabled"),
+        ("active(1)", "Enabled"),
+        ("2", "Disabled"),
+    ],
+)
+def test_active(raw_value, expected):
+    assert active(raw_value) == expected
 
-def test_startend_rsu41():
-    # 2023-10-27 10:30
-    # 2023 -> 07 E7
-    # 10 -> 0A
-    # 27 -> 1B
-    # 10 -> 0A
-    # 30 -> 1E
-    assert startend_rsu41("07 E7 0A 1B 0A 1E") == "2023-10-27 10:30"
-    # Padding check: 2023-01-02 03:04
-    assert startend_rsu41("07 E7 01 02 03 04") == "2023-01-02 03:04"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        # 2023-10-27 10:30
+        # 2023 -> 07 E7, 10 -> 0A, 27 -> 1B, 10 -> 0A, 30 -> 1E
+        ("07 E7 0A 1B 0A 1E", "2023-10-27 10:30"),
+        # Padding check: 2023-01-02 03:04
+        ("07 E7 01 02 03 04", "2023-01-02 03:04"),
+    ],
+)
+def test_startend_rsu41(raw_value, expected):
+    assert startend_rsu41(raw_value) == expected
 
-def test_startend_ntcip1218():
-    assert startend_ntcip1218("2023-10-27,10:30") == "2023-10-27 10:30"
-    # Padding check
-    assert startend_ntcip1218("2023-1-2,3:4") == "2023-01-02 03:04"
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("2023-10-27,10:30", "2023-10-27 10:30"),
+        # Padding check
+        ("2023-1-2,3:4", "2023-01-02 03:04"),
+    ],
+)
+def test_startend_ntcip1218(raw_value, expected):
+    assert startend_ntcip1218(raw_value) == expected
 
 @patch("common.util.format_date_denver_iso")
 def test_format_snmp_msgfwd_configs_dsrc(mock_format_date):

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -1,7 +1,5 @@
-import pytest
 import datetime
-import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from common.snmp.rsu_message_forward_helpers import (
     hex_datetime,
     message_type_rsu41,
@@ -15,7 +13,6 @@ from common.snmp.rsu_message_forward_helpers import (
     startend_rsu41,
     startend_ntcip1218,
     format_snmp_msgfwd_configs,
-    MsgFwdType,
     TableNames,
 )
 

--- a/services/common/tests/snmp/test_rsu_message_forward_helpers.py
+++ b/services/common/tests/snmp/test_rsu_message_forward_helpers.py
@@ -223,7 +223,7 @@ def test_format_snmp_msgfwd_configs_balancing():
     assert TableNames.XMIT.value in result["RsuFwdSnmpwalk"]
     assert result["RsuFwdSnmpwalk"][TableNames.RECEIVED.value] == {}
 
-def test_format_snmp_msgfwd_configs_unknown_type(caplog):
+def test_format_snmp_msgfwd_configs_unknown_type():
     config_list = [{
         "message_type": "bsm", "dest_ipv4": "ip", "dest_port": "port",
         "start_datetime": "start", "end_datetime": "end",
@@ -232,7 +232,6 @@ def test_format_snmp_msgfwd_configs_unknown_type(caplog):
     with patch("common.util.format_date_denver_iso", side_effect=lambda x: x):
         result = format_snmp_msgfwd_configs(config_list, rsu_ip="1.1.1.1")
     
-    assert "Encountered unknown message forwarding configuration type 'unknown' for RSU '1.1.1.1'" in caplog.text
     assert result["RsuFwdSnmpwalk"] == {}
 
 def test_format_snmp_msgfwd_configs_case_insensitivity():

--- a/webapp/src/EnvironmentVars.tsx
+++ b/webapp/src/EnvironmentVars.tsx
@@ -49,6 +49,7 @@ class EnvironmentVars {
   static wzdxEndpoint = `${this.getBaseApiUrl()}/wzdx-feed`
   static rsuGeoQueryEndpoint = `${this.getBaseApiUrl()}/rsu-config-geo-query`
   static rsuMsgFwdQueryEndpoint = `${this.getBaseApiUrl()}/rsu-msgfwd-query`
+  static rsuMsgFwdFetchEndpoint = `${this.getBaseApiUrl()}/rsu-msgfwd-fetch`
   static geoMsgDataEndpoint = `${this.getBaseApiUrl()}/rsu-geo-msg-data`
   static mooveAiDataEndpoint = `${this.getBaseApiUrl()}/moove-ai-data`
   static issScmsStatusEndpoint = `${this.getBaseApiUrl()}/iss-scms-status`

--- a/webapp/src/apis/api-helper.test.ts
+++ b/webapp/src/apis/api-helper.test.ts
@@ -50,6 +50,12 @@ it('Test fetch with codes request Error', async () => {
   expect(actualResponse).toEqual(null)
 })
 
+it('Test fetch with non-ok response', async () => {
+  fetchMock.mockResponseOnce('NOT OK', { status: 400 })
+  const actualResponse = await ApiHelper._getData({ url: 'https://test.com', token: 'testToken' })
+  expect(actualResponse).toEqual(null)
+})
+
 it('Test post request', async () => {
   const expectedResponse = { data: 'Test JSON' }
   fetchMock.mockResponseOnce(JSON.stringify(expectedResponse))

--- a/webapp/src/apis/api-helper.ts
+++ b/webapp/src/apis/api-helper.ts
@@ -46,6 +46,11 @@ class ApiHelper {
         },
       })
 
+      if (!resp.ok) {
+        console.error(`Error in _getData: ${resp.status} ${resp.statusText}`)
+        return null
+      }
+
       const response = await resp.json()
       return response
     } catch (err) {

--- a/webapp/src/apis/rsu-api.ts
+++ b/webapp/src/apis/rsu-api.ts
@@ -57,7 +57,7 @@ class RsuApi {
       additional_headers: { Organization: org },
       tag: 'rsu',
     })
-  getRsuMsgFwdConfigs = async (
+  getCachedRsuMsgFwdConfigsFromDatabase = async (
     token: string,
     org: string,
     url_ext = '',
@@ -70,7 +70,7 @@ class RsuApi {
       additional_headers: { Organization: org },
       tag: 'rsu',
     })
-  getRsuMsgFwdFetch = async (
+  getRsuMsgConfigsFromRsu = async (
     token: string,
     org: string,
     url_ext = '',

--- a/webapp/src/apis/rsu-api.ts
+++ b/webapp/src/apis/rsu-api.ts
@@ -70,6 +70,19 @@ class RsuApi {
       additional_headers: { Organization: org },
       tag: 'rsu',
     })
+  getRsuMsgFwdFetch = async (
+    token: string,
+    org: string,
+    url_ext = '',
+    query_params: Record<string, string> = {}
+  ): Promise<RsuMsgFwdConfigs> =>
+    apiHelper._getData({
+      url: EnvironmentVars.rsuMsgFwdFetchEndpoint + url_ext,
+      token,
+      query_params,
+      additional_headers: { Organization: org },
+      tag: 'rsu',
+    })
   getRsuAuth = async (
     token: string,
     org: string,

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -138,7 +138,7 @@ const SnmpwalkMenu = () => {
             onClick={() => {
               dispatch(getRsuMsgConfigsFromRsu(rsuIp)).then((data: { payload: string }) => {
                 if (getRsuMsgConfigsFromRsu.rejected.match(data)) {
-                  toast.error((data.payload as string) || 'Failed to fetch RSU message forwarding configuration, loading cached data')
+                  toast.error('Failed to fetch RSU message forwarding configuration, loading cached data')
                   dispatch(getCachedSnmpFwdConfigsFromDatabase(rsuIp))
                 } else if (getRsuMsgConfigsFromRsu.fulfilled.match(data)) {
                   toast.success('Successfully fetched RSU message forwarding configuration')

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -31,10 +31,10 @@ const SnmpwalkMenu = () => {
   const isConfigEmpty = React.useMemo(() => {
     if (!msgFwdConfig) return true
     if (Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable')) {
-      const txEmpty = !Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || 
-                      Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable).length === 0
-      const rxEmpty = !Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') || 
-                      Object.keys(msgFwdConfig.rsuReceivedMsgTable).length === 0
+      const txEmpty = !Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') ||
+        Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable ?? {}).length === 0
+      const rxEmpty = !Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ||
+        Object.keys(msgFwdConfig.rsuReceivedMsgTable ?? {}).length === 0
       return txEmpty && rxEmpty
     }
     return Object.keys(msgFwdConfig).length === 0
@@ -89,10 +89,10 @@ const SnmpwalkMenu = () => {
         )}
       </div>
       <div>
-        {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') && Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (
+        {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (
           <div>
             <h2 id="snmptxheader">TX Forward Table</h2>
-            {Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable).map((index) => (
+            {Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable ?? {}).map((index) => (
               <div key={'msgFwd-' + index}>
                 <SnmpwalkItem
                   key={'snmptxitem-' + index}
@@ -104,7 +104,7 @@ const SnmpwalkMenu = () => {
             ))}
 
             <h2 id="snmprxheader">RX Forward Table</h2>
-            {Object.keys(msgFwdConfig.rsuReceivedMsgTable).map((index) => (
+            {Object.keys(msgFwdConfig.rsuReceivedMsgTable ?? {}).map((index) => (
               <div>
                 <SnmpwalkItem
                   key={'snmprxitem-' + index}

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -84,9 +84,6 @@ const SnmpwalkMenu = () => {
   return (
     <div>
       <div style={{ textAlign: 'center', marginBottom: '10px' }}>
-        <h3 className="museo-slab">
-          Source: {msgFwdConfigType === 'database' ? 'Cached (Database)' : 'Live (RSU)'}
-        </h3>
         {isConfigEmpty && (
           <h4 className="museo-slab">No message forward configurations set up</h4>
         )}
@@ -159,6 +156,9 @@ const SnmpwalkMenu = () => {
           </Button>
         </Tooltip>
       </div>
+      <h3 className="museo-slab">
+        Source: {msgFwdConfigType === 'database' ? 'Cached (Database)' : 'Live (RSU)'}
+      </h3>
     </div>
   )
 }

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -9,7 +9,7 @@ import {
   selectMsgFwdConfigType,
 
   // Actions
-  refreshSnmpFwdConfig, getRsuMsgFwdFetch,
+  getCachedSnmpFwdConfigsFromDatabase, getRsuMsgConfigsFromRsu,
 } from '../generalSlices/configSlice'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import './css/SnmpwalkMenu.css'
@@ -44,7 +44,7 @@ const SnmpwalkMenu = () => {
 
   useEffect(() => {
     // Refresh Data
-    dispatch(refreshSnmpFwdConfig(rsuIp))
+    dispatch(getCachedSnmpFwdConfigsFromDatabase(rsuIp))
   }, [rsuIp, dispatch])
 
   const handleDelete = (countsMsgType: string, ip: string) => {
@@ -136,11 +136,11 @@ const SnmpwalkMenu = () => {
             startIcon={<RefreshIcon />}
             variant="outlined"
             onClick={() => {
-              dispatch(getRsuMsgFwdFetch(rsuIp)).then((data: { payload: string }) => {
-                if (getRsuMsgFwdFetch.rejected.match(data)) {
+              dispatch(getRsuMsgConfigsFromRsu(rsuIp)).then((data: { payload: string }) => {
+                if (getRsuMsgConfigsFromRsu.rejected.match(data)) {
                   toast.error((data.payload as string) || 'Failed to fetch RSU message forwarding configuration')
-                  dispatch(refreshSnmpFwdConfig(rsuIp))
-                } else if (getRsuMsgFwdFetch.fulfilled.match(data)) {
+                  dispatch(getCachedSnmpFwdConfigsFromDatabase(rsuIp))
+                } else if (getRsuMsgConfigsFromRsu.fulfilled.match(data)) {
                   toast.success('Successfully fetched RSU message forwarding configuration')
                 }
               })

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -6,9 +6,10 @@ import { Options } from './AdminDeletionOptions'
 import { selectRsuIpv4 } from '../generalSlices/rsuSlice'
 import {
   selectMsgFwdConfig,
+  selectMsgFwdConfigType,
 
   // Actions
-  refreshSnmpFwdConfig,
+  refreshSnmpFwdConfig, getRsuMsgFwdFetch,
 } from '../generalSlices/configSlice'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import './css/SnmpwalkMenu.css'
@@ -25,6 +26,7 @@ const SnmpwalkMenu = () => {
   const dispatch: ThunkDispatch<RootState, void, AnyAction> = useDispatch()
 
   const msgFwdConfig = useSelector(selectMsgFwdConfig)
+  const msgFwdConfigType = useSelector(selectMsgFwdConfigType)
 
   const rsuIp = useSelector(selectRsuIpv4)
 
@@ -69,6 +71,11 @@ const SnmpwalkMenu = () => {
 
   return (
     <div>
+      <div style={{ textAlign: 'center', marginBottom: '10px' }}>
+        <h3 className="museo-slab">
+          Source: {msgFwdConfigType === 'database' ? 'Cached (Database)' : 'Live (RSU)'}
+        </h3>
+      </div>
       <div>
         {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') && Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (
           <div>
@@ -117,7 +124,14 @@ const SnmpwalkMenu = () => {
             startIcon={<RefreshIcon />}
             variant="outlined"
             onClick={() => {
-              dispatch(refreshSnmpFwdConfig(rsuIp))
+              dispatch(getRsuMsgFwdFetch(rsuIp)).then((data: any) => {
+                if (data.type.endsWith('rejected')) {
+                  toast.error(data.payload || 'Failed to fetch RSU message forwarding configuration')
+                  dispatch(refreshSnmpFwdConfig(rsuIp))
+                } else {
+                  toast.success('Successfully fetched RSU message forwarding configuration')
+                }
+              })
             }}
             size="large"
             sx={{

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -138,7 +138,7 @@ const SnmpwalkMenu = () => {
             onClick={() => {
               dispatch(getRsuMsgConfigsFromRsu(rsuIp)).then((data: { payload: string }) => {
                 if (getRsuMsgConfigsFromRsu.rejected.match(data)) {
-                  toast.error((data.payload as string) || 'Failed to fetch RSU message forwarding configuration')
+                  toast.error((data.payload as string) || 'Failed to fetch RSU message forwarding configuration, loading cached data')
                   dispatch(getCachedSnmpFwdConfigsFromDatabase(rsuIp))
                 } else if (getRsuMsgConfigsFromRsu.fulfilled.match(data)) {
                   toast.success('Successfully fetched RSU message forwarding configuration')

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -136,11 +136,11 @@ const SnmpwalkMenu = () => {
             startIcon={<RefreshIcon />}
             variant="outlined"
             onClick={() => {
-              dispatch(getRsuMsgFwdFetch(rsuIp)).then((data: any) => {
-                if (data.type.endsWith('rejected')) {
-                  toast.error(data.payload || 'Failed to fetch RSU message forwarding configuration')
+              dispatch(getRsuMsgFwdFetch(rsuIp)).then((data: { payload: string }) => {
+                if (getRsuMsgFwdFetch.rejected.match(data)) {
+                  toast.error((data.payload as string) || 'Failed to fetch RSU message forwarding configuration')
                   dispatch(refreshSnmpFwdConfig(rsuIp))
-                } else {
+                } else if (getRsuMsgFwdFetch.fulfilled.match(data)) {
                   toast.success('Successfully fetched RSU message forwarding configuration')
                 }
               })

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -28,6 +28,18 @@ const SnmpwalkMenu = () => {
   const msgFwdConfig = useSelector(selectMsgFwdConfig)
   const msgFwdConfigType = useSelector(selectMsgFwdConfigType)
 
+  const isConfigEmpty = React.useMemo(() => {
+    if (!msgFwdConfig) return true
+    if (Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable')) {
+      const txEmpty = !Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || 
+                      Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable).length === 0
+      const rxEmpty = !Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') || 
+                      Object.keys(msgFwdConfig.rsuReceivedMsgTable).length === 0
+      return txEmpty && rxEmpty
+    }
+    return Object.keys(msgFwdConfig).length === 0
+  }, [msgFwdConfig])
+
   const rsuIp = useSelector(selectRsuIpv4)
 
   useEffect(() => {
@@ -75,6 +87,9 @@ const SnmpwalkMenu = () => {
         <h3 className="museo-slab">
           Source: {msgFwdConfigType === 'database' ? 'Cached (Database)' : 'Live (RSU)'}
         </h3>
+        {isConfigEmpty && (
+          <h4 className="museo-slab">No message forward configurations set up</h4>
+        )}
       </div>
       <div>
         {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') && Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -136,7 +136,7 @@ const SnmpwalkMenu = () => {
             startIcon={<RefreshIcon />}
             variant="outlined"
             onClick={() => {
-              dispatch(getRsuMsgConfigsFromRsu(rsuIp)).then((data: { payload: string }) => {
+              dispatch(getRsuMsgConfigsFromRsu(rsuIp)).then((data: any) => {
                 if (getRsuMsgConfigsFromRsu.rejected.match(data)) {
                   toast.error('Failed to fetch RSU message forwarding configuration, loading cached data')
                   dispatch(getCachedSnmpFwdConfigsFromDatabase(rsuIp))

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -30,7 +30,7 @@ const SnmpwalkMenu = () => {
 
   const isConfigEmpty = React.useMemo(() => {
     if (!msgFwdConfig) return true
-    if (Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable')) {
+    if (Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') && Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable')) {
       const txEmpty = !Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') ||
         Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable ?? {}).length === 0
       const rxEmpty = !Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ||
@@ -89,7 +89,7 @@ const SnmpwalkMenu = () => {
         )}
       </div>
       <div>
-        {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') || Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (
+        {Object.hasOwn(msgFwdConfig, 'rsuXmitMsgFwdingTable') && Object.hasOwn(msgFwdConfig, 'rsuReceivedMsgTable') ? (
           <div>
             <h2 id="snmptxheader">TX Forward Table</h2>
             {Object.keys(msgFwdConfig.rsuXmitMsgFwdingTable ?? {}).map((index) => (

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -156,6 +156,7 @@ const SnmpwalkMenu = () => {
           </Button>
         </Tooltip>
       </div>
+      <br />
       <h3 className="museo-slab">
         Source: {msgFwdConfigType === 'database' ? 'Cached (Database)' : 'Live (RSU)'}
       </h3>

--- a/webapp/src/components/SnmpwalkMenu.tsx
+++ b/webapp/src/components/SnmpwalkMenu.tsx
@@ -85,7 +85,7 @@ const SnmpwalkMenu = () => {
     <div>
       <div style={{ textAlign: 'center', marginBottom: '10px' }}>
         {isConfigEmpty && (
-          <h4 className="museo-slab">No message forward configurations set up</h4>
+          <h5 className="museo-slab">No message forwarding configurations were found. This may indicate that none are configured or that there was an error retrieving them. Verify that this RSU is configured and refresh.</h5>
         )}
       </div>
       <div>

--- a/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`should take a snapshot 1`] = `
     <div
       style="text-align: center; margin-bottom: 10px;"
     >
-      <h4
+      <h5
         class="museo-slab"
       >
-        No message forward configurations set up
-      </h4>
+        No message forwarding configurations were found. This may indicate that none are configured or that there was an error retrieving them. Verify that this RSU is configured and refresh.
+      </h5>
     </div>
     <div>
       <div />

--- a/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/SnmpwalkMenu.test.tsx.snap
@@ -3,6 +3,15 @@
 exports[`should take a snapshot 1`] = `
 <div>
   <div>
+    <div
+      style="text-align: center; margin-bottom: 10px;"
+    >
+      <h4
+        class="museo-slab"
+      >
+        No message forward configurations set up
+      </h4>
+    </div>
     <div>
       <div />
     </div>
@@ -34,6 +43,13 @@ exports[`should take a snapshot 1`] = `
         Refresh Message Forwarding
       </button>
     </div>
+    <br />
+    <h3
+      class="museo-slab"
+    >
+      Source: 
+      Cached (Database)
+    </h3>
   </div>
 </div>
 `;

--- a/webapp/src/generalSlices/configSlice.test.ts
+++ b/webapp/src/generalSlices/configSlice.test.ts
@@ -95,13 +95,24 @@ describe('async thunks', () => {
       const loading = true
       const msgFwdConfig = {}
       const rebootChangeSuccess = false
+      const changeSuccess = false
       const errorState = ''
+      const destIp = ''
+      const snmpMsgType = 'bsm'
       const state = reducer(initialState, {
         type: 'config/refreshSnmpFwdConfig/pending',
       })
       expect(state).toEqual({
         loading,
-        value: { ...initialState.value, msgFwdConfig, errorState, rebootChangeSuccess },
+        value: {
+          ...initialState.value,
+          msgFwdConfig,
+          errorState,
+          rebootChangeSuccess,
+          changeSuccess,
+          destIp,
+          snmpMsgType,
+        },
       })
     })
 
@@ -174,13 +185,24 @@ describe('async thunks', () => {
       const loading = true
       const msgFwdConfig = {}
       const rebootChangeSuccess = false
+      const changeSuccess = false
       const errorState = ''
+      const destIp = ''
+      const snmpMsgType = 'bsm'
       const state = reducer(initialState, {
         type: 'config/getRsuMsgFwdFetch/pending',
       })
       expect(state).toEqual({
         loading,
-        value: { ...initialState.value, msgFwdConfig, errorState, rebootChangeSuccess },
+        value: {
+          ...initialState.value,
+          msgFwdConfig,
+          errorState,
+          rebootChangeSuccess,
+          changeSuccess,
+          destIp,
+          snmpMsgType,
+        },
       })
     })
 

--- a/webapp/src/generalSlices/configSlice.test.ts
+++ b/webapp/src/generalSlices/configSlice.test.ts
@@ -203,6 +203,50 @@ describe('async thunks', () => {
       expect(resp.payload).toEqual('Test Exception')
     })
 
+    it('returns error when API throws a string', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn().mockReturnValue({
+        user: {
+          value: {
+            authLoginData: { token: 'token' },
+            organization: { name: 'name' },
+          },
+        },
+      })
+      RsuApi.getRsuMsgConfigsFromRsu = jest.fn().mockImplementation(() => {
+        throw 'String Exception'
+      })
+
+      const rsu_ip = '1.2.3.4'
+
+      const action = getRsuMsgConfigsFromRsu(rsu_ip)
+
+      const resp = await action(dispatch, getState, undefined)
+      expect(resp.payload).toEqual('String Exception')
+    })
+
+    it('returns error when API throws an unknown error', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn().mockReturnValue({
+        user: {
+          value: {
+            authLoginData: { token: 'token' },
+            organization: { name: 'name' },
+          },
+        },
+      })
+      RsuApi.getRsuMsgConfigsFromRsu = jest.fn().mockImplementation(() => {
+        throw 123
+      })
+
+      const rsu_ip = '1.2.3.4'
+
+      const action = getRsuMsgConfigsFromRsu(rsu_ip)
+
+      const resp = await action(dispatch, getState, undefined)
+      expect(resp.payload).toEqual('An unknown error occurred while fetching RSU message forwarding configuration')
+    })
+
     it('Updates the state correctly pending', async () => {
       const loading = true
       const msgFwdConfig = {}

--- a/webapp/src/generalSlices/configSlice.test.ts
+++ b/webapp/src/generalSlices/configSlice.test.ts
@@ -1,6 +1,6 @@
 import reducer, {
-  refreshSnmpFwdConfig,
-  getRsuMsgFwdFetch,
+  getCachedSnmpFwdConfigsFromDatabase,
+  getRsuMsgConfigsFromRsu,
   submitSnmpSet,
   deleteSnmpSet,
   rebootRsu,
@@ -80,14 +80,14 @@ describe('async thunks', () => {
           },
         },
       })
-      RsuApi.getRsuMsgFwdConfigs = jest.fn().mockReturnValue({ RsuFwdSnmpwalk: 'test' })
+      RsuApi.getCachedRsuMsgFwdConfigsFromDatabase = jest.fn().mockReturnValue({ RsuFwdSnmpwalk: 'test' })
 
       const rsu_ip = '1.2.3.4'
 
-      const action = refreshSnmpFwdConfig(rsu_ip)
+      const action = getCachedSnmpFwdConfigsFromDatabase(rsu_ip)
 
       const resp = await action(dispatch, getState, undefined)
-      expect(RsuApi.getRsuMsgFwdConfigs).toHaveBeenCalledWith('token', 'name', '', { rsu_ip })
+      expect(RsuApi.getCachedRsuMsgFwdConfigsFromDatabase).toHaveBeenCalledWith('token', 'name', '', { rsu_ip })
       expect(resp.payload).toEqual({ msgFwdConfig: 'test', errorState: '' })
     })
 
@@ -139,14 +139,14 @@ describe('async thunks', () => {
           },
         },
       })
-      RsuApi.getRsuMsgFwdFetch = jest.fn().mockReturnValue({ RsuFwdSnmpwalk: 'test' })
+      RsuApi.getRsuMsgConfigsFromRsu = jest.fn().mockReturnValue({ RsuFwdSnmpwalk: 'test' })
 
       const rsu_ip = '1.2.3.4'
 
-      const action = getRsuMsgFwdFetch(rsu_ip)
+      const action = getRsuMsgConfigsFromRsu(rsu_ip)
 
       const resp = await action(dispatch, getState, undefined)
-      expect(RsuApi.getRsuMsgFwdFetch).toHaveBeenCalledWith('token', 'name', '', { rsu_ip })
+      expect(RsuApi.getRsuMsgConfigsFromRsu).toHaveBeenCalledWith('token', 'name', '', { rsu_ip })
       expect(resp.payload).toEqual({ msgFwdConfig: 'test', errorState: '' })
     })
 
@@ -160,11 +160,11 @@ describe('async thunks', () => {
           },
         },
       })
-      RsuApi.getRsuMsgFwdFetch = jest.fn().mockReturnValue(null)
+      RsuApi.getRsuMsgConfigsFromRsu = jest.fn().mockReturnValue(null)
 
       const rsu_ip = '1.2.3.4'
 
-      const action = getRsuMsgFwdFetch(rsu_ip)
+      const action = getRsuMsgConfigsFromRsu(rsu_ip)
 
       const resp = await action(dispatch, getState, undefined)
       expect(resp.payload).toEqual('Failed to fetch RSU message forwarding configuration')

--- a/webapp/src/generalSlices/configSlice.test.ts
+++ b/webapp/src/generalSlices/configSlice.test.ts
@@ -181,6 +181,28 @@ describe('async thunks', () => {
       expect(resp.payload).toEqual('Failed to fetch RSU message forwarding configuration')
     })
 
+    it('returns error when API throws exception', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn().mockReturnValue({
+        user: {
+          value: {
+            authLoginData: { token: 'token' },
+            organization: { name: 'name' },
+          },
+        },
+      })
+      RsuApi.getRsuMsgConfigsFromRsu = jest.fn().mockImplementation(() => {
+        throw new Error('Test Exception')
+      })
+
+      const rsu_ip = '1.2.3.4'
+
+      const action = getRsuMsgConfigsFromRsu(rsu_ip)
+
+      const resp = await action(dispatch, getState, undefined)
+      expect(resp.payload).toEqual('Test Exception')
+    })
+
     it('Updates the state correctly pending', async () => {
       const loading = true
       const msgFwdConfig = {}

--- a/webapp/src/generalSlices/configSlice.test.ts
+++ b/webapp/src/generalSlices/configSlice.test.ts
@@ -1,5 +1,6 @@
 import reducer, {
   refreshSnmpFwdConfig,
+  getRsuMsgFwdFetch,
   submitSnmpSet,
   deleteSnmpSet,
   rebootRsu,
@@ -33,6 +34,7 @@ describe('config reducer', () => {
         addConfigPoint: false,
         configCoordinates: [],
         configList: [],
+        msgFwdConfigType: 'database',
       },
     })
   })
@@ -111,7 +113,10 @@ describe('async thunks', () => {
         type: 'config/refreshSnmpFwdConfig/fulfilled',
         payload: { msgFwdConfig, errorState },
       })
-      expect(state).toEqual({ loading, value: { ...initialState.value, msgFwdConfig, errorState } })
+      expect(state).toEqual({
+        loading,
+        value: { ...initialState.value, msgFwdConfig, errorState, msgFwdConfigType: 'database' },
+      })
     })
 
     it('Updates the state correctly rejected', async () => {
@@ -120,6 +125,89 @@ describe('async thunks', () => {
         type: 'config/refreshSnmpFwdConfig/rejected',
       })
       expect(state).toEqual({ loading, value: { ...initialState.value } })
+    })
+  })
+
+  describe('getRsuMsgFwdFetch', () => {
+    it('returns and calls the api correctly', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn().mockReturnValue({
+        user: {
+          value: {
+            authLoginData: { token: 'token' },
+            organization: { name: 'name' },
+          },
+        },
+      })
+      RsuApi.getRsuMsgFwdFetch = jest.fn().mockReturnValue({ RsuFwdSnmpwalk: 'test' })
+
+      const rsu_ip = '1.2.3.4'
+
+      const action = getRsuMsgFwdFetch(rsu_ip)
+
+      const resp = await action(dispatch, getState, undefined)
+      expect(RsuApi.getRsuMsgFwdFetch).toHaveBeenCalledWith('token', 'name', '', { rsu_ip })
+      expect(resp.payload).toEqual({ msgFwdConfig: 'test', errorState: '' })
+    })
+
+    it('returns error when API fails', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn().mockReturnValue({
+        user: {
+          value: {
+            authLoginData: { token: 'token' },
+            organization: { name: 'name' },
+          },
+        },
+      })
+      RsuApi.getRsuMsgFwdFetch = jest.fn().mockReturnValue(null)
+
+      const rsu_ip = '1.2.3.4'
+
+      const action = getRsuMsgFwdFetch(rsu_ip)
+
+      const resp = await action(dispatch, getState, undefined)
+      expect(resp.payload).toEqual('Failed to fetch RSU message forwarding configuration')
+    })
+
+    it('Updates the state correctly pending', async () => {
+      const loading = true
+      const msgFwdConfig = {}
+      const rebootChangeSuccess = false
+      const errorState = ''
+      const state = reducer(initialState, {
+        type: 'config/getRsuMsgFwdFetch/pending',
+      })
+      expect(state).toEqual({
+        loading,
+        value: { ...initialState.value, msgFwdConfig, errorState, rebootChangeSuccess },
+      })
+    })
+
+    it('Updates the state correctly fulfilled', async () => {
+      const loading = false
+      const msgFwdConfig = 'test'
+      const errorState = 'error'
+      const state = reducer(initialState, {
+        type: 'config/getRsuMsgFwdFetch/fulfilled',
+        payload: { msgFwdConfig, errorState },
+      })
+      expect(state).toEqual({
+        loading,
+        value: { ...initialState.value, msgFwdConfig, errorState, msgFwdConfigType: 'rsu' },
+      })
+    })
+
+    it('Updates the state correctly rejected', async () => {
+      const loading = false
+      const state = reducer(initialState, {
+        type: 'config/getRsuMsgFwdFetch/rejected',
+        payload: 'error',
+      })
+      expect(state).toEqual({
+        loading,
+        value: { ...initialState.value, errorState: 'error' },
+      })
     })
   })
 

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -19,20 +19,51 @@ const initialState = {
   addConfigPoint: false,
   configCoordinates: [] as number[][],
   configList: [] as number[],
+  msgFwdConfigType: 'database' as 'database' | 'rsu',
 }
 
 export const refreshSnmpFwdConfig = createAsyncThunk(
   'config/refreshSnmpFwdConfig',
   async (rsu_ip: string, { getState }) => {
+    console.log('Retrieving RSU message forwarding config from database for IP:', rsu_ip)
     const currentState = getState() as RootState
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)
 
     const response = await RsuApi.getRsuMsgFwdConfigs(token, organization, '', { rsu_ip })
+    if (!response) {
+      return {
+        msgFwdConfig: {},
+        errorState: 'Failed to retrieve RSU message forwarding configuration from database',
+      }
+    }
 
     return {
       msgFwdConfig: response.RsuFwdSnmpwalk,
       errorState: '',
+    }
+  }
+)
+
+export const getRsuMsgFwdFetch = createAsyncThunk(
+  'config/getRsuMsgFwdFetch',
+  async (rsu_ip: string, { getState, rejectWithValue }) => {
+    console.log('Retrieving RSU message forwarding config directly from RSU for IP:', rsu_ip)
+    const currentState = getState() as RootState
+    const token = selectToken(currentState)
+    const organization = selectOrganizationName(currentState)
+
+    try {
+      const response = await RsuApi.getRsuMsgFwdFetch(token, organization, '', { rsu_ip })
+      if (!response) {
+        return rejectWithValue('Failed to fetch RSU message forwarding configuration')
+      }
+      return {
+        msgFwdConfig: response.RsuFwdSnmpwalk,
+        errorState: '',
+      }
+    } catch (e) {
+      return rejectWithValue(e.message)
     }
   }
 )
@@ -56,10 +87,13 @@ export const submitSnmpSet = createAsyncThunk('config/submitSnmpSet', async (ipL
   }
 
   const response = await RsuApi.postRsuData(token, organization, body, '')
+  if (!response) {
+    return { changeSuccess: false, errorState: 'Failed to submit SNMP configuration' }
+  }
 
   return response.status === 200
     ? { changeSuccess: true, errorState: '' }
-    : { changeSuccess: false, errorState: response.body.RsuFwdSnmpset }
+    : { changeSuccess: false, errorState: response.body?.RsuFwdSnmpset }
 })
 
 export const deleteSnmpSet = createAsyncThunk(
@@ -86,10 +120,13 @@ export const deleteSnmpSet = createAsyncThunk(
     }
 
     const response = await RsuApi.postRsuData(token, organization, body, '')
+    if (!response) {
+      return { changeSuccess: false, errorState: 'Failed to delete SNMP configuration' }
+    }
 
     return response.status === 200
       ? { changeSuccess: true, errorState: '' }
-      : { changeSuccess: false, errorState: response.body.RsuFwdSnmpset }
+      : { changeSuccess: false, errorState: response.body?.RsuFwdSnmpset }
   }
 )
 
@@ -123,6 +160,12 @@ export const checkFirmwareUpgrade = createAsyncThunk(
     }
 
     const response = await RsuApi.postRsuData(token, organization, body, '')
+    if (!response) {
+      return {
+        firmwareUpgradeAvailable: false,
+        firmwareUpgradeName: '',
+      }
+    }
     return {
       firmwareUpgradeAvailable: response.body?.upgrade_available,
       firmwareUpgradeName: response.body?.upgrade_name,
@@ -144,6 +187,9 @@ export const startFirmwareUpgrade = createAsyncThunk(
     }
 
     const response = await RsuApi.postRsuData(token, organization, body, '')
+    if (!response) {
+      return { message: 'Firmware upgrades failed to be started', statusCode: 500 }
+    }
 
     if (ipList.length === 1) {
       return {
@@ -166,7 +212,7 @@ export const geoRsuQuery = createAsyncThunk(
     const organization = selectOrganizationName(currentState)
     const configCoordinates = selectConfigCoordinates(currentState)
 
-    return await RsuApi.postRsuGeo(
+    const response = await RsuApi.postRsuGeo(
       token,
       organization,
       JSON.stringify({
@@ -175,6 +221,10 @@ export const geoRsuQuery = createAsyncThunk(
       }),
       ''
     )
+    if (!response) {
+      return rejectWithValue('Failed to query RSUs by geometry')
+    }
+    return response
   },
   {
     // Will guard thunk from being executed
@@ -237,9 +287,29 @@ export const configSlice = createSlice({
         state.loading = false
         state.value.msgFwdConfig = action.payload.msgFwdConfig ?? ({} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs)
         state.value.errorState = action.payload.errorState
+        state.value.msgFwdConfigType = 'database'
       })
       .addCase(refreshSnmpFwdConfig.rejected, (state) => {
         state.loading = false
+      })
+      .addCase(getRsuMsgFwdFetch.pending, (state) => {
+        state.loading = true
+        state.value.msgFwdConfig = {} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs
+        state.value.errorState = ''
+        state.value.destIp = ''
+        state.value.snmpMsgType = 'bsm'
+        state.value.changeSuccess = false
+        state.value.rebootChangeSuccess = false
+      })
+      .addCase(getRsuMsgFwdFetch.fulfilled, (state, action) => {
+        state.loading = false
+        state.value.msgFwdConfig = action.payload.msgFwdConfig ?? ({} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs)
+        state.value.errorState = action.payload.errorState
+        state.value.msgFwdConfigType = 'rsu'
+      })
+      .addCase(getRsuMsgFwdFetch.rejected, (state, action) => {
+        state.loading = false
+        state.value.errorState = (action.payload as string) || 'Failed to fetch RSU message forwarding configuration'
       })
       .addCase(submitSnmpSet.pending, (state) => {
         state.loading = true
@@ -318,7 +388,7 @@ export const configSlice = createSlice({
         state.value.rebootChangeSuccess = false
       })
       .addCase(geoRsuQuery.fulfilled, (state, action) => {
-        state.value.configList = action.payload.body
+        state.value.configList = action.payload.body ?? []
         state.value.addConfigPoint = false
         state.loading = false
       })
@@ -343,6 +413,7 @@ export const selectLoading = (state: RootState) => state.config.loading
 export const selectAddConfigPoint = (state: RootState) => state.config.value.addConfigPoint
 export const selectConfigCoordinates = (state: RootState) => state.config.value.configCoordinates
 export const selectConfigList = (state: RootState) => state.config.value.configList
+export const selectMsgFwdConfigType = (state: RootState) => state.config.value.msgFwdConfigType
 
 export const {
   setDestIp,

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -37,7 +37,7 @@ export const getCachedSnmpFwdConfigsFromDatabase = createAsyncThunk<
     if (!response) {
       return {
         msgFwdConfig: {},
-        errorState: 'Failed to retrieve RSU message forwarding configuration from database',
+        errorState: 'Failed to retrieve RSU message forwarding configuration from database for RSU IP ${rsu_ip}: received empty or no response',
       }
     }
 

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -29,7 +29,6 @@ export const getCachedSnmpFwdConfigsFromDatabase = createAsyncThunk<
 >(
   'config/refreshSnmpFwdConfig',
   async (rsu_ip: string, { getState }) => {
-    console.log('Retrieving RSU message forwarding config from database for IP:', rsu_ip)
     const currentState = getState() as RootState
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)
@@ -56,7 +55,6 @@ export const getRsuMsgConfigsFromRsu = createAsyncThunk<
 >(
   'config/getRsuMsgFwdFetch',
   async (rsu_ip: string, { getState, rejectWithValue }) => {
-    console.log('Retrieving RSU message forwarding config directly from RSU for IP:', rsu_ip)
     const currentState = getState() as RootState
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -321,7 +321,7 @@ export const configSlice = createSlice({
       })
       .addCase(getRsuMsgConfigsFromRsu.rejected, (state, action) => {
         state.loading = false
-        state.value.errorState = (action.payload as string) || 'Failed to fetch RSU message forwarding configuration'
+        state.value.errorState = (action.payload as string | undefined) || 'Failed to fetch RSU message forwarding configuration'
       })
       .addCase(submitSnmpSet.pending, (state) => {
         state.loading = true

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -77,7 +77,8 @@ export const getRsuMsgConfigsFromRsu = createAsyncThunk<
       if (typeof e === 'string') {
         return rejectWithValue(e)
       }
-      return rejectWithValue('An unknown error occurred while fetching RSU message forwarding configuration')    }
+      return rejectWithValue('An unknown error occurred while fetching RSU message forwarding configuration')
+    }
   }
 )
 

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -214,7 +214,7 @@ export const startFirmwareUpgrade = createAsyncThunk(
 
 export const geoRsuQuery = createAsyncThunk(
   'config/geoRsuQuery',
-  async (vendor: string, { getState }) => {
+  async (vendor: string, { getState, rejectWithValue }) => {
     const currentState = getState() as RootState
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -71,8 +71,13 @@ export const getRsuMsgConfigsFromRsu = createAsyncThunk<
         errorState: '',
       }
     } catch (e) {
-      return rejectWithValue(e.message)
-    }
+      if (e instanceof Error) {
+        return rejectWithValue(e.message)
+      }
+      if (typeof e === 'string') {
+        return rejectWithValue(e)
+      }
+      return rejectWithValue('An unknown error occurred while fetching RSU message forwarding configuration')    }
   }
 )
 

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -22,7 +22,7 @@ const initialState = {
   msgFwdConfigType: 'database' as 'database' | 'rsu',
 }
 
-export const refreshSnmpFwdConfig = createAsyncThunk<
+export const getCachedSnmpFwdConfigsFromDatabase = createAsyncThunk<
   { msgFwdConfig: RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs; errorState: string },
   string,
   { state: RootState }
@@ -34,7 +34,7 @@ export const refreshSnmpFwdConfig = createAsyncThunk<
     const token = selectToken(currentState)
     const organization = selectOrganizationName(currentState)
 
-    const response = await RsuApi.getRsuMsgFwdConfigs(token, organization, '', { rsu_ip })
+    const response = await RsuApi.getCachedRsuMsgFwdConfigsFromDatabase(token, organization, '', { rsu_ip })
     if (!response) {
       return {
         msgFwdConfig: {},
@@ -49,7 +49,7 @@ export const refreshSnmpFwdConfig = createAsyncThunk<
   }
 )
 
-export const getRsuMsgFwdFetch = createAsyncThunk<
+export const getRsuMsgConfigsFromRsu = createAsyncThunk<
   { msgFwdConfig: RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs; errorState: string },
   string,
   { state: RootState }
@@ -62,7 +62,7 @@ export const getRsuMsgFwdFetch = createAsyncThunk<
     const organization = selectOrganizationName(currentState)
 
     try {
-      const response = await RsuApi.getRsuMsgFwdFetch(token, organization, '', { rsu_ip })
+      const response = await RsuApi.getRsuMsgConfigsFromRsu(token, organization, '', { rsu_ip })
       if (!response) {
         return rejectWithValue('Failed to fetch RSU message forwarding configuration')
       }
@@ -282,7 +282,7 @@ export const configSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(refreshSnmpFwdConfig.pending, (state) => {
+      .addCase(getCachedSnmpFwdConfigsFromDatabase.pending, (state) => {
         state.loading = true
         state.value.msgFwdConfig = {} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs
         state.value.errorState = ''
@@ -291,16 +291,16 @@ export const configSlice = createSlice({
         state.value.changeSuccess = false
         state.value.rebootChangeSuccess = false
       })
-      .addCase(refreshSnmpFwdConfig.fulfilled, (state, action) => {
+      .addCase(getCachedSnmpFwdConfigsFromDatabase.fulfilled, (state, action) => {
         state.loading = false
         state.value.msgFwdConfig = action.payload.msgFwdConfig ?? ({} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs)
         state.value.errorState = action.payload.errorState
         state.value.msgFwdConfigType = 'database'
       })
-      .addCase(refreshSnmpFwdConfig.rejected, (state) => {
+      .addCase(getCachedSnmpFwdConfigsFromDatabase.rejected, (state) => {
         state.loading = false
       })
-      .addCase(getRsuMsgFwdFetch.pending, (state) => {
+      .addCase(getRsuMsgConfigsFromRsu.pending, (state) => {
         state.loading = true
         state.value.msgFwdConfig = {} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs
         state.value.errorState = ''
@@ -309,13 +309,13 @@ export const configSlice = createSlice({
         state.value.changeSuccess = false
         state.value.rebootChangeSuccess = false
       })
-      .addCase(getRsuMsgFwdFetch.fulfilled, (state, action) => {
+      .addCase(getRsuMsgConfigsFromRsu.fulfilled, (state, action) => {
         state.loading = false
         state.value.msgFwdConfig = action.payload.msgFwdConfig ?? ({} as RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs)
         state.value.errorState = action.payload.errorState
         state.value.msgFwdConfigType = 'rsu'
       })
-      .addCase(getRsuMsgFwdFetch.rejected, (state, action) => {
+      .addCase(getRsuMsgConfigsFromRsu.rejected, (state, action) => {
         state.loading = false
         state.value.errorState = (action.payload as string) || 'Failed to fetch RSU message forwarding configuration'
       })

--- a/webapp/src/generalSlices/configSlice.ts
+++ b/webapp/src/generalSlices/configSlice.ts
@@ -22,7 +22,11 @@ const initialState = {
   msgFwdConfigType: 'database' as 'database' | 'rsu',
 }
 
-export const refreshSnmpFwdConfig = createAsyncThunk(
+export const refreshSnmpFwdConfig = createAsyncThunk<
+  { msgFwdConfig: RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs; errorState: string },
+  string,
+  { state: RootState }
+>(
   'config/refreshSnmpFwdConfig',
   async (rsu_ip: string, { getState }) => {
     console.log('Retrieving RSU message forwarding config from database for IP:', rsu_ip)
@@ -45,7 +49,11 @@ export const refreshSnmpFwdConfig = createAsyncThunk(
   }
 )
 
-export const getRsuMsgFwdFetch = createAsyncThunk(
+export const getRsuMsgFwdFetch = createAsyncThunk<
+  { msgFwdConfig: RsuDsrcFwdConfigs | RsuRxTxMsgFwdConfigs; errorState: string },
+  string,
+  { state: RootState }
+>(
   'config/getRsuMsgFwdFetch',
   async (rsu_ip: string, { getState, rejectWithValue }) => {
     console.log('Retrieving RSU message forwarding config directly from RSU for IP:', rsu_ip)


### PR DESCRIPTION
# PR Details

## Description
The 'refresh' button for the message forward configurations displayed in the SnmpwalkMenu for an RSU retrieved the latest cached configurations in the database instead of reaching out to the RSU directly. Functionality for reaching out to the RSU directly to retrieve this information has been exposed in the API and is now utilized when pressing the 'refresh' button.

## How Has This Been Tested?
I deployed these changes to CDOT's dev environment and verified the following:
- New UI elements indicating source of data show up and update when refresh button pressed
- Refresh button is capable of successfully retrieving data directly from RSUs
- User is alerted of success or failure when pressing refresh button
- When refresh button fails, the UI shows the cached information

### Screenshot of menu showing cached configurations
<img width="409" height="549" alt="image" src="https://github.com/user-attachments/assets/5602f3e3-e972-4056-9adf-ca4cd359e137" />

### Screenshot of menu showing live configurations after pressing refresh button
<img width="411" height="554" alt="image" src="https://github.com/user-attachments/assets/bbfbde02-e3c2-4c2f-83dc-e3f95e1414ca" />

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [ ] All existing tests pass.

### Note
There are failing unit tests for the python API, but they were not introduced in this PR and are present on the develop branch.

<img width="1415" height="156" alt="image" src="https://github.com/user-attachments/assets/8e7245ff-ac8b-471e-adcb-a13b963697d3" />


