### PR TITLE
Allowing Operators to use RSU Configuration Menu

### DIFF
--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {(selectedRsu || selectedRsuList?.length > 0) && (
+      {SecureStorageManager.getUserRole() === 'operator' && (selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"

--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {SecureStorageManager.getUserRole() === 'admin' && (selectedRsu || selectedRsuList?.length > 0) && (
+      {(selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Previously, the RSU configuration menu (seen pictured in red) was restricted to use by administrators. This has been reduced to requiring the "operator" role, as that role gives access to overall device management and configuration.

## How Has This Been Tested?

This was tested through creating a new test user (through the admin user page), giving the new user operator permissions, setting a keycloak password for that user, then logging into the cvmanager dashboard as that user and selecting an RSU. The operator user was successfully able to view and use the RSU configuration menu.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
