### PR TITLE
Fixing RSU Configuration Menu Permissions

### DIFF
--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -28,7 +28,7 @@ const Menu = () => {
   const displayCounts = useSelector(selectDisplayCounts)
   const displayRsuErrors = useSelector(selectDisplayRsuErrors)
 
-  const isOperator = useMemo(() => {
+  const isOperatorOrAbove = useMemo(() => {
     const allowedRoles = ['operator', 'admin']
     return allowedRoles.includes(SecureStorageManager.getUserRole())
   }, [])
@@ -55,7 +55,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {isOperator && (selectedRsu || selectedRsuList?.length > 0) && (
+      {isOperatorOrAbove && (selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"

--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {(selectedRsu || selectedRsuList?.length > 0) && (
+      {SecureStorageManager.getUserRole() === 'operator' && (selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"

--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import './Menu.css'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { selectSelectedRsu } from '../../generalSlices/rsuSlice'
 import { selectConfigList } from '../../generalSlices/configSlice'
 import { selectDisplayCounts, selectDisplayRsuErrors } from './menuSlice'
@@ -8,8 +8,6 @@ import { SecureStorageManager } from '../../managers'
 import DisplayCounts from './DisplayCounts'
 import DisplayRsuErrors from './DisplayRsuErrors'
 import ConfigureRSU from './ConfigureRSU'
-import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
-import { RootState } from '../../store'
 import { headerTabHeight } from '../../styles/index'
 import { useTheme } from '@mui/material'
 
@@ -24,12 +22,16 @@ const menuStyle: React.CSSProperties = {
 }
 
 const Menu = () => {
-  const dispatch: ThunkDispatch<RootState, void, AnyAction> = useDispatch()
   const theme = useTheme()
   const selectedRsu = useSelector(selectSelectedRsu)
   const selectedRsuList = useSelector(selectConfigList)
   const displayCounts = useSelector(selectDisplayCounts)
   const displayRsuErrors = useSelector(selectDisplayRsuErrors)
+
+  const isOperator = useMemo(() => {
+    const allowedRoles = ['operator', 'admin']
+    return allowedRoles.includes(SecureStorageManager.getUserRole())
+  }, [])
 
   return (
     <div>
@@ -53,7 +55,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {SecureStorageManager.getUserRole() === 'operator' && (selectedRsu || selectedRsuList?.length > 0) && (
+      {isOperator && (selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"

--- a/webapp/src/features/menu/Menu.tsx
+++ b/webapp/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ const Menu = () => {
           <DisplayRsuErrors />
         </div>
       )}
-      {SecureStorageManager.getUserRole() === 'admin' && (selectedRsu || selectedRsuList?.length > 0) && (
+      {(selectedRsu || selectedRsuList?.length > 0) && (
         <div
           style={{ ...menuStyle, backgroundColor: theme.palette.custom.mapLegendBackground, width: '400px' }}
           className="visibleProp map-control-container"


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Fixing RSU configuration menu permissions to allow all org-roles above Operator to access the menu (operator and admin). The menu should only be hidden from users

## How Has This Been Tested?

Running locally, I confirmed that the default user (role admin) could view the rsu config menu. I then used postgresql to update the default user's role to operator, logged out and back in, and confirmed that the menu was still visible. I then updated the default user's role to user, logged out and back in, and verified that the menu was not visible.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
