### PR TITLE
Fixing Missing API Port Variable

### DIFF
--- a/services/api/src/main.py
+++ b/services/api/src/main.py
@@ -84,4 +84,4 @@ if api_environment.ENABLE_INTERSECTION_FEATURES:
     api.add_resource(AdminIntersection, "/admin-intersection")
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=api_environment.FLASK_RUN_PORT)
+    app.run(host="0.0.0.0", port=api_environment.APPLICATION_PORT)


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

The cv-manager python API was referencing a missing environment variable, FLASK_RUN_PORT. This has been replaced by an existing environment variable, APPLICATION_PORT

## How Has This Been Tested?

This was tested through running the python API locally (vscode launch.json) and through docker.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
