### PR TITLE
Bug: Fix SNMPset for Map message forwarding

### DIFF
--- a/services/api/src/rsu_snmpset.py
+++ b/services/api/src/rsu_snmpset.py
@@ -10,7 +10,7 @@ import rsu_commands
 msg_type_map = {
     "bsm": {"port": "46800", "psid": "20", "tx": False, "raw": False},
     "spat": {"port": "44910", "psid": "8002", "tx": True, "raw": False},
-    "map": {"port": "44920", "psid": "20", "tx": True, "raw": True},
+    "map": {"port": "44920", "psid": "E0000017", "tx": True, "raw": True},
     "ssm": {"port": "44900", "psid": "E0000015", "tx": True, "raw": True},
     "srm": {"port": "44930", "psid": "E0000016", "tx": False, "raw": True},
     "tim": {"port": "47900", "psid": "8003", "tx": True, "raw": True},


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
There is a bug in develop that causes RSU SNMP message forwarding configurations for the Map message type to be configured as a BSM message forwarding configuration. For NTCIP-1218 it would put this configuration in the TX table and for the older 4.1 spec it would just be a BSM configuration.

This simple fix resolves this issue by correcting the PSID to be the Map message PSID.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally with a Commsignia RSU on the local network.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
