### PR TITLE
Adding RSU admin endpoints to IAPI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -152,5 +152,6 @@
     "json",
     "jsonc",
     "markdown"
-  ]
+  ],
+  "java.debug.settings.onBuildFailureProceed": true
 }

--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -373,8 +373,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<annotationProcessorPaths>
 						<!-- Lombok -->
 						<path>

--- a/services/intersection-api/api/pom.xml
+++ b/services/intersection-api/api/pom.xml
@@ -27,6 +27,8 @@
 		<!-- Allow override of github organization when publishing artifacts to github -->
 		<github_organization>usdot-jpo-ode</github_organization>
 		<geotools.version>19-SNAPSHOT</geotools.version>
+		<mapstruct.version>1.5.5.Final</mapstruct.version>
+		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -308,6 +310,11 @@
             <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${mapstruct.version}</version>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>
@@ -360,6 +367,35 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.2.5</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>17</source>
+					<target>17</target>
+					<annotationProcessorPaths>
+						<!-- Lombok -->
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<!-- MapStruct -->
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${mapstruct.version}</version>
+						</path>
+						<!-- Lombok + MapStruct binding -->
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>${lombok-mapstruct-binding.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -153,6 +153,11 @@ public class RsuController {
         return ResponseEntity.noContent().build();
     }
 
+    /*
+     * Maps API sort fields to database fields. If no mapping is found, the original
+     * field is used. This allows the API to use more user-friendly field names
+     * while still supporting sorting on database fields.
+     */
     private Pageable mapSortFields(Pageable pageable) {
         if (!pageable.getSort().isSorted()) {
             return pageable;

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -1,0 +1,174 @@
+package us.dot.its.jpo.ode.api.controllers.devices;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelections;
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.services.PermissionService;
+import us.dot.its.jpo.ode.api.services.RsuManagementService;
+
+@Slf4j
+@RestController
+@ConditionalOnProperty(name = "enable.api", havingValue = "true", matchIfMissing = false)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+})
+@RequestMapping("/devices/rsus")
+@RequiredArgsConstructor
+public class RsuController {
+    private final RsuManagementService rsuManagementService;
+
+    private static final Map<String, String> SORT_FIELD_MAPPING = Map.of(
+            "ip", "ipv4Address",
+            "primary_route", "primaryRoute",
+            "serial_number", "serialNumber",
+            "scms_id", "issScmsId");
+
+    @Operation(summary = "Get All RSUs for Organization", description = "Get summary data for all RSUs the user has access to in the specified organization.")
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json", params = "!rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+    })
+    public Page<RsuInfoDto> getAllRsus(
+            @RequestHeader(name = "Organization", required = true) String organization,
+            @PageableDefault(size = 100) Pageable pageable) {
+        log.info("Getting all RSUs for organization: {}", organization);
+
+        Pageable mappedPageable = mapSortFields(pageable);
+
+        Page<RsuInfoDto> allRsuInfo = rsuManagementService.getAllRsuInfo(organization, mappedPageable);
+        return allRsuInfo;
+    }
+
+    @Operation(summary = "Get Single RSU Management Data", description = "Get RSU data required for RSU modification page. "
+            + "Returns detailed data for the specified RSU along with allowed selections for modification.")
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json", params = "rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'USER') and @PermissionService.hasRole('USER'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role with access to the RSU requested"),
+    })
+    public RsuInfoDto getSingleRsuData(
+            @RequestParam(name = "rsu_ip", required = true) String rsuIp) {
+        log.info("Getting RSU data for IP: {}", rsuIp);
+        RsuInfoDto rsuInfo = rsuManagementService.getRsuInfo(rsuIp);
+        if (rsuInfo == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found");
+        }
+
+        return rsuInfo;
+    }
+
+    @Operation(summary = "Get Single RSU Management Data", description = "Get RSU data required for RSU modification page. "
+            + "Returns detailed data for the specified RSU along with allowed selections for modification.")
+    @RequestMapping(method = RequestMethod.GET, path = "/allowed-selections", produces = "application/json")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
+    })
+    public ModifyRsuAllowedSelections getSingleRsuAllowedSelections() {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = PermissionService.getUsername(auth);
+        ModifyRsuAllowedSelections allowedSelections = rsuManagementService.getAllowedSelections(username);
+
+        return allowedSelections;
+    }
+
+    @Operation(summary = "Modify RSU", description = "Modify RSU information")
+    @RequestMapping(method = RequestMethod.PATCH, produces = "application/json", params = "rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
+    })
+    public ResponseEntity<Void> modifyRsu(@RequestParam(name = "rsu_ip", required = true) String rsuIp,
+            @Validated @RequestBody RsuPatch body) {
+        log.info("Modifying RSU with IP: {}", rsuIp);
+
+        rsuManagementService.modifyRsu(rsuIp, body);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Delete RSU", description = "Delete RSU from management system")
+    @RequestMapping(method = RequestMethod.DELETE, produces = "application/json", params = "rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
+    })
+    public ResponseEntity<Void> deleteRsu(@RequestParam(name = "rsu_ip", required = true) String rsuIp) {
+        log.info("Deleting RSU with IP: {}", rsuIp);
+
+        rsuManagementService.deleteRsuByIpv4Address(rsuIp);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Delete RSU", description = "Delete RSU from management system")
+    @RequestMapping(method = RequestMethod.DELETE, path = "/batch", produces = "application/json")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
+    })
+    public ResponseEntity<Void> deleteRsus(@RequestBody List<String> rsuIps) {
+        log.info("Deleting {} RSUs with IPs: {}", rsuIps.size(), rsuIps);
+
+        rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private Pageable mapSortFields(Pageable pageable) {
+        if (!pageable.getSort().isSorted()) {
+            return pageable;
+        }
+
+        Sort mappedSort = Sort.unsorted();
+
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            String mappedProperty = SORT_FIELD_MAPPING.getOrDefault(property, property);
+            mappedSort = mappedSort.and(Sort.by(order.getDirection(), mappedProperty));
+        }
+
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                mappedSort);
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -90,15 +90,15 @@ public class RsuController {
         return rsuInfo;
     }
 
-    @Operation(summary = "Get Single RSU Management Data", description = "Get RSU data required for RSU modification page. "
+    @Operation(summary = "Get Allowed Selections for RSU Management", description = "Get RSU data required for RSU modification page. "
             + "Returns detailed data for the specified RSU along with allowed selections for modification.")
     @RequestMapping(method = RequestMethod.GET, path = "/allowed-selections", produces = "application/json")
-    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('OPERATOR')")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Success"),
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
     })
-    public ModifyRsuAllowedSelections getSingleRsuAllowedSelections() {
+    public ModifyRsuAllowedSelections getAllowedSelections() {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = PermissionService.getUsername(auth);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -140,7 +140,7 @@ public class RsuController {
 
     @Operation(summary = "Delete RSU", description = "Delete RSU from management system")
     @RequestMapping(method = RequestMethod.DELETE, path = "/batch", produces = "application/json")
-    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'OPERATOR') and @PermissionService.hasRole('OPERATOR'))")
+    @PreAuthorize("@PermissionService.isSuperUser() || (#rsuIps.?[!@PermissionService.hasRsu(#this, 'OPERATOR')].empty and @PermissionService.hasRole('OPERATOR'))")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Success"),
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -63,8 +63,6 @@ public class RsuController {
     public Page<RsuInfoDto> getAllRsus(
             @RequestHeader(name = "Organization", required = true) String organization,
             @PageableDefault(size = 100) Pageable pageable) {
-        log.info("Getting all RSUs for organization: {}", organization);
-
         Pageable mappedPageable = mapSortFields(pageable);
 
         Page<RsuInfoDto> allRsuInfo = rsuManagementService.getAllRsuInfo(organization, mappedPageable);
@@ -81,7 +79,6 @@ public class RsuController {
     })
     public RsuInfoDto getSingleRsuData(
             @RequestParam(name = "rsu_ip", required = true) String rsuIp) {
-        log.info("Getting RSU data for IP: {}", rsuIp);
         RsuInfoDto rsuInfo = rsuManagementService.getRsuInfo(rsuIp);
         if (rsuInfo == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found");
@@ -99,7 +96,6 @@ public class RsuController {
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
     })
     public ModifyRsuAllowedSelections getAllowedSelections() {
-
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = PermissionService.getUsername(auth);
         ModifyRsuAllowedSelections allowedSelections = rsuManagementService.getAllowedSelections(username);
@@ -116,8 +112,6 @@ public class RsuController {
     })
     public ResponseEntity<Void> modifyRsu(@RequestParam(name = "rsu_ip", required = true) String rsuIp,
             @Validated @RequestBody RsuPatch body) {
-        log.info("Modifying RSU with IP: {}", rsuIp);
-
         rsuManagementService.modifyRsu(rsuIp, body);
 
         return ResponseEntity.noContent().build();
@@ -131,23 +125,19 @@ public class RsuController {
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
     })
     public ResponseEntity<Void> deleteRsu(@RequestParam(name = "rsu_ip", required = true) String rsuIp) {
-        log.info("Deleting RSU with IP: {}", rsuIp);
-
         rsuManagementService.deleteRsuByIpv4Address(rsuIp);
 
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Delete RSU", description = "Delete RSU from management system")
+    @Operation(summary = "Delete Multiple RSUs", description = "Delete Multiple RSUs from management system")
     @RequestMapping(method = RequestMethod.DELETE, path = "/batch", produces = "application/json")
-    @PreAuthorize("@PermissionService.isSuperUser() || (#rsuIps.?[!@PermissionService.hasRsu(#this, 'OPERATOR')].empty and @PermissionService.hasRole('OPERATOR'))")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsus(#rsuIps, 'OPERATOR') && @PermissionService.hasRole('OPERATOR'))")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Success"),
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role with access to the RSU requested"),
     })
     public ResponseEntity<Void> deleteRsus(@RequestBody List<String> rsuIps) {
-        log.info("Deleting {} RSUs with IPs: {}", rsuIps.size(), rsuIps);
-
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
 
         return ResponseEntity.noContent().build();

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -112,7 +112,9 @@ public class RsuController {
     })
     public ResponseEntity<Void> modifyRsu(@RequestParam(name = "rsu_ip", required = true) String rsuIp,
             @Validated @RequestBody RsuPatch body) {
-        rsuManagementService.modifyRsu(rsuIp, body);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = PermissionService.getUsername(auth);
+        rsuManagementService.modifyRsu(rsuIp, body, username);
 
         return ResponseEntity.noContent().build();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
@@ -9,9 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,9 +45,7 @@ public class OrganizationController {
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or ADMIN role"),
     })
     public List<String> getRsuIpsByOrganization(
-            @RequestHeader(name = "Organization", required = true) String organization,
-            @PageableDefault(size = 100) Pageable pageable) {
-
+            @RequestHeader(name = "Organization", required = true) String organization) {
         return rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization).stream()
                 .map(InetAddress::getHostAddress)
                 .collect(Collectors.toList());

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
@@ -39,7 +39,7 @@ public class OrganizationController {
     RsuRepository rsuRepository;
     RsuOrganizationRepository rsuOrganizationRepository;
 
-    @Operation(summary = "Get All RSU IPs for the Organization", description = "Get IPs of all RSUs the user has access to in the specified organization.")
+    @Operation(summary = "Get RSU IPs by Organization", description = "Retrieves a list of IP addresses for all RSUs belonging to the specified organization.")
     @RequestMapping(path = "rsus", method = RequestMethod.GET, produces = "application/json", params = "!rsu_ip")
     @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('ADMIN')")
     @ApiResponses(value = {
@@ -55,12 +55,12 @@ public class OrganizationController {
                 .collect(Collectors.toList());
     }
 
-    @Operation(summary = "Get Single RSU Management Data", description = "Get RSU data required for RSU modification page. "
-            + "Returns detailed data for the specified RSU along with allowed selections for modification.")
+    @Operation(summary = "Get RSU Organization Assignments", description = "Retrieves a list of organization names that the specified RSU is assigned to.")
     @RequestMapping(path = "rsus", method = RequestMethod.GET, produces = "application/json", params = "rsu_ip")
     @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'ADMIN') and @PermissionService.hasRole('ADMIN'))")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - Invalid RSU IP address format"),
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or ADMIN role with access to the RSU requested"),
     })
     public List<String> getRsuOrganizationAssignments(
@@ -68,7 +68,6 @@ public class OrganizationController {
         try {
             return rsuRepository.findAllOrganizationNamesByIpv4Address(InetAddress.getByName(rsuIp));
         } catch (UnknownHostException e) {
-            // return 400 Bad Request
             log.error("Invalid RSU IP address: {}", rsuIp, e);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid RSU IP address: " + rsuIp, e);
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
@@ -34,8 +34,8 @@ import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 @RequestMapping("/organizations")
 @RequiredArgsConstructor
 public class OrganizationController {
-    RsuRepository rsuRepository;
-    RsuOrganizationRepository rsuOrganizationRepository;
+    final RsuRepository rsuRepository;
+    final RsuOrganizationRepository rsuOrganizationRepository;
 
     @Operation(summary = "Get RSU IPs by Organization", description = "Retrieves a list of IP addresses for all RSUs belonging to the specified organization.")
     @RequestMapping(path = "rsus", method = RequestMethod.GET, produces = "application/json", params = "!rsu_ip")

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationController.java
@@ -1,0 +1,76 @@
+package us.dot.its.jpo.ode.api.controllers.organizations;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+
+@Slf4j
+@RestController
+@ConditionalOnProperty(name = "enable.api", havingValue = "true", matchIfMissing = false)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+})
+@RequestMapping("/organizations")
+@RequiredArgsConstructor
+public class OrganizationController {
+    RsuRepository rsuRepository;
+    RsuOrganizationRepository rsuOrganizationRepository;
+
+    @Operation(summary = "Get All RSU IPs for the Organization", description = "Get IPs of all RSUs the user has access to in the specified organization.")
+    @RequestMapping(path = "rsus", method = RequestMethod.GET, produces = "application/json", params = "!rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or ADMIN role"),
+    })
+    public List<String> getRsuIpsByOrganization(
+            @RequestHeader(name = "Organization", required = true) String organization,
+            @PageableDefault(size = 100) Pageable pageable) {
+
+        return rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization).stream()
+                .map(InetAddress::getHostAddress)
+                .collect(Collectors.toList());
+    }
+
+    @Operation(summary = "Get Single RSU Management Data", description = "Get RSU data required for RSU modification page. "
+            + "Returns detailed data for the specified RSU along with allowed selections for modification.")
+    @RequestMapping(path = "rsus", method = RequestMethod.GET, produces = "application/json", params = "rsu_ip")
+    @PreAuthorize("@PermissionService.isSuperUser() || (@PermissionService.hasRsu(#rsuIp, 'ADMIN') and @PermissionService.hasRole('ADMIN'))")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or ADMIN role with access to the RSU requested"),
+    })
+    public List<String> getRsuOrganizationAssignments(
+            @RequestParam(name = "rsu_ip", required = true) String rsuIp) {
+        try {
+            return rsuRepository.findAllOrganizationNamesByIpv4Address(InetAddress.getByName(rsuIp));
+        } catch (UnknownHostException e) {
+            // return 400 Bad Request
+            log.error("Invalid RSU IP address: {}", rsuIp, e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid RSU IP address: " + rsuIp, e);
+        }
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/keycloak/support/CorsUtil.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/keycloak/support/CorsUtil.java
@@ -25,7 +25,7 @@ public class CorsUtil {
         UrlBasedCorsConfigurationSource defaultUrlBasedCorsConfigSource = new UrlBasedCorsConfigurationSource();
         CorsConfiguration corsConfiguration = new CorsConfiguration().applyPermitDefaultValues();
         corsConfiguration.addAllowedOrigin(properties.getCors());
-        List.of("GET", "POST", "PUT", "DELETE", "OPTIONS").forEach(corsConfiguration::addAllowedMethod);
+        List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH").forEach(corsConfiguration::addAllowedMethod);
         defaultUrlBasedCorsConfigSource.registerCorsConfiguration("/**", corsConfiguration);
 
         cors.configurationSource(req -> {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -1,0 +1,72 @@
+package us.dot.its.jpo.ode.api.mappers;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.locationtech.jts.geom.Point;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface RsuInfoMapper {
+
+    /**
+     * Convert Rsu entity to RsuInfoDto
+     * MapStruct will automatically map fields with the same name
+     */
+    @Mapping(source = "ipv4Address", target = "ipv4Address", qualifiedByName = "mapInetAddressToString")
+    @Mapping(source = "geography", target = "geoPosition", qualifiedByName = "mapGeoPosition")
+    @Mapping(target = "model", expression = "java(mapModelNames(rsu.getModel()))")
+    @Mapping(source = "credential.nickname", target = "sshCredentialGroup")
+    @Mapping(source = "snmpCredential.nickname", target = "snmpCredentialGroup")
+    @Mapping(source = "snmpProtocol.nickname", target = "snmpVersionGroup")
+    @Mapping(source = "rsuOrganizations", target = "organizations", qualifiedByName = "mapOrganizationNames")
+    RsuInfoDto toDto(Rsu rsu);
+
+    /**
+     * Combine model name and manufacturer name
+     */
+    @Named("mapInetAddressToString")
+    default String mapInetAddressToString(InetAddress inetAddress) {
+        return inetAddress.getHostAddress();
+    }
+
+    /**
+     * Combine model name and manufacturer name
+     */
+    @Named("mapGeoPosition")
+    default SimplePosition mapLatitude(Point geography) {
+        return new SimplePosition(geography.getY(), geography.getX());
+    }
+
+    /**
+     * Combine model name and manufacturer name
+     */
+    default String mapModelNames(us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel rsuModel) {
+        if (rsuModel == null || rsuModel.getManufacturer() == null) {
+            return rsuModel != null ? rsuModel.getName() : null;
+        }
+        return String.format("%s %s", rsuModel.getManufacturer().getName(), rsuModel.getName());
+    }
+
+    /**
+     * Extract organization names from RsuOrganization list
+     */
+    @Named("mapOrganizationNames")
+    default List<String> mapOrganizationNames(List<RsuOrganization> rsuOrganizations) {
+        if (rsuOrganizations == null) {
+            return null;
+        }
+        return rsuOrganizations.stream()
+                .map(ro -> ro.getOrganization().getName())
+                .collect(Collectors.toList());
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -32,7 +32,7 @@ public interface RsuInfoMapper {
     RsuInfoDto toDto(Rsu rsu);
 
     /**
-     * Combine model name and manufacturer name
+     * Convert InetAddress to String representation (IP address)
      */
     @Named("mapInetAddressToString")
     default String mapInetAddressToString(InetAddress inetAddress) {
@@ -40,15 +40,16 @@ public interface RsuInfoMapper {
     }
 
     /**
-     * Combine model name and manufacturer name
+     * Convert JTS Point geometry to SimplePosition (latitude/longitude)
      */
     @Named("mapGeoPosition")
-    default SimplePosition mapLatitude(Point geography) {
+    default SimplePosition mapGeoPosition(Point geography) {
         return new SimplePosition(geography.getY(), geography.getX());
     }
 
     /**
-     * Combine model name and manufacturer name
+     * Combine manufacturer name and model name into a single string
+     * Returns format: "Manufacturer Model" (e.g., "Commsignia ITS-RS4-M")
      */
     default String mapModelNames(us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel rsuModel) {
         if (rsuModel == null || rsuModel.getManufacturer() == null) {
@@ -59,6 +60,7 @@ public interface RsuInfoMapper {
 
     /**
      * Extract organization names from RsuOrganization list
+     * Returns a list of organization name strings
      */
     @Named("mapOrganizationNames")
     default List<String> mapOrganizationNames(List<RsuOrganization> rsuOrganizations) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -13,6 +13,7 @@ import org.mapstruct.Named;
 import us.dot.its.jpo.ode.api.models.SimplePosition;
 import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
@@ -24,7 +25,7 @@ public interface RsuInfoMapper {
      */
     @Mapping(source = "ipv4Address", target = "ipv4Address", qualifiedByName = "mapInetAddressToString")
     @Mapping(source = "geography", target = "geoPosition", qualifiedByName = "mapGeoPosition")
-    @Mapping(target = "model", expression = "java(mapModelNames(rsu.getModel()))")
+    @Mapping(source = "model", target = "model", qualifiedByName = "mapModelNames")
     @Mapping(source = "credential.nickname", target = "sshCredentialGroup")
     @Mapping(source = "snmpCredential.nickname", target = "snmpCredentialGroup")
     @Mapping(source = "snmpProtocol.nickname", target = "snmpVersionGroup")
@@ -51,7 +52,8 @@ public interface RsuInfoMapper {
      * Combine manufacturer name and model name into a single string
      * Returns format: "Manufacturer Model" (e.g., "Commsignia ITS-RS4-M")
      */
-    default String mapModelNames(us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel rsuModel) {
+    @Named("mapModelNames")
+    default String mapModelNames(RsuModel rsuModel) {
         if (rsuModel == null || rsuModel.getManufacturer() == null) {
             return rsuModel != null ? rsuModel.getName() : null;
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -37,6 +37,9 @@ public interface RsuInfoMapper {
      */
     @Named("mapInetAddressToString")
     default String mapInetAddressToString(InetAddress inetAddress) {
+        if (inetAddress == null) {
+            return null;
+        }
         return inetAddress.getHostAddress();
     }
 
@@ -45,6 +48,9 @@ public interface RsuInfoMapper {
      */
     @Named("mapGeoPosition")
     default SimplePosition mapGeoPosition(Point geography) {
+        if (geography == null) {
+            return null;
+        }
         return new SimplePosition(geography.getY(), geography.getX());
     }
 
@@ -70,6 +76,7 @@ public interface RsuInfoMapper {
             return null;
         }
         return rsuOrganizations.stream()
+                .filter(ro -> ro != null && ro.getOrganization() != null && ro.getOrganization().getName() != null)
                 .map(ro -> ro.getOrganization().getName())
                 .collect(Collectors.toList());
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuPatchMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuPatchMapper.java
@@ -1,0 +1,104 @@
+package us.dot.its.jpo.ode.api.mappers;
+
+import java.net.InetAddress;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface RsuPatchMapper {
+
+    /**
+     * Update existing Rsu entity with non-null values from RsuPatch
+     * Null values in the patch are ignored (existing values preserved)
+     */
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(source = "ipv4Address", target = "ipv4Address", qualifiedByName = "mapStringToInetAddress")
+    @Mapping(source = "geoPosition", target = "geography", qualifiedByName = "mapGeoPosition")
+    @Mapping(target = "model", ignore = true) // Set in service layer
+    @Mapping(target = "credential", ignore = true) // Set in service layer
+    @Mapping(target = "snmpCredential", ignore = true) // Set in service layer
+    @Mapping(target = "snmpProtocol", ignore = true) // Set in service layer
+    @Mapping(target = "rsuOrganizations", ignore = true) // Set in service layer
+    @Mapping(target = "id", ignore = true) // Never update ID
+    @Mapping(target = "firmwareVersion", ignore = true)
+    @Mapping(target = "targetFirmwareVersion", ignore = true)
+    void updateRsuFromPatch(RsuPatch patch, @MappingTarget Rsu rsu);
+
+    /**
+     * Convert RsuPatch to new Rsu entity (for create operations)
+     */
+    @Mapping(source = "ipv4Address", target = "ipv4Address", qualifiedByName = "mapStringToInetAddress")
+    @Mapping(source = "geoPosition", target = "geography", qualifiedByName = "mapGeoPosition")
+    @Mapping(target = "model", ignore = true) // Set in service layer
+    @Mapping(target = "credential", ignore = true) // Set in service layer
+    @Mapping(target = "snmpCredential", ignore = true) // Set in service layer
+    @Mapping(target = "snmpProtocol", ignore = true) // Set in service layer
+    @Mapping(target = "rsuOrganizations", ignore = true) // Set in service layer
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "firmwareVersion", ignore = true)
+    @Mapping(target = "targetFirmwareVersion", ignore = true)
+    Rsu toRsu(RsuPatch rsuPatch);
+
+    /**
+     * Map String IP address to InetAddress
+     */
+    @Named("mapStringToInetAddress")
+    default InetAddress mapStringToInetAddress(String ipv4Address) {
+        if (ipv4Address == null) {
+            return null;
+        }
+        try {
+            return InetAddress.getByName(ipv4Address);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid IP address: " + ipv4Address, e);
+        }
+    }
+
+    /**
+     * Convert SimplePosition (lat/long) to JTS Point
+     * Note: PostGIS uses SRID 4326 (WGS 84) for geographic coordinates
+     * Coordinate order is (longitude, latitude) for POINT geometry
+     */
+    @Named("mapGeoPosition")
+    default Point mapGeoPosition(SimplePosition position) {
+        if (position == null) {
+            return null;
+        }
+        
+        // Create GeometryFactory with SRID 4326 (WGS 84 - standard for GPS coordinates)
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        
+        // Create coordinate (longitude, latitude) - ORDER MATTERS!
+        // PostGIS uses (X, Y) = (longitude, latitude)
+        Coordinate coordinate = new Coordinate(position.longitude(), position.latitude());
+        
+        // Create and return Point
+        return geometryFactory.createPoint(coordinate);
+    }
+
+    /**
+     * Convert JTS Point back to SimplePosition (for reverse mapping if needed)
+     */
+    @Named("mapPointToSimplePosition")
+    default SimplePosition mapPointToSimplePosition(Point point) {
+        if (point == null) {
+            return null;
+        }
+        
+        return new SimplePosition(point.getY(), point.getX()); // latitude, longitude
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuPatchMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuPatchMapper.java
@@ -75,17 +75,17 @@ public interface RsuPatchMapper {
      */
     @Named("mapGeoPosition")
     default Point mapGeoPosition(SimplePosition position) {
-        if (position == null) {
+        if (position == null || position.latitude() == null || position.longitude() == null) {
             return null;
         }
-        
+
         // Create GeometryFactory with SRID 4326 (WGS 84 - standard for GPS coordinates)
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-        
+
         // Create coordinate (longitude, latitude) - ORDER MATTERS!
         // PostGIS uses (X, Y) = (longitude, latitude)
         Coordinate coordinate = new Coordinate(position.longitude(), position.latitude());
-        
+
         // Create and return Point
         return geometryFactory.createPoint(coordinate);
     }
@@ -98,7 +98,7 @@ public interface RsuPatchMapper {
         if (point == null) {
             return null;
         }
-        
+
         return new SimplePosition(point.getY(), point.getX()); // latitude, longitude
     }
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/SimplePosition.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/SimplePosition.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.ode.api.models;
+
+public record SimplePosition(Double latitude, Double longitude) {
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/ModifyRsuAllowedSelections.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/ModifyRsuAllowedSelections.java
@@ -1,0 +1,29 @@
+package us.dot.its.jpo.ode.api.models.devices.management;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModifyRsuAllowedSelections {
+    @JsonProperty("primary_routes")
+    List<String> primaryRoutes;
+    @JsonProperty("rsu_models")
+    List<String> rsuModels;
+    @JsonProperty("ssh_credential_groups")
+    List<String> sshCredentialGroups;
+    @JsonProperty("snmp_credential_groups")
+    List<String> snmpCredentialGroups;
+    @JsonProperty("snmp_version_groups")
+    List<String> snmpVersionGroups;
+    @JsonProperty("organizations")
+    List<String> organizations;
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/RsuPatch.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/RsuPatch.java
@@ -1,0 +1,58 @@
+package us.dot.its.jpo.ode.api.models.devices.management;
+
+import lombok.Getter;
+import lombok.Setter;
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RsuPatch {
+    @JsonProperty("ip")
+    String ipv4Address;
+
+    @JsonProperty("geo_position")
+    SimplePosition geoPosition;
+
+    @JsonProperty("milepost")
+    Double milepost;
+
+    @JsonProperty("primary_route")
+    @Size(max = 128)
+    String primaryRoute;
+
+    @JsonProperty("serial_number")
+    @Size(max = 128)
+    String serialNumber;
+
+    @JsonProperty("model")
+    String model;
+
+    @JsonProperty("scms_id")
+    @Size(max = 128)
+    String issScmsId;
+
+    @JsonProperty("ssh_credential_group")
+    String sshCredentialGroup;
+
+    @JsonProperty("snmp_credential_group")
+    String snmpCredentialGroup;
+
+    @JsonProperty("snmp_version_group")
+    String snmpVersionGroup;
+
+    @JsonProperty("organizations_to_add")
+    List<String> organizationsToAdd;
+
+    @JsonProperty("organizations_to_remove")
+    List<String> organizationsToRemove;
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/dtos/RsuInfoDto.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/dtos/RsuInfoDto.java
@@ -1,0 +1,60 @@
+package us.dot.its.jpo.ode.api.models.postgres.dtos;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Value;
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for {@link Rsu}
+ */
+@Value
+public class RsuInfoDto implements Serializable {
+    @JsonProperty("ip")
+    @NotNull
+    String ipv4Address;
+
+    @JsonProperty("geo_position")
+    @NotNull
+    SimplePosition geoPosition;
+
+    @JsonProperty("milepost")
+    @NotNull
+    Double milepost;
+
+    @JsonProperty("primary_route")
+    @NotNull
+    @Size(max = 128)
+    String primaryRoute;
+
+    @JsonProperty("serial_number")
+    @NotNull
+    @Size(max = 128)
+    String serialNumber;
+
+    @JsonProperty("scms_id")
+    @NotNull
+    @Size(max = 128)
+    String issScmsId;
+
+    @JsonProperty("model")
+    String model;
+
+    @JsonProperty("ssh_credential_group")
+    String sshCredentialGroup;
+
+    @JsonProperty("snmp_credential_group")
+    String snmpCredentialGroup;
+
+    @JsonProperty("snmp_version_group")
+    String snmpVersionGroup;
+
+    @JsonProperty("organizations")
+    List<String> organizations;
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/ConsecutiveFirmwareUpgradeFailure.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/ConsecutiveFirmwareUpgradeFailure.java
@@ -17,11 +17,10 @@ public class ConsecutiveFirmwareUpgradeFailure {
     @MapsId
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "rsu_id", nullable = false)
-    private Rsu rsus;
+    private Rsu rsu;
 
     @NotNull
     @Column(name = "consecutive_failures", nullable = false)
     private Integer consecutiveFailures;
-
 
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/RsuOrganization.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/RsuOrganization.java
@@ -25,6 +25,4 @@ public class RsuOrganization {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
-
-
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/User.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/User.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.List;

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ConsecutiveFirmwareUpgradeFailureRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ConsecutiveFirmwareUpgradeFailureRepository.java
@@ -1,0 +1,29 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.ConsecutiveFirmwareUpgradeFailure;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface ConsecutiveFirmwareUpgradeFailureRepository
+        extends JpaRepository<ConsecutiveFirmwareUpgradeFailure, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ConsecutiveFirmwareUpgradeFailure uf WHERE uf.rsu.ipv4Address = :ipv4Address")
+    void removeConsecutiveFirmwareUpgradeFailureByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ConsecutiveFirmwareUpgradeFailure uf WHERE uf.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(
+            @Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/MaxRetryLimitReachedInstanceRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/MaxRetryLimitReachedInstanceRepository.java
@@ -1,0 +1,29 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.MaxRetryLimitReachedInstance;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface MaxRetryLimitReachedInstanceRepository
+        extends JpaRepository<MaxRetryLimitReachedInstance, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM MaxRetryLimitReachedInstance mr WHERE mr.rsu.ipv4Address = :ipv4Address")
+    void removeMaxRetryLimitReachedInstanceByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM MaxRetryLimitReachedInstance mr WHERE mr.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(
+            @Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/MaxRetryLimitReachedInstanceRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/MaxRetryLimitReachedInstanceRepository.java
@@ -8,13 +8,14 @@ import org.springframework.stereotype.Repository;
 
 import jakarta.transaction.Transactional;
 import us.dot.its.jpo.ode.api.models.postgres.tables.MaxRetryLimitReachedInstance;
+import us.dot.its.jpo.ode.api.models.postgres.tables.MaxRetryLimitReachedInstanceId;
 
 import java.net.InetAddress;
 import java.util.List;
 
 @Repository
 public interface MaxRetryLimitReachedInstanceRepository
-        extends JpaRepository<MaxRetryLimitReachedInstance, Integer> {
+        extends JpaRepository<MaxRetryLimitReachedInstance, MaxRetryLimitReachedInstanceId> {
 
     @Modifying
     @Transactional

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/OrganizationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/OrganizationRepository.java
@@ -1,0 +1,14 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
+
+import java.util.Optional;
+
+@Repository
+public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
+
+    Optional<Organization> findByName(String name);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
@@ -1,0 +1,26 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Ping;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface PingRepository extends JpaRepository<Ping, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Ping p WHERE p.rsu.ipv4Address = :ipv4Address")
+    void removePingByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Transactional
+    @Query("DELETE FROM Ping ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultiplePingsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
@@ -20,6 +20,7 @@ public interface PingRepository extends JpaRepository<Ping, Integer> {
     @Query("DELETE FROM Ping p WHERE p.rsu.ipv4Address = :ipv4Address")
     void removePingByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
+    @Modifying
     @Transactional
     @Query("DELETE FROM Ping ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
     void removeMultiplePingsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/PingRepository.java
@@ -22,6 +22,6 @@ public interface PingRepository extends JpaRepository<Ping, Integer> {
 
     @Modifying
     @Transactional
-    @Query("DELETE FROM Ping ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    @Query("DELETE FROM Ping p WHERE p.rsu.ipv4Address IN :ipv4Addresses")
     void removeMultiplePingsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuCredentialRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuCredentialRepository.java
@@ -1,0 +1,18 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RsuCredentialRepository extends JpaRepository<RsuCredential, Integer> {
+    @Query("SELECT rc.nickname FROM RsuCredential rc ORDER BY rc.nickname ASC")
+    List<String> findAllNicknames();
+
+    Optional<RsuCredential> findByNickname(String nickname);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuIntersectionRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuIntersectionRepository.java
@@ -1,0 +1,27 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuIntersection;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface RsuIntersectionRepository extends JpaRepository<RsuIntersection, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RsuIntersection ri WHERE ri.rsu.ipv4Address = :ipv4Address")
+    void removeRsuIntersectionByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RsuIntersection ri WHERE ri.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleRsuIntersectionsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuModelRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuModelRepository.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+
+import java.util.Optional;
+
+@Repository
+public interface RsuModelRepository extends JpaRepository<RsuModel, Integer> {
+
+    @Query("SELECT rm FROM RsuModel rm " +
+            "JOIN rm.manufacturer m " +
+            "WHERE rm.name = :name AND m.name = :manufacturerName")
+    Optional<RsuModel> findByNameAndManufacturerName(@Param("name") String name,
+            @Param("manufacturerName") String manufacturerName);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
@@ -21,6 +21,7 @@ public interface RsuOrganizationRepository extends JpaRepository<RsuOrganization
     @Query("DELETE FROM RsuOrganization ro WHERE ro.rsu.ipv4Address = :ipv4Address")
     void removeRsuOrganizationByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
+    @Modifying
     @Transactional
     @Query("DELETE FROM RsuOrganization ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
     void removeMultipleRsuOrganizationsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
@@ -31,6 +31,9 @@ public interface RsuOrganizationRepository extends JpaRepository<RsuOrganization
 
     Optional<RsuOrganization> findByOrganization_Name(String organizationName);
 
+    Optional<RsuOrganization> findByRsuIpv4AddressAndOrganization_Name(InetAddress ipv4Address,
+            String organizationName);
+
     @Query("SELECT ro.rsu.ipv4Address FROM RsuOrganization ro WHERE ro.organization.name = :organizationName")
     List<InetAddress> findAllRsuIpsByOrganizationName(@Param("organizationName") String organizationName);
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
@@ -29,7 +29,7 @@ public interface RsuOrganizationRepository extends JpaRepository<RsuOrganization
     @Query("SELECT ro FROM RsuOrganization ro WHERE ro.rsu.ipv4Address = :ipv4Address")
     List<RsuOrganization> findAllByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
-    Optional<RsuOrganization> findByOrganizationName(String organizationName);
+    Optional<RsuOrganization> findByOrganization_Name(String organizationName);
 
     @Query("SELECT ro.rsu.ipv4Address FROM RsuOrganization ro WHERE ro.organization.name = :organizationName")
     List<InetAddress> findAllRsuIpsByOrganizationName(@Param("organizationName") String organizationName);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOrganizationRepository.java
@@ -1,0 +1,35 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RsuOrganizationRepository extends JpaRepository<RsuOrganization, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RsuOrganization ro WHERE ro.rsu.ipv4Address = :ipv4Address")
+    void removeRsuOrganizationByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Transactional
+    @Query("DELETE FROM RsuOrganization ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleRsuOrganizationsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+
+    @Query("SELECT ro FROM RsuOrganization ro WHERE ro.rsu.ipv4Address = :ipv4Address")
+    List<RsuOrganization> findAllByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    Optional<RsuOrganization> findByOrganizationName(String organizationName);
+
+    @Query("SELECT ro.rsu.ipv4Address FROM RsuOrganization ro WHERE ro.organization.name = :organizationName")
+    List<InetAddress> findAllRsuIpsByOrganizationName(@Param("organizationName") String organizationName);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
@@ -24,11 +24,13 @@ public interface RsuRepository extends JpaRepository<Rsu, Integer> {
             "FROM Rsu r " +
             "JOIN r.rsuOrganizations ro " +
             "JOIN ro.organization o " +
-            "WHERE r.ipv4Address = :rsuIp AND o.name IN :organizations")
-    boolean existsByIpAndOrganizations(@Param("rsuIp") String rsuIp,
+            "WHERE r.ipv4Address = :ipv4Address AND o.name IN :organizations")
+    boolean existsByIpAndOrganizations(@Param("ipv4Address") InetAddress ipv4Address,
             @Param("organizations") List<String> organizations);
 
     Rsu findByIpv4Address(InetAddress ipv4Address);
+
+    List<Rsu> findByIpv4AddressIn(List<InetAddress> ipv4Addresses);
 
     @Query("SELECT rsu " +
             "FROM Rsu rsu " +
@@ -60,7 +62,7 @@ public interface RsuRepository extends JpaRepository<Rsu, Integer> {
     @Modifying
     @Transactional
     @Query("DELETE FROM Rsu r WHERE r.ipv4Address IN :ipv4Addresses")
-    void deleteByIpv4AddressIn(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+    void removeByIpv4AddressIn(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
 
     interface RsuModelProjection {
         String getManufacturer();

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
@@ -56,6 +56,13 @@ public interface RsuRepository extends JpaRepository<Rsu, Integer> {
             "ORDER BY o.name ASC")
     List<String> findAllOrganizationNamesByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
+    @Query("SELECT r.ipv4Address " +
+            "FROM Rsu r " +
+            "JOIN r.rsuOrganizations ro " +
+            "JOIN ro.organization o " +
+            "WHERE o.name in :organizationNames")
+    List<InetAddress> findAllowedRsuIpsInOrganizations(@Param("organizationNames") List<String> organizationNames);
+
     @Transactional
     void removeRsuByIpv4Address(InetAddress ipv4Address);
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuRepository.java
@@ -1,22 +1,70 @@
 package us.dot.its.jpo.ode.api.repositories;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 
+import java.net.InetAddress;
 import java.util.List;
 
 @Repository
 public interface RsuRepository extends JpaRepository<Rsu, Integer> {
     /**
-     * Check if RSU exists in any of the given organizations using entity relationships
+     * Check if RSU exists in any of the given organizations using entity
+     * relationships
      */
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END " +
-           "FROM Rsu r " +
-           "JOIN r.rsuOrganizations ro " +
-           "JOIN ro.organization o " +
-           "WHERE r.ipv4Address = :rsuIp AND o.name IN :organizations")
-    boolean existsByIpAndOrganizations(@Param("rsuIp") String rsuIp, @Param("organizations") List<String> organizations);
+            "FROM Rsu r " +
+            "JOIN r.rsuOrganizations ro " +
+            "JOIN ro.organization o " +
+            "WHERE r.ipv4Address = :rsuIp AND o.name IN :organizations")
+    boolean existsByIpAndOrganizations(@Param("rsuIp") String rsuIp,
+            @Param("organizations") List<String> organizations);
+
+    Rsu findByIpv4Address(InetAddress ipv4Address);
+
+    @Query("SELECT rsu " +
+            "FROM Rsu rsu " +
+            "JOIN rsu.rsuOrganizations ro " +
+            "JOIN ro.organization o " +
+            "WHERE o.name = :orgName")
+    Page<Rsu> findAllByOrganization(@Param("orgName") String orgName, Pageable pageable);
+
+    @Query("SELECT DISTINCT r.primaryRoute FROM Rsu r ORDER BY r.primaryRoute ASC")
+    List<String> findAllPrimaryRoutes();
+
+    @Query("SELECT m.name as manufacturer, rm.name as model " +
+            "FROM RsuModel rm " +
+            "JOIN rm.manufacturer m " +
+            "ORDER BY m.name ASC, rm.name ASC")
+    List<RsuModelProjection> findAllRsuModels();
+
+    @Query("SELECT o.name " +
+            "FROM Rsu r " +
+            "JOIN r.rsuOrganizations ro " +
+            "JOIN ro.organization o " +
+            "WHERE r.ipv4Address = :ipv4Address " +
+            "ORDER BY o.name ASC")
+    List<String> findAllOrganizationNamesByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Transactional
+    void removeRsuByIpv4Address(InetAddress ipv4Address);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Rsu r WHERE r.ipv4Address IN :ipv4Addresses")
+    void deleteByIpv4AddressIn(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+
+    interface RsuModelProjection {
+        String getManufacturer();
+
+        String getModel();
+    }
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ScmsHealthRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ScmsHealthRepository.java
@@ -1,0 +1,26 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.ScmsHealth;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface ScmsHealthRepository extends JpaRepository<ScmsHealth, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ScmsHealth ro WHERE ro.rsu.ipv4Address = :ipv4Address")
+    void removeScmsHealthByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Transactional
+    @Query("DELETE FROM ScmsHealth ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleScmsHealthByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ScmsHealthRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/ScmsHealthRepository.java
@@ -20,6 +20,7 @@ public interface ScmsHealthRepository extends JpaRepository<ScmsHealth, Integer>
     @Query("DELETE FROM ScmsHealth ro WHERE ro.rsu.ipv4Address = :ipv4Address")
     void removeScmsHealthByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
+    @Modifying
     @Transactional
     @Query("DELETE FROM ScmsHealth ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
     void removeMultipleScmsHealthByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpCredentialRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpCredentialRepository.java
@@ -1,0 +1,18 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SnmpCredentialRepository extends JpaRepository<SnmpCredential, Integer> {
+    @Query("SELECT sc.nickname FROM SnmpCredential sc ORDER BY sc.nickname ASC")
+    List<String> findAllNicknames();
+
+    Optional<SnmpCredential> findByNickname(String nickname);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpMsgfwdConfigRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpMsgfwdConfigRepository.java
@@ -1,0 +1,27 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpMsgfwdConfig;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpMsgfwdConfigId;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@Repository
+public interface SnmpMsgfwdConfigRepository extends JpaRepository<SnmpMsgfwdConfig, SnmpMsgfwdConfigId> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM SnmpMsgfwdConfig ro WHERE ro.rsu.ipv4Address = :ipv4Address")
+    void removeSnmpMsgfwdConfigByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Transactional
+    @Query("DELETE FROM SnmpMsgfwdConfig ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleSnmpMsgfwdConfigByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpMsgfwdConfigRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpMsgfwdConfigRepository.java
@@ -21,6 +21,7 @@ public interface SnmpMsgfwdConfigRepository extends JpaRepository<SnmpMsgfwdConf
     @Query("DELETE FROM SnmpMsgfwdConfig ro WHERE ro.rsu.ipv4Address = :ipv4Address")
     void removeSnmpMsgfwdConfigByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
 
+    @Modifying
     @Transactional
     @Query("DELETE FROM SnmpMsgfwdConfig ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
     void removeMultipleSnmpMsgfwdConfigByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpProtocolRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/SnmpProtocolRepository.java
@@ -1,0 +1,18 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SnmpProtocolRepository extends JpaRepository<SnmpProtocol, Integer> {
+    @Query("SELECT sp.nickname FROM SnmpProtocol sp ORDER BY sp.nickname ASC")
+    List<String> findAllNicknames();
+
+    Optional<SnmpProtocol> findByNickname(String nickname);
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
@@ -1,11 +1,13 @@
 package us.dot.its.jpo.ode.api.services;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,8 @@ import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.UserRepository;
 import us.dot.its.jpo.ode.api.repositories.UserRepository.UserOrgRoleProjection;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,6 +140,13 @@ public class PermissionService {
 
     // Allow Connection if the users organization controls the specified RSU unit
     public boolean hasRsu(String rsuIP, String role) {
+        InetAddress ipv4Address;
+        try {
+            ipv4Address = InetAddress.getByName(rsuIP);
+        } catch (UnknownHostException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid RSU IP address: " + rsuIP, e);
+        }
+
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (!isAuthValid(auth)) {
             return false;
@@ -149,10 +160,10 @@ public class PermissionService {
 
         String organization = getOrganizationFromHeader();
         if (organization != null) {
-            return rsuRepository.existsByIpAndOrganizations(rsuIP, List.of(organization));
+            return rsuRepository.existsByIpAndOrganizations(ipv4Address, List.of(organization));
         }
 
-        return rsuRepository.existsByIpAndOrganizations(rsuIP, getQualifiedOrgList(username, role));
+        return rsuRepository.existsByIpAndOrganizations(ipv4Address, getQualifiedOrgList(username, role));
     }
 
     // helper method to make sure authentication is valid

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
@@ -135,7 +135,7 @@ public class PermissionService {
     }
 
     // Allow Connection if the users organization controls the specified RSU unit
-    public boolean hasRSU(String rsuIP, String role) {
+    public boolean hasRsu(String rsuIP, String role) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (!isAuthValid(auth)) {
             return false;

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
@@ -20,6 +20,7 @@ import us.dot.its.jpo.ode.api.repositories.UserRepository.UserOrgRoleProjection;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,6 +165,33 @@ public class PermissionService {
         }
 
         return rsuRepository.existsByIpAndOrganizations(ipv4Address, getQualifiedOrgList(username, role));
+    }
+
+    // Allow Connection if the users organization controls the specified RSU unit
+    public boolean hasRsus(List<String> rsuIP, String role) {
+        List<InetAddress> ipv4Addresses = new ArrayList<>();
+        for (String ip : rsuIP) {
+            try {
+                ipv4Addresses.add(InetAddress.getByName(ip));
+            } catch (UnknownHostException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid RSU IP address: " + ip, e);
+            }
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!isAuthValid(auth)) {
+            return false;
+        }
+
+        if (isSuperUser()) {
+            return true;
+        }
+
+        String username = getUsername(auth);
+
+        List<String> authorizedOrgs = getQualifiedOrgList(username, role);
+        List<InetAddress> allowedRsuIps = rsuRepository.findAllowedRsuIpsInOrganizations(authorizedOrgs);
+        return allowedRsuIps.containsAll(ipv4Addresses);
     }
 
     // helper method to make sure authentication is valid

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/PermissionService.java
@@ -53,7 +53,7 @@ public class PermissionService {
         return roles.indexOf(userRole.toUpperCase()) >= roles.indexOf(requiredRole.toUpperCase());
     }
 
-    private List<String> getQualifiedOrgList(String email, String requiredRole) {
+    public List<String> getQualifiedOrgList(String email, String requiredRole) {
         List<UserOrgRoleProjection> organizationRoles = userRepository.findUserOrgRoles(email);
         return getQualifiedOrgList(organizationRoles, requiredRole);
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -66,7 +66,7 @@ public class RsuManagementService {
             Rsu rsu = rsuRepository.findByIpv4Address(InetAddress.getByName(ipv4Address));
             return rsu != null ? rsuMapper.toDto(rsu) : null;
         } catch (UnknownHostException e) {
-            throw new IllegalArgumentException("Invalid IP address: " + ipv4Address, e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + ipv4Address, e);
         }
     }
 
@@ -100,7 +100,7 @@ public class RsuManagementService {
             Rsu existingRsu = rsuRepository.findByIpv4Address(inetAddress);
 
             if (existingRsu == null) {
-                throw new IllegalArgumentException("RSU not found with IP: " + rsuIp);
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found with IP: " + rsuIp);
             }
 
             // 2. Update only non-null fields using MapStruct
@@ -119,7 +119,7 @@ public class RsuManagementService {
             return rsuMapper.toDto(savedRsu);
 
         } catch (UnknownHostException e) {
-            throw new IllegalArgumentException("Invalid IP address: " + rsuIp, e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
         }
     }
 
@@ -134,7 +134,7 @@ public class RsuManagementService {
         if (patch.getSshCredentialGroup() != null) {
             RsuCredential credential = rsuCredentialRepository
                     .findByNickname(patch.getSshCredentialGroup())
-                    .orElseThrow(() -> new IllegalArgumentException(
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                             "SSH credential not found: " + patch.getSshCredentialGroup()));
             rsu.setCredential(credential);
         }
@@ -143,7 +143,7 @@ public class RsuManagementService {
         if (patch.getSnmpCredentialGroup() != null) {
             SnmpCredential snmpCredential = snmpCredentialRepository
                     .findByNickname(patch.getSnmpCredentialGroup())
-                    .orElseThrow(() -> new IllegalArgumentException(
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                             "SNMP credential not found: " + patch.getSnmpCredentialGroup()));
             rsu.setSnmpCredential(snmpCredential);
         }
@@ -152,7 +152,7 @@ public class RsuManagementService {
         if (patch.getSnmpVersionGroup() != null) {
             SnmpProtocol snmpProtocol = snmpProtocolRepository
                     .findByNickname(patch.getSnmpVersionGroup())
-                    .orElseThrow(() -> new IllegalArgumentException(
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                             "SNMP protocol not found: " + patch.getSnmpVersionGroup()));
             rsu.setSnmpProtocol(snmpProtocol);
         }
@@ -168,7 +168,7 @@ public class RsuManagementService {
 
                 if (!exists) {
                     Organization org = organizationRepository.findByName(orgName)
-                            .orElseThrow(() -> new IllegalArgumentException(
+                            .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                                     "Organization not found: " + orgName));
 
                     RsuOrganization rsuOrg = new RsuOrganization();
@@ -190,7 +190,7 @@ public class RsuManagementService {
         // Parse "Manufacturer Model" format
         String[] parts = modelStr.trim().split("\\s+", 2);
         if (parts.length != 2) {
-            throw new IllegalArgumentException(
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "Invalid model format. Expected 'Manufacturer Model', got: " + modelStr);
         }
 
@@ -198,7 +198,7 @@ public class RsuManagementService {
         String modelName = parts[1];
 
         return rsuModelRepository.findByNameAndManufacturerName(modelName, manufacturerName)
-                .orElseThrow(() -> new IllegalArgumentException("Model not found: " + modelStr));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Model not found: " + modelStr));
     }
 
     @Transactional
@@ -225,7 +225,7 @@ public class RsuManagementService {
             // Finally, delete the RSU itself
             rsuRepository.removeRsuByIpv4Address(inetAddress);
         } catch (UnknownHostException e) {
-            throw new IllegalArgumentException("Invalid IP address: " + ipv4Address, e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + ipv4Address, e);
         }
     }
 
@@ -235,7 +235,7 @@ public class RsuManagementService {
             try {
                 return InetAddress.getByName(ip);
             } catch (UnknownHostException e) {
-                throw new IllegalArgumentException("Invalid IP address: " + ip, e);
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + ip, e);
             }
         }).toList();
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -47,6 +47,7 @@ public class RsuManagementService {
     private final ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
     private final MaxRetryLimitReachedInstanceRepository maxRetryLimitReachedInstanceRepository;
     private final OrganizationRepository organizationRepository;
+    private final PermissionService permissionService;
     private final PingRepository pingRepository;
     private final RsuCredentialRepository rsuCredentialRepository;
     private final RsuIntersectionRepository rsuIntersectionRepository;
@@ -93,8 +94,10 @@ public class RsuManagementService {
     }
 
     @Transactional
-    public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch) {
+    public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch, String username) {
         try {
+            List<String> authorizedOrgs = permissionService.getQualifiedOrgList(username, "ADMIN");
+
             // 1. Find existing RSU by original IP
             InetAddress inetAddress = InetAddress.getByName(rsuIp);
             Rsu existingRsu = rsuRepository.findByIpv4Address(inetAddress);
@@ -110,7 +113,7 @@ public class RsuManagementService {
             updateRelationships(existingRsu, rsuPatch);
 
             // 4. Handle organization additions/removals
-            handleOrganizationChanges(existingRsu, rsuPatch);
+            handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);
 
             // 5. Save updated entity (JPA handles UPDATE SQL)
             Rsu savedRsu = rsuRepository.save(existingRsu);
@@ -158,13 +161,23 @@ public class RsuManagementService {
         }
     }
 
-    private void handleOrganizationChanges(Rsu rsu, RsuPatch patch) {
+    private void handleOrganizationChanges(Rsu rsu, RsuPatch patch, List<String> authorizedOrgs) {
+
         // Add organizations
         if (patch.getOrganizationsToAdd() != null && !patch.getOrganizationsToAdd().isEmpty()) {
+            List<String> unqualifiedAdds = patch.getOrganizationsToAdd().stream()
+                    .filter(org -> !authorizedOrgs.contains(org))
+                    .toList();
+            if (!unqualifiedAdds.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "User does not have permission to add RSU to organization(s): "
+                                + String.join(", ", unqualifiedAdds));
+            }
             for (String orgName : patch.getOrganizationsToAdd()) {
                 // Check if already associated
-                boolean exists = rsu.getRsuOrganizations().stream()
-                        .anyMatch(ro -> ro.getOrganization().getName().equals(orgName));
+                boolean exists = rsuRepository.existsByIpAndOrganizations(
+                        rsu.getIpv4Address(),
+                        List.of(orgName));
 
                 if (!exists) {
                     Organization org = organizationRepository.findByName(orgName)
@@ -174,15 +187,29 @@ public class RsuManagementService {
                     RsuOrganization rsuOrg = new RsuOrganization();
                     rsuOrg.setRsu(rsu);
                     rsuOrg.setOrganization(org);
-                    rsu.getRsuOrganizations().add(rsuOrg);
+
+                    // Save to repository
+                    rsuOrganizationRepository.save(rsuOrg);
                 }
             }
         }
 
         // Remove organizations
         if (patch.getOrganizationsToRemove() != null && !patch.getOrganizationsToRemove().isEmpty()) {
-            rsu.getRsuOrganizations()
-                    .removeIf(ro -> patch.getOrganizationsToRemove().contains(ro.getOrganization().getName()));
+            List<String> unqualifiedRemoves = patch.getOrganizationsToRemove().stream()
+                    .filter(org -> !authorizedOrgs.contains(org))
+                    .toList();
+            if (!unqualifiedRemoves.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "User does not have permission to remove RSU from organization(s): "
+                                + String.join(", ", unqualifiedRemoves));
+            }
+            for (String orgName : patch.getOrganizationsToRemove()) {
+                // Find and delete the specific association
+                rsuOrganizationRepository.findByRsuIpv4AddressAndOrganization_Name(
+                        rsu.getIpv4Address(),
+                        orgName).ifPresent(rsuOrganizationRepository::delete);
+            }
         }
     }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -251,6 +251,8 @@ public class RsuManagementService {
                     .toList();
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "RSU(s) not found with IP(s): " + String.join(", ", missingIps));
+        } else if (existingRsus.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No valid RSU IP addresses provided");
         }
 
         pingRepository.removeMultiplePingsByIpv4Address(inetAddresses);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -6,8 +6,10 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +45,7 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 public class RsuManagementService {
 
     private final ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
+    private final MaxRetryLimitReachedInstanceRepository maxRetryLimitReachedInstanceRepository;
     private final OrganizationRepository organizationRepository;
     private final PingRepository pingRepository;
     private final RsuCredentialRepository rsuCredentialRepository;
@@ -50,7 +53,6 @@ public class RsuManagementService {
     private final RsuOrganizationRepository rsuOrganizationRepository;
     private final RsuModelRepository rsuModelRepository;
     private final RsuRepository rsuRepository;
-    private final MaxRetryLimitReachedInstanceRepository maxRetryLimitReachedInstanceRepository;
     private final ScmsHealthRepository scmsHealthRepository;
     private final SnmpCredentialRepository snmpCredentialRepository;
     private final SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
@@ -204,6 +206,12 @@ public class RsuManagementService {
         try {
             InetAddress inetAddress = InetAddress.getByName(ipv4Address);
 
+            // Check if RSU exists
+            Rsu rsu = rsuRepository.findByIpv4Address(inetAddress);
+            if (rsu == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found with IP: " + ipv4Address);
+            }
+
             // Delete related entities first to maintain referential integrity
             pingRepository.removePingByIpv4Address(inetAddress);
             rsuOrganizationRepository.removeRsuOrganizationByIpv4Address(inetAddress);
@@ -230,6 +238,21 @@ public class RsuManagementService {
                 throw new IllegalArgumentException("Invalid IP address: " + ip, e);
             }
         }).toList();
+
+        // Check if all RSUs exist
+        List<Rsu> existingRsus = rsuRepository.findByIpv4AddressIn(inetAddresses);
+        if (existingRsus.size() != inetAddresses.size()) {
+            // Find which IPs don't exist
+            List<String> existingIps = existingRsus.stream()
+                    .map(rsu -> rsu.getIpv4Address().getHostAddress())
+                    .toList();
+            List<String> missingIps = rsuIps.stream()
+                    .filter(ip -> !existingIps.contains(ip))
+                    .toList();
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "RSU(s) not found with IP(s): " + String.join(", ", missingIps));
+        }
+
         pingRepository.removeMultiplePingsByIpv4Address(inetAddresses);
         rsuOrganizationRepository.removeMultipleRsuOrganizationsByIpv4Address(inetAddresses);
         scmsHealthRepository.removeMultipleScmsHealthByIpv4Address(inetAddresses);
@@ -239,7 +262,7 @@ public class RsuManagementService {
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(inetAddresses);
         maxRetryLimitReachedInstanceRepository
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(inetAddresses);
-        rsuRepository.deleteByIpv4AddressIn(inetAddresses);
+        rsuRepository.removeByIpv4AddressIn(inetAddresses);
 
     }
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -1,0 +1,224 @@
+package us.dot.its.jpo.ode.api.services;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+
+import us.dot.its.jpo.ode.api.mappers.RsuInfoMapper;
+import us.dot.its.jpo.ode.api.mappers.RsuPatchMapper;
+import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelections;
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.repositories.OrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.PingRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpMsgfwdConfigRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpProtocolRepository;
+import us.dot.its.jpo.ode.api.repositories.UserRepository;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
+
+@Service
+@RequiredArgsConstructor
+public class RsuManagementService {
+
+    private final OrganizationRepository organizationRepository;
+    private final PingRepository pingRepository;
+    private final RsuCredentialRepository rsuCredentialRepository;
+    private final RsuOrganizationRepository rsuOrganizationRepository;
+    private final RsuModelRepository rsuModelRepository;
+    private final RsuRepository rsuRepository;
+    private final ScmsHealthRepository scmsHealthRepository;
+    private final SnmpCredentialRepository snmpCredentialRepository;
+    private final SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
+    private final SnmpProtocolRepository snmpProtocolRepository;
+    private final UserRepository userRepository;
+    private final RsuInfoMapper rsuMapper;
+    private final RsuPatchMapper rsuPatchMapper;
+
+    public RsuInfoDto getRsuInfo(String ipv4Address) {
+        try {
+            Rsu rsu = rsuRepository.findByIpv4Address(InetAddress.getByName(ipv4Address));
+            return rsu != null ? rsuMapper.toDto(rsu) : null;
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP address: " + ipv4Address, e);
+        }
+    }
+
+    public Page<RsuInfoDto> getAllRsuInfo(String orgName, Pageable pageable) {
+        Page<Rsu> rsus = rsuRepository.findAllByOrganization(orgName, pageable);
+        return rsus.map(rsuMapper::toDto);
+    }
+
+    public ModifyRsuAllowedSelections getAllowedSelections(String username) {
+        ModifyRsuAllowedSelections allowed = new ModifyRsuAllowedSelections();
+
+        allowed.setPrimaryRoutes(rsuRepository.findAllPrimaryRoutes());
+        allowed.setRsuModels(rsuRepository.findAllRsuModels().stream()
+                .map(v -> String.format("%s %s", v.getManufacturer(),
+                        v.getModel()))
+                .toList());
+        allowed.setSshCredentialGroups(rsuCredentialRepository.findAllNicknames());
+        allowed.setSnmpCredentialGroups(snmpCredentialRepository.findAllNicknames());
+        allowed.setSnmpVersionGroups(snmpProtocolRepository.findAllNicknames());
+        allowed.setOrganizations(userRepository.findUserOrgRoles(username).stream()
+                .map(role -> role.getOrganizationName()).toList());
+
+        return allowed;
+    }
+
+    public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch) {
+        try {
+            // 1. Find existing RSU by original IP
+            InetAddress inetAddress = InetAddress.getByName(rsuIp);
+            Rsu existingRsu = rsuRepository.findByIpv4Address(inetAddress);
+
+            if (existingRsu == null) {
+                throw new IllegalArgumentException("RSU not found with IP: " + rsuIp);
+            }
+
+            // 2. Update only non-null fields using MapStruct
+            rsuPatchMapper.updateRsuFromPatch(rsuPatch, existingRsu);
+
+            // 3. Update relationships that require database lookups
+            updateRelationships(existingRsu, rsuPatch);
+
+            // 4. Handle organization additions/removals
+            handleOrganizationChanges(existingRsu, rsuPatch);
+
+            // 5. Save updated entity (JPA handles UPDATE SQL)
+            Rsu savedRsu = rsuRepository.save(existingRsu);
+
+            // 6. Return DTO
+            return rsuMapper.toDto(savedRsu);
+
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP address: " + rsuIp, e);
+        }
+    }
+
+    private void updateRelationships(Rsu rsu, RsuPatch patch) {
+        // Update model if provided
+        if (patch.getModel() != null) {
+            RsuModel model = findRsuModelByName(patch.getModel());
+            rsu.setModel(model);
+        }
+
+        // Update SSH credential if provided
+        if (patch.getSshCredentialGroup() != null) {
+            RsuCredential credential = rsuCredentialRepository
+                    .findByNickname(patch.getSshCredentialGroup())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "SSH credential not found: " + patch.getSshCredentialGroup()));
+            rsu.setCredential(credential);
+        }
+
+        // Update SNMP credential if provided
+        if (patch.getSnmpCredentialGroup() != null) {
+            SnmpCredential snmpCredential = snmpCredentialRepository
+                    .findByNickname(patch.getSnmpCredentialGroup())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "SNMP credential not found: " + patch.getSnmpCredentialGroup()));
+            rsu.setSnmpCredential(snmpCredential);
+        }
+
+        // Update SNMP protocol if provided
+        if (patch.getSnmpVersionGroup() != null) {
+            SnmpProtocol snmpProtocol = snmpProtocolRepository
+                    .findByNickname(patch.getSnmpVersionGroup())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "SNMP protocol not found: " + patch.getSnmpVersionGroup()));
+            rsu.setSnmpProtocol(snmpProtocol);
+        }
+    }
+
+    private void handleOrganizationChanges(Rsu rsu, RsuPatch patch) {
+        // Add organizations
+        if (patch.getOrganizationsToAdd() != null && !patch.getOrganizationsToAdd().isEmpty()) {
+            for (String orgName : patch.getOrganizationsToAdd()) {
+                // Check if already associated
+                boolean exists = rsu.getRsuOrganizations().stream()
+                        .anyMatch(ro -> ro.getOrganization().getName().equals(orgName));
+
+                if (!exists) {
+                    Organization org = organizationRepository.findByName(orgName)
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "Organization not found: " + orgName));
+
+                    RsuOrganization rsuOrg = new RsuOrganization();
+                    rsuOrg.setRsu(rsu);
+                    rsuOrg.setOrganization(org);
+                    rsu.getRsuOrganizations().add(rsuOrg);
+                }
+            }
+        }
+
+        // Remove organizations
+        if (patch.getOrganizationsToRemove() != null && !patch.getOrganizationsToRemove().isEmpty()) {
+            rsu.getRsuOrganizations()
+                    .removeIf(ro -> patch.getOrganizationsToRemove().contains(ro.getOrganization().getName()));
+        }
+    }
+
+    private RsuModel findRsuModelByName(String modelStr) {
+        // Parse "Manufacturer Model" format
+        String[] parts = modelStr.trim().split("\\s+", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(
+                    "Invalid model format. Expected 'Manufacturer Model', got: " + modelStr);
+        }
+
+        String manufacturerName = parts[0];
+        String modelName = parts[1];
+
+        return rsuModelRepository.findByNameAndManufacturerName(modelName, manufacturerName)
+                .orElseThrow(() -> new IllegalArgumentException("Model not found: " + modelStr));
+    }
+
+    public void deleteRsuByIpv4Address(String ipv4Address) {
+        try {
+            InetAddress inetAddress = InetAddress.getByName(ipv4Address);
+
+            // Delete related entities first to maintain referential integrity
+            pingRepository.removePingByIpv4Address(inetAddress);
+            rsuOrganizationRepository.removeRsuOrganizationByIpv4Address(inetAddress);
+            scmsHealthRepository.removeScmsHealthByIpv4Address(inetAddress);
+            snmpMsgfwdConfigRepository.removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
+
+            // Finally, delete the RSU itself
+            rsuRepository.removeRsuByIpv4Address(inetAddress);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP address: " + ipv4Address, e);
+        }
+    }
+
+    public void deleteMultipleRsusByIpv4Address(List<String> rsuIps) {
+        List<InetAddress> inetAddresses = rsuIps.stream().map(ip -> {
+            try {
+                return InetAddress.getByName(ip);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid IP address: " + ip, e);
+            }
+        }).toList();
+        pingRepository.removeMultiplePingsByIpv4Address(inetAddresses);
+        rsuOrganizationRepository.removeMultipleRsuOrganizationsByIpv4Address(inetAddresses);
+        scmsHealthRepository.removeMultipleScmsHealthByIpv4Address(inetAddresses);
+        snmpMsgfwdConfigRepository.removeMultipleSnmpMsgfwdConfigByIpv4Address(inetAddresses);
+        rsuRepository.deleteByIpv4AddressIn(inetAddresses);
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import lombok.RequiredArgsConstructor;
 
 import us.dot.its.jpo.ode.api.mappers.RsuInfoMapper;
@@ -14,9 +16,12 @@ import us.dot.its.jpo.ode.api.mappers.RsuPatchMapper;
 import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelections;
 import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
 import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.repositories.ConsecutiveFirmwareUpgradeFailureRepository;
+import us.dot.its.jpo.ode.api.repositories.MaxRetryLimitReachedInstanceRepository;
 import us.dot.its.jpo.ode.api.repositories.OrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.PingRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
@@ -37,12 +42,15 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 @RequiredArgsConstructor
 public class RsuManagementService {
 
+    private final ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
     private final OrganizationRepository organizationRepository;
     private final PingRepository pingRepository;
     private final RsuCredentialRepository rsuCredentialRepository;
+    private final RsuIntersectionRepository rsuIntersectionRepository;
     private final RsuOrganizationRepository rsuOrganizationRepository;
     private final RsuModelRepository rsuModelRepository;
     private final RsuRepository rsuRepository;
+    private final MaxRetryLimitReachedInstanceRepository maxRetryLimitReachedInstanceRepository;
     private final ScmsHealthRepository scmsHealthRepository;
     private final SnmpCredentialRepository snmpCredentialRepository;
     private final SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
@@ -82,6 +90,7 @@ public class RsuManagementService {
         return allowed;
     }
 
+    @Transactional
     public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch) {
         try {
             // 1. Find existing RSU by original IP
@@ -190,6 +199,7 @@ public class RsuManagementService {
                 .orElseThrow(() -> new IllegalArgumentException("Model not found: " + modelStr));
     }
 
+    @Transactional
     public void deleteRsuByIpv4Address(String ipv4Address) {
         try {
             InetAddress inetAddress = InetAddress.getByName(ipv4Address);
@@ -199,6 +209,10 @@ public class RsuManagementService {
             rsuOrganizationRepository.removeRsuOrganizationByIpv4Address(inetAddress);
             scmsHealthRepository.removeScmsHealthByIpv4Address(inetAddress);
             snmpMsgfwdConfigRepository.removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
+            rsuIntersectionRepository.removeRsuIntersectionByIpv4Address(inetAddress);
+            consecutiveFirmwareUpgradeFailureRepository
+                    .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
+            maxRetryLimitReachedInstanceRepository.removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
 
             // Finally, delete the RSU itself
             rsuRepository.removeRsuByIpv4Address(inetAddress);
@@ -207,6 +221,7 @@ public class RsuManagementService {
         }
     }
 
+    @Transactional
     public void deleteMultipleRsusByIpv4Address(List<String> rsuIps) {
         List<InetAddress> inetAddresses = rsuIps.stream().map(ip -> {
             try {
@@ -219,6 +234,12 @@ public class RsuManagementService {
         rsuOrganizationRepository.removeMultipleRsuOrganizationsByIpv4Address(inetAddresses);
         scmsHealthRepository.removeMultipleScmsHealthByIpv4Address(inetAddresses);
         snmpMsgfwdConfigRepository.removeMultipleSnmpMsgfwdConfigByIpv4Address(inetAddresses);
+        rsuIntersectionRepository.removeMultipleRsuIntersectionsByIpv4Address(inetAddresses);
+        consecutiveFirmwareUpgradeFailureRepository
+                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(inetAddresses);
+        maxRetryLimitReachedInstanceRepository
+                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(inetAddresses);
         rsuRepository.deleteByIpv4AddressIn(inetAddresses);
+
     }
 }

--- a/services/intersection-api/api/src/main/resources/application.yaml
+++ b/services/intersection-api/api/src/main/resources/application.yaml
@@ -5,6 +5,8 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+  error:
+    include-stacktrace: never
 
 ### keycloak configuration
 keycloak:

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
@@ -191,11 +191,11 @@ class RsuControllerTest {
         String invalidRsuIp = "invalid-ip";
 
         when(rsuManagementService.getRsuInfo(invalidRsuIp))
-                .thenThrow(new IllegalArgumentException("Invalid IP address: " + invalidRsuIp));
+                .thenThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + invalidRsuIp));
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.getSingleRsuData(invalidRsuIp));
+                ResponseStatusException.class,
+                        () -> rsuController.getSingleRsuData(invalidRsuIp));
 
         verify(rsuManagementService).getRsuInfo(invalidRsuIp);
     }
@@ -203,7 +203,7 @@ class RsuControllerTest {
     // ==================== GET ALLOWED SELECTIONS TESTS ====================
 
     @Test
-    void testGetSingleRsuAllowedSelections_Success() {
+    void testGetAllowedSelections_Success() {
         String username = "testuser@example.com";
 
         ModifyRsuAllowedSelections allowedSelections = new ModifyRsuAllowedSelections(
@@ -219,7 +219,7 @@ class RsuControllerTest {
         try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
             mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
 
-            ModifyRsuAllowedSelections result = rsuController.getSingleRsuAllowedSelections();
+            ModifyRsuAllowedSelections result = rsuController.getAllowedSelections();
 
             assertNotNull(result);
 
@@ -258,12 +258,12 @@ class RsuControllerTest {
         String rsuIp = "192.168.1.999";
         RsuPatch patch = new RsuPatch();
 
-        doThrow(new IllegalArgumentException("RSU not found"))
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found"))
                 .when(rsuManagementService).modifyRsu(rsuIp, patch);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.modifyRsu(rsuIp, patch));
+                ResponseStatusException.class,
+                        () -> rsuController.modifyRsu(rsuIp, patch));
 
         verify(rsuManagementService).modifyRsu(rsuIp, patch);
     }
@@ -274,12 +274,12 @@ class RsuControllerTest {
         RsuPatch invalidPatch = new RsuPatch();
         invalidPatch.setIpv4Address("invalid-ip");
 
-        doThrow(new IllegalArgumentException("Invalid IP address"))
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address"))
                 .when(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.modifyRsu(rsuIp, invalidPatch));
+                ResponseStatusException.class,
+                        () -> rsuController.modifyRsu(rsuIp, invalidPatch));
 
         verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
     }
@@ -320,12 +320,12 @@ class RsuControllerTest {
     void testDeleteRsu_RsuNotFound() {
         String rsuIp = "192.168.1.999";
 
-        doThrow(new IllegalArgumentException("RSU not found"))
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found"))
                 .when(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.deleteRsu(rsuIp));
+                ResponseStatusException.class,
+                        () -> rsuController.deleteRsu(rsuIp));
 
         verify(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
     }
@@ -334,12 +334,12 @@ class RsuControllerTest {
     void testDeleteRsu_InvalidIpAddress() {
         String invalidRsuIp = "invalid-ip";
 
-        doThrow(new IllegalArgumentException("Invalid IP address: " + invalidRsuIp))
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + invalidRsuIp))
                 .when(rsuManagementService).deleteRsuByIpv4Address(invalidRsuIp);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.deleteRsu(invalidRsuIp));
+                ResponseStatusException.class,
+                        () -> rsuController.deleteRsu(invalidRsuIp));
 
         verify(rsuManagementService).deleteRsuByIpv4Address(invalidRsuIp);
     }
@@ -407,12 +407,12 @@ class RsuControllerTest {
     void testDeleteRsus_SomeNotFound() {
         List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.999", "192.168.1.101");
 
-        doThrow(new IllegalArgumentException("Some RSUs not found"))
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Some RSUs not found"))
                 .when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.deleteRsus(rsuIps));
+                ResponseStatusException.class,
+                        () -> rsuController.deleteRsus(rsuIps));
 
         verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
     }
@@ -421,12 +421,12 @@ class RsuControllerTest {
     void testDeleteRsus_InvalidIpInList() {
         List<String> rsuIps = Arrays.asList("192.168.1.100", "invalid-ip", "192.168.1.101");
 
-        doThrow(new IllegalArgumentException("Invalid IP address: invalid-ip"))
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: invalid-ip"))
                 .when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> rsuController.deleteRsus(rsuIps));
+                ResponseStatusException.class,
+                        () -> rsuController.deleteRsus(rsuIps));
 
         verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
     }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
@@ -37,6 +37,9 @@ class RsuControllerTest {
     private RsuManagementService rsuManagementService;
 
     @Mock
+    private PermissionService permissionService;
+
+    @Mock
     private SecurityContext securityContext;
 
     @InjectMocks
@@ -241,63 +244,79 @@ class RsuControllerTest {
         String rsuIp = "192.168.1.100";
         RsuPatch patch = new RsuPatch();
         patch.setIpv4Address("192.168.1.101");
+        String username = "testuser@example.com";
 
-        doReturn(null).when(rsuManagementService).modifyRsu(rsuIp, patch);
+        doReturn(null).when(rsuManagementService).modifyRsu(rsuIp, patch, username);
 
-        ResponseEntity<Void> result = rsuController.modifyRsu(rsuIp, patch);
+        try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
+            mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
+            ResponseEntity<Void> result = rsuController.modifyRsu(rsuIp, patch);
 
-        assertNotNull(result);
-        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
-        assertNull(result.getBody());
+            assertNotNull(result);
+            assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+            assertNull(result.getBody());
 
-        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+            verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+        }
     }
 
     @Test
     void testModifyRsu_RsuNotFound() {
         String rsuIp = "192.168.1.999";
         RsuPatch patch = new RsuPatch();
+        String username = "testuser@example.com";
 
         doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found"))
-                .when(rsuManagementService).modifyRsu(rsuIp, patch);
+                .when(rsuManagementService).modifyRsu(rsuIp, patch, username);
 
+        try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
+            mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
         assertThrows(
                 ResponseStatusException.class,
                         () -> rsuController.modifyRsu(rsuIp, patch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+        verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
     }
+}
 
     @Test
     void testModifyRsu_InvalidPatch() {
         String rsuIp = "192.168.1.100";
         RsuPatch invalidPatch = new RsuPatch();
         invalidPatch.setIpv4Address("invalid-ip");
+        String username = "testuser@example.com";
 
         doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address"))
-                .when(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
+                .when(rsuManagementService).modifyRsu(rsuIp, invalidPatch, username);
 
+        try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
+            mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
         assertThrows(
                 ResponseStatusException.class,
                         () -> rsuController.modifyRsu(rsuIp, invalidPatch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
+        verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch, username);
     }
+}
 
     @Test
     void testModifyRsu_ServiceException() {
         String rsuIp = "192.168.1.100";
         RsuPatch patch = new RsuPatch();
+        String username = "testuser@example.com";
 
         doThrow(new RuntimeException("Database error"))
-                .when(rsuManagementService).modifyRsu(rsuIp, patch);
+                .when(rsuManagementService).modifyRsu(rsuIp, patch, username);
 
+        try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
+            mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
         assertThrows(
                 RuntimeException.class,
                 () -> rsuController.modifyRsu(rsuIp, patch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+        verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
     }
+}
 
     // ==================== DELETE SINGLE RSU TESTS ====================
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
@@ -1,0 +1,463 @@
+package us.dot.its.jpo.ode.api.controllers.devices;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.server.ResponseStatusException;
+
+import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelections;
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.services.PermissionService;
+import us.dot.its.jpo.ode.api.services.RsuManagementService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RsuControllerTest {
+
+    @Mock
+    private RsuManagementService rsuManagementService;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @InjectMocks
+    private RsuController rsuController;
+
+    // ==================== GET ALL RSUS TESTS ====================
+
+    @Test
+    void testGetAllRsus_Success() {
+        String organization = "TestOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+
+        RsuInfoDto rsu1 = new RsuInfoDto(
+                "192.168.1.100",
+                new SimplePosition(39.7392, -105.0844),
+                123.4,
+                "I-25",
+                "RSU1",
+                "SCMS1",
+                "Commsignia ITS-RS4-M",
+                "ssh-group-1",
+                "snmp-group-1",
+                "v3",
+                Arrays.asList("TestOrg"));
+
+        RsuInfoDto rsu2 = new RsuInfoDto(
+                "192.168.1.101",
+                new SimplePosition(39.7400, -105.0850),
+                124.5,
+                "I-70",
+                "RSU2",
+                "SCMS2",
+                "Yunex RSU-2X",
+                "ssh-group-2",
+                "snmp-group-2",
+                "v2c",
+                Arrays.asList("TestOrg"));
+
+        List<RsuInfoDto> rsuList = Arrays.asList(rsu1, rsu2);
+        Page<RsuInfoDto> rsuPage = new PageImpl<>(rsuList, pageable, 2);
+
+        when(rsuManagementService.getAllRsuInfo(organization, pageable)).thenReturn(rsuPage);
+
+        Page<RsuInfoDto> result = rsuController.getAllRsus(organization, pageable);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.getContent().size());
+        assertEquals("192.168.1.100", result.getContent().get(0).getIpv4Address());
+        assertEquals("192.168.1.101", result.getContent().get(1).getIpv4Address());
+
+        verify(rsuManagementService).getAllRsuInfo(organization, pageable);
+    }
+
+    @Test
+    void testGetAllRsus_EmptyResult() {
+        String organization = "EmptyOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+        Page<RsuInfoDto> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(rsuManagementService.getAllRsuInfo(organization, pageable)).thenReturn(emptyPage);
+
+        Page<RsuInfoDto> result = rsuController.getAllRsus(organization, pageable);
+
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+
+        verify(rsuManagementService).getAllRsuInfo(organization, pageable);
+    }
+
+    @Test
+    void testGetAllRsus_WithCustomPageSize() {
+        String organization = "TestOrg";
+        Pageable pageable = PageRequest.of(0, 50);
+
+        RsuInfoDto rsu1 = new RsuInfoDto(
+                "192.168.1.100",
+                new SimplePosition(39.7392, -105.0844),
+                123.4,
+                "I-25",
+                "RSU1",
+                "SCMS1",
+                "Model X",
+                "ssh-group",
+                "snmp-group",
+                "v3",
+                Arrays.asList("TestOrg"));
+
+        Page<RsuInfoDto> rsuPage = new PageImpl<>(List.of(rsu1), pageable, 1);
+
+        when(rsuManagementService.getAllRsuInfo(organization, pageable)).thenReturn(rsuPage);
+
+        Page<RsuInfoDto> result = rsuController.getAllRsus(organization, pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(50, result.getPageable().getPageSize());
+
+        verify(rsuManagementService).getAllRsuInfo(organization, pageable);
+    }
+
+    // ==================== GET SINGLE RSU TESTS ====================
+
+    @Test
+    void testGetSingleRsuData_Success() {
+        String rsuIp = "192.168.1.100";
+
+        RsuInfoDto rsuInfo = new RsuInfoDto(
+                rsuIp,
+                new SimplePosition(39.7392, -105.0844),
+                123.4,
+                "I-25",
+                "RSU123",
+                "SCMS123",
+                "Commsignia ITS-RS4-M",
+                "ssh-group-1",
+                "snmp-group-1",
+                "v3",
+                Arrays.asList("TestOrg"));
+
+        when(rsuManagementService.getRsuInfo(rsuIp)).thenReturn(rsuInfo);
+
+        RsuInfoDto result = rsuController.getSingleRsuData(rsuIp);
+
+        assertNotNull(result);
+
+        assertEquals(rsuIp, result.getIpv4Address());
+        assertEquals("I-25", result.getPrimaryRoute());
+
+        verify(rsuManagementService).getRsuInfo(rsuIp);
+    }
+
+    @Test
+    void testGetSingleRsuData_RsuNotFound() {
+        String rsuIp = "192.168.1.999";
+
+        when(rsuManagementService.getRsuInfo(rsuIp)).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> rsuController.getSingleRsuData(rsuIp));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("RSU not found", exception.getReason());
+
+        verify(rsuManagementService).getRsuInfo(rsuIp);
+    }
+
+    @Test
+    void testGetSingleRsuData_InvalidIpAddress() {
+        String invalidRsuIp = "invalid-ip";
+
+        when(rsuManagementService.getRsuInfo(invalidRsuIp))
+                .thenThrow(new IllegalArgumentException("Invalid IP address: " + invalidRsuIp));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.getSingleRsuData(invalidRsuIp));
+
+        verify(rsuManagementService).getRsuInfo(invalidRsuIp);
+    }
+
+    // ==================== GET ALLOWED SELECTIONS TESTS ====================
+
+    @Test
+    void testGetSingleRsuAllowedSelections_Success() {
+        String username = "testuser@example.com";
+
+        ModifyRsuAllowedSelections allowedSelections = new ModifyRsuAllowedSelections(
+                Arrays.asList("I-25", "I-70"),
+                Arrays.asList("Commsignia ITS-RS4-M", "Yunex RSU-2X"),
+                Arrays.asList("ssh-group-1", "ssh-group-2"),
+                Arrays.asList("snmp-group-1", "snmp-group-2"),
+                Arrays.asList("v2c", "v3"),
+                Arrays.asList("TestOrg", "OtherOrg"));
+
+        when(rsuManagementService.getAllowedSelections(username)).thenReturn(allowedSelections);
+
+        try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
+            mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
+
+            ModifyRsuAllowedSelections result = rsuController.getSingleRsuAllowedSelections();
+
+            assertNotNull(result);
+
+            assertEquals(2, result.getPrimaryRoutes().size());
+            assertEquals(2, result.getRsuModels().size());
+            assertEquals(2, result.getSshCredentialGroups().size());
+            assertEquals(2, result.getSnmpCredentialGroups().size());
+            assertEquals(2, result.getSnmpVersionGroups().size());
+            assertEquals(2, result.getOrganizations().size());
+
+            verify(rsuManagementService).getAllowedSelections(username);
+        }
+    }
+
+    // ==================== MODIFY RSU TESTS ====================
+
+    @Test
+    void testModifyRsu_Success() {
+        String rsuIp = "192.168.1.100";
+        RsuPatch patch = new RsuPatch();
+        patch.setIpv4Address("192.168.1.101");
+
+        doReturn(null).when(rsuManagementService).modifyRsu(rsuIp, patch);
+
+        ResponseEntity<Void> result = rsuController.modifyRsu(rsuIp, patch);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        assertNull(result.getBody());
+
+        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+    }
+
+    @Test
+    void testModifyRsu_RsuNotFound() {
+        String rsuIp = "192.168.1.999";
+        RsuPatch patch = new RsuPatch();
+
+        doThrow(new IllegalArgumentException("RSU not found"))
+                .when(rsuManagementService).modifyRsu(rsuIp, patch);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.modifyRsu(rsuIp, patch));
+
+        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+    }
+
+    @Test
+    void testModifyRsu_InvalidPatch() {
+        String rsuIp = "192.168.1.100";
+        RsuPatch invalidPatch = new RsuPatch();
+        invalidPatch.setIpv4Address("invalid-ip");
+
+        doThrow(new IllegalArgumentException("Invalid IP address"))
+                .when(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.modifyRsu(rsuIp, invalidPatch));
+
+        verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch);
+    }
+
+    @Test
+    void testModifyRsu_ServiceException() {
+        String rsuIp = "192.168.1.100";
+        RsuPatch patch = new RsuPatch();
+
+        doThrow(new RuntimeException("Database error"))
+                .when(rsuManagementService).modifyRsu(rsuIp, patch);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> rsuController.modifyRsu(rsuIp, patch));
+
+        verify(rsuManagementService).modifyRsu(rsuIp, patch);
+    }
+
+    // ==================== DELETE SINGLE RSU TESTS ====================
+
+    @Test
+    void testDeleteRsu_Success() {
+        String rsuIp = "192.168.1.100";
+
+        doNothing().when(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+
+        ResponseEntity<Void> result = rsuController.deleteRsu(rsuIp);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        assertNull(result.getBody());
+
+        verify(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+    }
+
+    @Test
+    void testDeleteRsu_RsuNotFound() {
+        String rsuIp = "192.168.1.999";
+
+        doThrow(new IllegalArgumentException("RSU not found"))
+                .when(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.deleteRsu(rsuIp));
+
+        verify(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+    }
+
+    @Test
+    void testDeleteRsu_InvalidIpAddress() {
+        String invalidRsuIp = "invalid-ip";
+
+        doThrow(new IllegalArgumentException("Invalid IP address: " + invalidRsuIp))
+                .when(rsuManagementService).deleteRsuByIpv4Address(invalidRsuIp);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.deleteRsu(invalidRsuIp));
+
+        verify(rsuManagementService).deleteRsuByIpv4Address(invalidRsuIp);
+    }
+
+    @Test
+    void testDeleteRsu_ServiceException() {
+        String rsuIp = "192.168.1.100";
+
+        doThrow(new RuntimeException("Database connection failed"))
+                .when(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> rsuController.deleteRsu(rsuIp));
+
+        verify(rsuManagementService).deleteRsuByIpv4Address(rsuIp);
+    }
+
+    // ==================== DELETE MULTIPLE RSUS TESTS ====================
+
+    @Test
+    void testDeleteRsus_Success() {
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.101", "192.168.1.102");
+
+        doNothing().when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+
+        ResponseEntity<Void> result = rsuController.deleteRsus(rsuIps);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        assertNull(result.getBody());
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+    }
+
+    @Test
+    void testDeleteRsus_SingleRsu() {
+        List<String> rsuIps = Arrays.asList("192.168.1.100");
+
+        doNothing().when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+
+        ResponseEntity<Void> result = rsuController.deleteRsus(rsuIps);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+    }
+
+    @Test
+    void testDeleteRsus_EmptyList() {
+        List<String> emptyList = Arrays.asList();
+
+        doNothing().when(rsuManagementService).deleteMultipleRsusByIpv4Address(emptyList);
+
+        ResponseEntity<Void> result = rsuController.deleteRsus(emptyList);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(emptyList);
+    }
+
+    @Test
+    void testDeleteRsus_SomeNotFound() {
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.999", "192.168.1.101");
+
+        doThrow(new IllegalArgumentException("Some RSUs not found"))
+                .when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.deleteRsus(rsuIps));
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+    }
+
+    @Test
+    void testDeleteRsus_InvalidIpInList() {
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "invalid-ip", "192.168.1.101");
+
+        doThrow(new IllegalArgumentException("Invalid IP address: invalid-ip"))
+                .when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuController.deleteRsus(rsuIps));
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+    }
+
+    @Test
+    void testDeleteRsus_LargeList() {
+        List<String> largeList = Arrays.asList(
+                "192.168.1.1", "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5",
+                "192.168.1.6", "192.168.1.7", "192.168.1.8", "192.168.1.9", "192.168.1.10");
+
+        doNothing().when(rsuManagementService).deleteMultipleRsusByIpv4Address(largeList);
+
+        ResponseEntity<Void> result = rsuController.deleteRsus(largeList);
+
+        assertNotNull(result);
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(largeList);
+    }
+
+    @Test
+    void testDeleteRsus_ServiceException() {
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.101");
+
+        doThrow(new RuntimeException("Database transaction failed"))
+                .when(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> rsuController.deleteRsus(rsuIps));
+
+        verify(rsuManagementService).deleteMultipleRsusByIpv4Address(rsuIps);
+    }
+}

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
@@ -1,0 +1,350 @@
+package us.dot.its.jpo.ode.api.controllers.organizations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrganizationControllerTest {
+
+    @Mock
+    private RsuRepository rsuRepository;
+
+    @Mock
+    private RsuOrganizationRepository rsuOrganizationRepository;
+
+    @InjectMocks
+    private OrganizationController organizationController;
+
+    // ==================== GET RSU IPS BY ORGANIZATION TESTS ====================
+
+    @Test
+    void testGetRsuIpsByOrganization_Success() throws UnknownHostException {
+        // Arrange
+        String organization = "TestOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+
+        List<InetAddress> mockIpAddresses = Arrays.asList(
+                InetAddress.getByName("192.168.1.100"),
+                InetAddress.getByName("192.168.1.101"),
+                InetAddress.getByName("192.168.1.102"));
+
+        when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
+                .thenReturn(mockIpAddresses);
+
+        // Act
+        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals("192.168.1.100", result.get(0));
+        assertEquals("192.168.1.101", result.get(1));
+        assertEquals("192.168.1.102", result.get(2));
+
+        verify(rsuOrganizationRepository).findAllRsuIpsByOrganizationName(organization);
+    }
+
+    @Test
+    void testGetRsuIpsByOrganization_EmptyResult() {
+        // Arrange
+        String organization = "EmptyOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+
+        when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
+                .thenReturn(Arrays.asList());
+
+        // Act
+        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(rsuOrganizationRepository).findAllRsuIpsByOrganizationName(organization);
+    }
+
+    @Test
+    void testGetRsuIpsByOrganization_SingleRsu() throws UnknownHostException {
+        // Arrange
+        String organization = "SingleRsuOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+
+        List<InetAddress> mockIpAddresses = Arrays.asList(
+                InetAddress.getByName("192.168.1.100"));
+
+        when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
+                .thenReturn(mockIpAddresses);
+
+        // Act
+        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("192.168.1.100", result.get(0));
+
+        verify(rsuOrganizationRepository).findAllRsuIpsByOrganizationName(organization);
+    }
+
+    @Test
+    void testGetRsuIpsByOrganization_MultiplePages() throws UnknownHostException {
+        // Arrange
+        String organization = "LargeOrg";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<InetAddress> mockIpAddresses = Arrays.asList(
+                InetAddress.getByName("192.168.1.1"),
+                InetAddress.getByName("192.168.1.2"),
+                InetAddress.getByName("192.168.1.3"),
+                InetAddress.getByName("192.168.1.4"),
+                InetAddress.getByName("192.168.1.5"));
+
+        when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
+                .thenReturn(mockIpAddresses);
+
+        // Act
+        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(5, result.size());
+
+        verify(rsuOrganizationRepository).findAllRsuIpsByOrganizationName(organization);
+    }
+
+    @Test
+    void testGetRsuIpsByOrganization_IpAddressFormatting() throws UnknownHostException {
+        // Arrange
+        String organization = "TestOrg";
+        Pageable pageable = PageRequest.of(0, 100);
+
+        List<InetAddress> mockIpAddresses = Arrays.asList(
+                InetAddress.getByName("10.0.0.1"),
+                InetAddress.getByName("172.16.0.1"),
+                InetAddress.getByName("192.168.0.1"));
+
+        when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
+                .thenReturn(mockIpAddresses);
+
+        // Act
+        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+
+        // Assert
+        assertEquals("10.0.0.1", result.get(0));
+        assertEquals("172.16.0.1", result.get(1));
+        assertEquals("192.168.0.1", result.get(2));
+    }
+
+    // ==================== GET RSU ORGANIZATION ASSIGNMENTS TESTS
+    // ====================
+
+    @Test
+    void testGetRsuOrganizationAssignments_Success() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        List<String> mockOrganizations = Arrays.asList("Org1", "Org2", "Org3");
+
+        when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                .thenReturn(mockOrganizations);
+
+        // Act
+        List<String> result = organizationController.getRsuOrganizationAssignments(rsuIp);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals("Org1", result.get(0));
+        assertEquals("Org2", result.get(1));
+        assertEquals("Org3", result.get(2));
+
+        verify(rsuRepository).findAllOrganizationNamesByIpv4Address(inetAddress);
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_SingleOrganization() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        List<String> mockOrganizations = Arrays.asList("OnlyOrg");
+
+        when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                .thenReturn(mockOrganizations);
+
+        // Act
+        List<String> result = organizationController.getRsuOrganizationAssignments(rsuIp);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("OnlyOrg", result.get(0));
+
+        verify(rsuRepository).findAllOrganizationNamesByIpv4Address(inetAddress);
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_NoOrganizations() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                .thenReturn(Arrays.asList());
+
+        // Act
+        List<String> result = organizationController.getRsuOrganizationAssignments(rsuIp);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(rsuRepository).findAllOrganizationNamesByIpv4Address(inetAddress);
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_InvalidIpAddress() {
+        // Arrange
+        String invalidIp = "invalid-ip-address";
+
+        // Act & Assert
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> organizationController.getRsuOrganizationAssignments(invalidIp));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertTrue(exception.getReason().contains("Invalid RSU IP address"));
+        assertTrue(exception.getReason().contains(invalidIp));
+
+        verify(rsuRepository, never()).findAllOrganizationNamesByIpv4Address(any());
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_MalformedIpAddress() {
+        // Arrange
+        String malformedIp = "999.999.999.999";
+
+        // Act & Assert
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> organizationController.getRsuOrganizationAssignments(malformedIp));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertTrue(exception.getReason().contains("Invalid RSU IP address"));
+
+        verify(rsuRepository, never()).findAllOrganizationNamesByIpv4Address(any());
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_EmptyIpAddress() {
+        // Arrange
+        String emptyIp = "";
+
+        // Act & Assert
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> organizationController.getRsuOrganizationAssignments(emptyIp));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+
+        verify(rsuRepository, never()).findAllOrganizationNamesByIpv4Address(any());
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_IpWithHostname() {
+        // Arrange
+        String hostnameIp = "localhost";
+
+        // Act & Assert - This should work as InetAddress.getByName() can resolve
+        // hostnames
+        // But in practice, you might want to validate IP format before calling the
+        // method
+        assertDoesNotThrow(() -> {
+            organizationController.getRsuOrganizationAssignments(hostnameIp);
+        });
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_IPv6Address() throws UnknownHostException {
+        // Arrange
+        String ipv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+        InetAddress inetAddress = InetAddress.getByName(ipv6Address);
+
+        List<String> mockOrganizations = Arrays.asList("Org1");
+
+        when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                .thenReturn(mockOrganizations);
+
+        // Act
+        List<String> result = organizationController.getRsuOrganizationAssignments(ipv6Address);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        verify(rsuRepository).findAllOrganizationNamesByIpv4Address(inetAddress);
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_DifferentIpRanges() throws UnknownHostException {
+        // Arrange
+        String[] testIps = {
+                "10.0.0.1",
+                "172.16.0.1",
+                "192.168.1.1",
+                "8.8.8.8"
+        };
+
+        for (String ip : testIps) {
+            InetAddress inetAddress = InetAddress.getByName(ip);
+            when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                    .thenReturn(Arrays.asList("TestOrg"));
+
+            // Act
+            List<String> result = organizationController.getRsuOrganizationAssignments(ip);
+
+            // Assert
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals("TestOrg", result.get(0));
+        }
+
+        verify(rsuRepository, times(4)).findAllOrganizationNamesByIpv4Address(any());
+    }
+
+    @Test
+    void testGetRsuOrganizationAssignments_RepositoryThrowsException() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        when(rsuRepository.findAllOrganizationNamesByIpv4Address(inetAddress))
+                .thenThrow(new RuntimeException("Database connection failed"));
+
+        // Act & Assert
+        assertThrows(RuntimeException.class,
+                () -> organizationController.getRsuOrganizationAssignments(rsuIp));
+
+        verify(rsuRepository).findAllOrganizationNamesByIpv4Address(inetAddress);
+    }
+}

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -40,7 +38,6 @@ class OrganizationControllerTest {
     void testGetRsuIpsByOrganization_Success() throws UnknownHostException {
         // Arrange
         String organization = "TestOrg";
-        Pageable pageable = PageRequest.of(0, 100);
 
         List<InetAddress> mockIpAddresses = Arrays.asList(
                 InetAddress.getByName("192.168.1.100"),
@@ -51,7 +48,7 @@ class OrganizationControllerTest {
                 .thenReturn(mockIpAddresses);
 
         // Act
-        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+        List<String> result = organizationController.getRsuIpsByOrganization(organization);
 
         // Assert
         assertNotNull(result);
@@ -67,13 +64,12 @@ class OrganizationControllerTest {
     void testGetRsuIpsByOrganization_EmptyResult() {
         // Arrange
         String organization = "EmptyOrg";
-        Pageable pageable = PageRequest.of(0, 100);
 
         when(rsuOrganizationRepository.findAllRsuIpsByOrganizationName(organization))
                 .thenReturn(Arrays.asList());
 
         // Act
-        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+        List<String> result = organizationController.getRsuIpsByOrganization(organization);
 
         // Assert
         assertNotNull(result);
@@ -86,7 +82,6 @@ class OrganizationControllerTest {
     void testGetRsuIpsByOrganization_SingleRsu() throws UnknownHostException {
         // Arrange
         String organization = "SingleRsuOrg";
-        Pageable pageable = PageRequest.of(0, 100);
 
         List<InetAddress> mockIpAddresses = Arrays.asList(
                 InetAddress.getByName("192.168.1.100"));
@@ -95,7 +90,7 @@ class OrganizationControllerTest {
                 .thenReturn(mockIpAddresses);
 
         // Act
-        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+        List<String> result = organizationController.getRsuIpsByOrganization(organization);
 
         // Assert
         assertNotNull(result);
@@ -109,7 +104,6 @@ class OrganizationControllerTest {
     void testGetRsuIpsByOrganization_MultiplePages() throws UnknownHostException {
         // Arrange
         String organization = "LargeOrg";
-        Pageable pageable = PageRequest.of(0, 10);
 
         List<InetAddress> mockIpAddresses = Arrays.asList(
                 InetAddress.getByName("192.168.1.1"),
@@ -122,7 +116,7 @@ class OrganizationControllerTest {
                 .thenReturn(mockIpAddresses);
 
         // Act
-        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+        List<String> result = organizationController.getRsuIpsByOrganization(organization);
 
         // Assert
         assertNotNull(result);
@@ -135,7 +129,6 @@ class OrganizationControllerTest {
     void testGetRsuIpsByOrganization_IpAddressFormatting() throws UnknownHostException {
         // Arrange
         String organization = "TestOrg";
-        Pageable pageable = PageRequest.of(0, 100);
 
         List<InetAddress> mockIpAddresses = Arrays.asList(
                 InetAddress.getByName("10.0.0.1"),
@@ -146,7 +139,7 @@ class OrganizationControllerTest {
                 .thenReturn(mockIpAddresses);
 
         // Act
-        List<String> result = organizationController.getRsuIpsByOrganization(organization, pageable);
+        List<String> result = organizationController.getRsuIpsByOrganization(organization);
 
         // Assert
         assertEquals("10.0.0.1", result.get(0));

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/organizations/OrganizationControllerTest.java
@@ -256,21 +256,6 @@ class OrganizationControllerTest {
     }
 
     @Test
-    void testGetRsuOrganizationAssignments_EmptyIpAddress() {
-        // Arrange
-        String emptyIp = "";
-
-        // Act & Assert
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> organizationController.getRsuOrganizationAssignments(emptyIp));
-
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-
-        verify(rsuRepository, never()).findAllOrganizationNamesByIpv4Address(any());
-    }
-
-    @Test
     void testGetRsuOrganizationAssignments_IpWithHostname() {
         // Arrange
         String hostnameIp = "localhost";

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/PermissionServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/PermissionServiceTest.java
@@ -372,7 +372,7 @@ class PermissionServiceTest {
         assertTrue(permissionService.hasIntersection(123, "OPERATOR"));
     }
 
-    // ==================== hasRSU Tests ====================
+    // ==================== hasRsu Tests ====================
 
     @Test
     void testHasRSU_SuperUser() {
@@ -383,7 +383,7 @@ class PermissionServiceTest {
         superUser.setSuperUser(true);
         when(userRepository.findByEmail("test@example.com")).thenReturn(superUser);
 
-        assertTrue(permissionService.hasRSU("192.168.1.1", "USER"));
+        assertTrue(permissionService.hasRsu("192.168.1.1", "USER"));
         verify(rsuRepository, never()).existsByIpAndOrganizations(anyString(), anyList());
     }
 
@@ -403,7 +403,7 @@ class PermissionServiceTest {
         when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg")))
                 .thenReturn(true);
 
-        assertTrue(permissionService.hasRSU("192.168.1.1", "USER"));
+        assertTrue(permissionService.hasRsu("192.168.1.1", "USER"));
     }
 
     @Test
@@ -422,7 +422,7 @@ class PermissionServiceTest {
         when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg")))
                 .thenReturn(false);
 
-        assertFalse(permissionService.hasRSU("192.168.1.1", "USER"));
+        assertFalse(permissionService.hasRsu("192.168.1.1", "USER"));
         verify(userRepository).findByEmail("test@example.com");
         verify(rsuRepository).existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg"));
     }
@@ -444,7 +444,7 @@ class PermissionServiceTest {
         when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("Org1")))
                 .thenReturn(true);
 
-        assertTrue(permissionService.hasRSU("192.168.1.1", "OPERATOR"));
+        assertTrue(permissionService.hasRsu("192.168.1.1", "OPERATOR"));
     }
 
     // ==================== isAuthValid Tests ====================

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/PermissionServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/PermissionServiceTest.java
@@ -22,6 +22,8 @@ import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.UserRepository;
 import us.dot.its.jpo.ode.api.repositories.UserRepository.UserOrgRoleProjection;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
 
@@ -384,11 +386,11 @@ class PermissionServiceTest {
         when(userRepository.findByEmail("test@example.com")).thenReturn(superUser);
 
         assertTrue(permissionService.hasRsu("192.168.1.1", "USER"));
-        verify(rsuRepository, never()).existsByIpAndOrganizations(anyString(), anyList());
+        verify(rsuRepository, never()).existsByIpAndOrganizations(any(), anyList());
     }
 
     @Test
-    void testHasRSU_WithOrganizationHeader_HasAccess() {
+    void testHasRSU_WithOrganizationHeader_HasAccess() throws UnknownHostException {
         JwtAuthenticationToken token = createAuthenticatedToken("test@example.com");
         setupSecurityContext(token);
 
@@ -400,14 +402,14 @@ class PermissionServiceTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
         when(userRepository.findByEmail("test@example.com")).thenReturn(regularUser);
-        when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg")))
+        when(rsuRepository.existsByIpAndOrganizations(InetAddress.getByName("192.168.1.1"), List.of("TestOrg")))
                 .thenReturn(true);
 
         assertTrue(permissionService.hasRsu("192.168.1.1", "USER"));
     }
 
     @Test
-    void testHasRSU_WithOrganizationHeader_NoAccess() {
+    void testHasRSU_WithOrganizationHeader_NoAccess() throws UnknownHostException {
         JwtAuthenticationToken token = createAuthenticatedToken("test@example.com");
         setupSecurityContext(token);
 
@@ -419,16 +421,16 @@ class PermissionServiceTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
         when(userRepository.findByEmail("test@example.com")).thenReturn(regularUser);
-        when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg")))
+        when(rsuRepository.existsByIpAndOrganizations(InetAddress.getByName("192.168.1.1"), List.of("TestOrg")))
                 .thenReturn(false);
 
         assertFalse(permissionService.hasRsu("192.168.1.1", "USER"));
         verify(userRepository).findByEmail("test@example.com");
-        verify(rsuRepository).existsByIpAndOrganizations("192.168.1.1", List.of("TestOrg"));
+        verify(rsuRepository).existsByIpAndOrganizations(InetAddress.getByName("192.168.1.1"), List.of("TestOrg"));
     }
 
     @Test
-    void testHasRSU_WithoutOrganizationHeader_HasAccessInQualifiedOrg() {
+    void testHasRSU_WithoutOrganizationHeader_HasAccessInQualifiedOrg() throws UnknownHostException {
         JwtAuthenticationToken token = createAuthenticatedToken("test@example.com");
         setupSecurityContext(token);
 
@@ -441,7 +443,7 @@ class PermissionServiceTest {
 
         when(userRepository.findByEmail("test@example.com")).thenReturn(regularUser);
         when(userRepository.findUserOrgRoles("test@example.com")).thenReturn(List.of(projection));
-        when(rsuRepository.existsByIpAndOrganizations("192.168.1.1", List.of("Org1")))
+        when(rsuRepository.existsByIpAndOrganizations(InetAddress.getByName("192.168.1.1"), List.of("Org1")))
                 .thenReturn(true);
 
         assertTrue(permissionService.hasRsu("192.168.1.1", "OPERATOR"));

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import us.dot.its.jpo.ode.api.mappers.RsuInfoMapper;
 import us.dot.its.jpo.ode.api.mappers.RsuPatchMapper;
@@ -108,7 +110,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetRsuInfo_Success() throws UnknownHostException {
-        // Arrange
         String ipAddress = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(ipAddress);
 
@@ -129,10 +130,8 @@ class RsuManagementServiceTest {
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(mockRsu);
         when(rsuMapper.toDto(mockRsu)).thenReturn(mockDto);
 
-        // Act
         RsuInfoDto result = rsuManagementService.getRsuInfo(ipAddress);
 
-        // Assert
         assertNotNull(result);
         assertEquals(ipAddress, result.getIpv4Address());
         assertEquals(123.4, result.getMilepost());
@@ -143,16 +142,13 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetRsuInfo_NotFound() throws UnknownHostException {
-        // Arrange
         String ipAddress = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(ipAddress);
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
 
-        // Act
         RsuInfoDto result = rsuManagementService.getRsuInfo(ipAddress);
 
-        // Assert
         assertNull(result);
         verify(rsuRepository).findByIpv4Address(inetAddress);
         verify(rsuMapper, never()).toDto(any());
@@ -160,10 +156,8 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetRsuInfo_InvalidIpAddress() {
-        // Arrange
         String invalidIpAddress = "invalid-ip";
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.getRsuInfo(invalidIpAddress));
@@ -177,7 +171,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetAllRsuInfo_Success() {
-        // Arrange
         String orgName = "TestOrg";
         Pageable pageable = PageRequest.of(0, 10);
 
@@ -215,10 +208,8 @@ class RsuManagementServiceTest {
         when(rsuMapper.toDto(rsu1)).thenReturn(dto1);
         when(rsuMapper.toDto(rsu2)).thenReturn(dto2);
 
-        // Act
         Page<RsuInfoDto> result = rsuManagementService.getAllRsuInfo(orgName, pageable);
 
-        // Assert
         assertNotNull(result);
         assertEquals(2, result.getTotalElements());
         assertEquals(2, result.getContent().size());
@@ -230,17 +221,14 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetAllRsuInfo_EmptyResult() {
-        // Arrange
         String orgName = "EmptyOrg";
         Pageable pageable = PageRequest.of(0, 10);
         Page<Rsu> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
         when(rsuRepository.findAllByOrganization(orgName, pageable)).thenReturn(emptyPage);
 
-        // Act
         Page<RsuInfoDto> result = rsuManagementService.getAllRsuInfo(orgName, pageable);
 
-        // Assert
         assertNotNull(result);
         assertEquals(0, result.getTotalElements());
         assertTrue(result.getContent().isEmpty());
@@ -252,7 +240,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetAllowedSelections_Success() {
-        // Arrange
         String username = "testuser@example.com";
 
         List<String> primaryRoutes = Arrays.asList("I-25", "I-70", "US-36");
@@ -276,10 +263,8 @@ class RsuManagementServiceTest {
         when(snmpProtocolRepository.findAllNicknames()).thenReturn(snmpVersions);
         when(userRepository.findUserOrgRoles(username)).thenReturn(userOrgRoles);
 
-        // Act
         ModifyRsuAllowedSelections result = rsuManagementService.getAllowedSelections(username);
 
-        // Assert
         assertNotNull(result);
 
         assertEquals(3, result.getPrimaryRoutes().size());
@@ -312,7 +297,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testGetAllowedSelections_EmptyResults() {
-        // Arrange
         String username = "newuser@example.com";
 
         when(rsuRepository.findAllPrimaryRoutes()).thenReturn(List.of());
@@ -322,10 +306,8 @@ class RsuManagementServiceTest {
         when(snmpProtocolRepository.findAllNicknames()).thenReturn(List.of());
         when(userRepository.findUserOrgRoles(username)).thenReturn(List.of());
 
-        // Act
         ModifyRsuAllowedSelections result = rsuManagementService.getAllowedSelections(username);
 
-        // Assert
         assertNotNull(result);
         assertTrue(result.getPrimaryRoutes().isEmpty());
         assertTrue(result.getRsuModels().isEmpty());
@@ -339,7 +321,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_Success() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -371,10 +352,8 @@ class RsuManagementServiceTest {
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(expectedDto);
 
-        // Act
         RsuInfoDto result = rsuManagementService.modifyRsu(rsuIp, patch);
 
-        // Assert
         assertNotNull(result);
         assertEquals(150.0, result.getMilepost());
         assertEquals("I-70", result.getPrimaryRoute());
@@ -386,7 +365,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_WithModelUpdate() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -406,17 +384,14 @@ class RsuManagementServiceTest {
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(null);
 
-        // Act
         rsuManagementService.modifyRsu(rsuIp, patch);
 
-        // Assert
         verify(rsuModelRepository).findByNameAndManufacturerName("RSU-2X", "Yunex");
         verify(rsuRepository).save(existingRsu);
     }
 
     @Test
     void testModifyRsu_WithCredentialUpdates() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -440,10 +415,8 @@ class RsuManagementServiceTest {
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(null);
 
-        // Act
         rsuManagementService.modifyRsu(rsuIp, patch);
 
-        // Assert
         verify(rsuCredentialRepository).findByNickname("ssh-group-new");
         verify(snmpCredentialRepository).findByNickname("snmp-group-new");
         verify(snmpProtocolRepository).findByNickname("v3");
@@ -451,7 +424,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_WithOrganizationAdditions() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -470,24 +442,20 @@ class RsuManagementServiceTest {
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(null);
 
-        // Act
         rsuManagementService.modifyRsu(rsuIp, patch);
 
-        // Assert
         verify(organizationRepository).findByName("NewOrg");
         assertEquals(1, existingRsu.getRsuOrganizations().size());
     }
 
     @Test
     void testModifyRsu_RsuNotFound() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.123";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
         RsuPatch patch = new RsuPatch();
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
@@ -498,11 +466,9 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_InvalidIpAddress() {
-        // Arrange
         String invalidIp = "invalid-ip";
         RsuPatch patch = new RsuPatch();
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.modifyRsu(invalidIp, patch));
@@ -513,7 +479,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_ModelNotFound() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -527,7 +492,6 @@ class RsuManagementServiceTest {
         when(rsuModelRepository.findByNameAndManufacturerName(anyString(), anyString()))
                 .thenReturn(Optional.empty());
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
@@ -537,7 +501,6 @@ class RsuManagementServiceTest {
 
     @Test
     void testModifyRsu_InvalidModelFormat() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
@@ -549,7 +512,6 @@ class RsuManagementServiceTest {
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
@@ -561,10 +523,10 @@ class RsuManagementServiceTest {
 
     @Test
     void testDeleteRsuByIpv4Address_Success() throws UnknownHostException {
-        // Arrange
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
 
+        doReturn(new Rsu()).when(rsuRepository).findByIpv4Address(any());
         doNothing().when(pingRepository).removePingByIpv4Address(inetAddress);
         doNothing().when(rsuOrganizationRepository).removeRsuOrganizationByIpv4Address(inetAddress);
         doNothing().when(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
@@ -576,10 +538,8 @@ class RsuManagementServiceTest {
         doNothing().when(maxRetryLimitReachedInstanceRepository)
                 .removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
 
-        // Act
         rsuManagementService.deleteRsuByIpv4Address(rsuIp);
 
-        // Assert
         verify(pingRepository).removePingByIpv4Address(inetAddress);
         verify(rsuOrganizationRepository).removeRsuOrganizationByIpv4Address(inetAddress);
         verify(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
@@ -593,10 +553,8 @@ class RsuManagementServiceTest {
 
     @Test
     void testDeleteRsuByIpv4Address_InvalidIpAddress() {
-        // Arrange
         String invalidIp = "invalid-ip";
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.deleteRsuByIpv4Address(invalidIp));
@@ -609,9 +567,9 @@ class RsuManagementServiceTest {
 
     @Test
     void testDeleteMultipleRsusByIpv4Address_Success() throws UnknownHostException {
-        // Arrange
         List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.101", "192.168.1.102");
 
+        doReturn(List.of(new Rsu(), new Rsu(), new Rsu())).when(rsuRepository).findByIpv4AddressIn(anyList());
         doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
         doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
         doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
@@ -623,10 +581,8 @@ class RsuManagementServiceTest {
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
         doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
-        // Act
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
 
-        // Assert
         verify(pingRepository).removeMultiplePingsByIpv4Address(anyList());
         verify(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
         verify(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
@@ -640,34 +596,43 @@ class RsuManagementServiceTest {
     }
 
     @Test
+    void testDeleteMultipleRsusByIpv4Address_NotFound() throws UnknownHostException {
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.101", "192.168.1.102");
+        Rsu rsu = new Rsu();
+        rsu.setIpv4Address(InetAddress.getByName("192.168.1.100"));
+
+        doReturn(List.of(rsu)).when(rsuRepository).findByIpv4AddressIn(anyList());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps));
+
+        assertTrue(exception.getMessage().contains("RSU(s) not found with IP(s): 192.168.1.101, 192.168.1.102"));
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+
+        verify(rsuRepository, never()).removeByIpv4AddressIn(anyList());
+    }
+
+    @Test
     void testDeleteMultipleRsusByIpv4Address_EmptyList() {
-        // Arrange
         List<String> emptyList = Arrays.asList();
 
-        doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
-        doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
-        doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
-        doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
-        doNothing().when(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
-        doNothing().when(consecutiveFirmwareUpgradeFailureRepository)
-                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
-        doNothing().when(maxRetryLimitReachedInstanceRepository)
-                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
-        doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
+        doReturn(List.of()).when(rsuRepository).findByIpv4AddressIn(anyList());
 
-        // Act
-        rsuManagementService.deleteMultipleRsusByIpv4Address(emptyList);
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> rsuManagementService.deleteMultipleRsusByIpv4Address(emptyList));
 
-        // Assert
-        verify(rsuRepository).removeByIpv4AddressIn(anyList());
+        assertTrue(exception.getMessage().contains("No valid RSU IP addresses provided"));
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+
+        verify(rsuRepository, never()).removeByIpv4AddressIn(anyList());
     }
 
     @Test
     void testDeleteMultipleRsusByIpv4Address_InvalidIpInList() {
-        // Arrange
         List<String> rsuIps = Arrays.asList("192.168.1.100", "invalid-ip", "192.168.1.101");
 
-        // Act & Assert
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps));
@@ -678,9 +643,9 @@ class RsuManagementServiceTest {
 
     @Test
     void testDeleteMultipleRsusByIpv4Address_SingleRsu() {
-        // Arrange
         List<String> rsuIps = Arrays.asList("192.168.1.100");
 
+        doReturn(List.of(new Rsu())).when(rsuRepository).findByIpv4AddressIn(anyList());
         doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
         doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
         doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
@@ -692,10 +657,8 @@ class RsuManagementServiceTest {
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
         doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
-        // Act
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
 
-        // Assert
         verify(rsuRepository).removeByIpv4AddressIn(anyList());
     }
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -22,9 +22,12 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
+import us.dot.its.jpo.ode.api.repositories.ConsecutiveFirmwareUpgradeFailureRepository;
+import us.dot.its.jpo.ode.api.repositories.MaxRetryLimitReachedInstanceRepository;
 import us.dot.its.jpo.ode.api.repositories.OrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.PingRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
@@ -51,6 +54,12 @@ import static org.mockito.Mockito.*;
 class RsuManagementServiceTest {
 
     @Mock
+    private ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
+
+    @Mock
+    private MaxRetryLimitReachedInstanceRepository maxRetryLimitReachedInstanceRepository;
+
+    @Mock
     private OrganizationRepository organizationRepository;
 
     @Mock
@@ -58,6 +67,9 @@ class RsuManagementServiceTest {
 
     @Mock
     private RsuCredentialRepository rsuCredentialRepository;
+
+    @Mock
+    private RsuIntersectionRepository rsuIntersectionRepository;
 
     @Mock
     private RsuOrganizationRepository rsuOrganizationRepository;
@@ -558,6 +570,11 @@ class RsuManagementServiceTest {
         doNothing().when(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
         doNothing().when(snmpMsgfwdConfigRepository).removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
         doNothing().when(rsuRepository).removeRsuByIpv4Address(inetAddress);
+        doNothing().when(rsuIntersectionRepository).removeRsuIntersectionByIpv4Address(inetAddress);
+        doNothing().when(consecutiveFirmwareUpgradeFailureRepository)
+                .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
+        doNothing().when(maxRetryLimitReachedInstanceRepository)
+                .removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
 
         // Act
         rsuManagementService.deleteRsuByIpv4Address(rsuIp);
@@ -595,6 +612,11 @@ class RsuManagementServiceTest {
         doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
         doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
         doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        doNothing().when(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
+        doNothing().when(consecutiveFirmwareUpgradeFailureRepository)
+                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
+        doNothing().when(maxRetryLimitReachedInstanceRepository)
+                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
         doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
 
         // Act
@@ -617,6 +639,11 @@ class RsuManagementServiceTest {
         doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
         doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
         doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        doNothing().when(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
+        doNothing().when(consecutiveFirmwareUpgradeFailureRepository)
+                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
+        doNothing().when(maxRetryLimitReachedInstanceRepository)
+                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
         doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
 
         // Act

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -18,12 +18,13 @@ import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelectio
 import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
 import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
 import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
-import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 import us.dot.its.jpo.ode.api.repositories.ConsecutiveFirmwareUpgradeFailureRepository;
 import us.dot.its.jpo.ode.api.repositories.MaxRetryLimitReachedInstanceRepository;
 import us.dot.its.jpo.ode.api.repositories.OrganizationRepository;
@@ -63,6 +64,9 @@ class RsuManagementServiceTest {
 
     @Mock
     private OrganizationRepository organizationRepository;
+
+    @Mock
+    private PermissionService permissionService;
 
     @Mock
     private PingRepository pingRepository;
@@ -323,6 +327,7 @@ class RsuManagementServiceTest {
     void testModifyRsu_Success() throws UnknownHostException {
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
 
         RsuPatch patch = new RsuPatch();
         patch.setMilepost(150.0);
@@ -351,8 +356,9 @@ class RsuManagementServiceTest {
         doNothing().when(rsuPatchMapper).updateRsuFromPatch(patch, existingRsu);
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(expectedDto);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
 
-        RsuInfoDto result = rsuManagementService.modifyRsu(rsuIp, patch);
+        RsuInfoDto result = rsuManagementService.modifyRsu(rsuIp, patch, username);
 
         assertNotNull(result);
         assertEquals(150.0, result.getMilepost());
@@ -367,6 +373,7 @@ class RsuManagementServiceTest {
     void testModifyRsu_WithModelUpdate() throws UnknownHostException {
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
 
         RsuPatch patch = new RsuPatch();
         patch.setModel("Yunex RSU-2X");
@@ -383,8 +390,9 @@ class RsuManagementServiceTest {
                 .thenReturn(Optional.of(newModel));
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
 
-        rsuManagementService.modifyRsu(rsuIp, patch);
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
 
         verify(rsuModelRepository).findByNameAndManufacturerName("RSU-2X", "Yunex");
         verify(rsuRepository).save(existingRsu);
@@ -394,6 +402,7 @@ class RsuManagementServiceTest {
     void testModifyRsu_WithCredentialUpdates() throws UnknownHostException {
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
 
         RsuPatch patch = new RsuPatch();
         patch.setSshCredentialGroup("ssh-group-new");
@@ -414,8 +423,9 @@ class RsuManagementServiceTest {
         when(snmpProtocolRepository.findByNickname("v3")).thenReturn(Optional.of(snmpProtocol));
         when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
         when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
 
-        rsuManagementService.modifyRsu(rsuIp, patch);
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
 
         verify(rsuCredentialRepository).findByNickname("ssh-group-new");
         verify(snmpCredentialRepository).findByNickname("snmp-group-new");
@@ -423,42 +433,17 @@ class RsuManagementServiceTest {
     }
 
     @Test
-    void testModifyRsu_WithOrganizationAdditions() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-
-        RsuPatch patch = new RsuPatch();
-        patch.setOrganizationsToAdd(Arrays.asList("NewOrg"));
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new ArrayList<>());
-
-        Organization org = new Organization();
-        org.setName("NewOrg");
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(organizationRepository.findByName("NewOrg")).thenReturn(Optional.of(org));
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-
-        rsuManagementService.modifyRsu(rsuIp, patch);
-
-        verify(organizationRepository).findByName("NewOrg");
-        assertEquals(1, existingRsu.getRsuOrganizations().size());
-    }
-
-    @Test
     void testModifyRsu_RsuNotFound() throws UnknownHostException {
         String rsuIp = "192.168.1.123";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
         RsuPatch patch = new RsuPatch();
+        String username = "testuser@example.com";
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+                () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
 
         assertTrue(exception.getMessage().contains("RSU not found"));
         verify(rsuRepository, never()).save(any());
@@ -468,10 +453,11 @@ class RsuManagementServiceTest {
     void testModifyRsu_InvalidIpAddress() {
         String invalidIp = "invalid-ip";
         RsuPatch patch = new RsuPatch();
+        String username = "testuser@example.com";
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> rsuManagementService.modifyRsu(invalidIp, patch));
+                () -> rsuManagementService.modifyRsu(invalidIp, patch, username));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
         verify(rsuRepository, never()).save(any());
@@ -481,6 +467,7 @@ class RsuManagementServiceTest {
     void testModifyRsu_ModelNotFound() throws UnknownHostException {
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
 
         RsuPatch patch = new RsuPatch();
         patch.setModel("Unknown Model");
@@ -494,7 +481,7 @@ class RsuManagementServiceTest {
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+                () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
 
         assertTrue(exception.getMessage().contains("Model not found"));
     }
@@ -503,6 +490,7 @@ class RsuManagementServiceTest {
     void testModifyRsu_InvalidModelFormat() throws UnknownHostException {
         String rsuIp = "192.168.1.100";
         InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
 
         RsuPatch patch = new RsuPatch();
         patch.setModel("InvalidFormat");
@@ -514,10 +502,404 @@ class RsuManagementServiceTest {
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+                () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
 
         assertTrue(exception.getMessage().contains("Invalid model format"));
     }
+
+    // Add these tests to RsuManagementServiceTest.java
+
+    // ==================== HANDLE ORGANIZATION CHANGES TESTS ====================
+
+    @Test
+    void testHandleOrganizationChanges_AddOrganizations_Success() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setOrganizationsToAdd(Arrays.asList("Org1", "Org2"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    Organization org1 = new Organization();
+    org1.setName("Org1");
+    Organization org2 = new Organization();
+    org2.setName("Org2");
+
+    List<String> authorizedOrgs = Arrays.asList("Org1", "Org2", "Org3");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.existsByIpAndOrganizations(inetAddress, List.of("Org1")))
+            .thenReturn(false);
+    when(rsuRepository.existsByIpAndOrganizations(inetAddress, List.of("Org2")))
+            .thenReturn(false);
+    when(organizationRepository.findByName("Org1")).thenReturn(Optional.of(org1));
+    when(organizationRepository.findByName("Org2")).thenReturn(Optional.of(org2));
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, times(2)).save(any(RsuOrganization.class));
+    verify(organizationRepository).findByName("Org1");
+    verify(organizationRepository).findByName("Org2");
+}
+
+@Test
+void testHandleOrganizationChanges_AddOrganizations_AlreadyExists() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(Arrays.asList("Org1"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.existsByIpAndOrganizations(inetAddress, List.of("Org1")))
+            .thenReturn(true);
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+    verify(organizationRepository, never()).findByName(anyString());
+}
+
+@Test
+void testHandleOrganizationChanges_AddOrganizations_Unauthorized() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(Arrays.asList("UnauthorizedOrg"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1", "Org2");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    ResponseStatusException exception = assertThrows(
+                    ResponseStatusException.class,
+            () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
+
+    assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    assertTrue(exception.getMessage().contains("User does not have permission to add RSU to organization(s)"));
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg"));
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_AddOrganizations_OrganizationNotFound() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(Arrays.asList("NonExistentOrg"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("NonExistentOrg");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.existsByIpAndOrganizations(inetAddress, List.of("NonExistentOrg")))
+            .thenReturn(false);
+    when(organizationRepository.findByName("NonExistentOrg")).thenReturn(Optional.empty());
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    ResponseStatusException exception = assertThrows(
+                    ResponseStatusException.class,
+            () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    assertTrue(exception.getMessage().contains("Organization not found: NonExistentOrg"));
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_RemoveOrganizations_Success() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToRemove(Arrays.asList("Org1", "Org2"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    Organization org1 = new Organization();
+    org1.setName("Org1");
+    Organization org2 = new Organization();
+    org2.setName("Org2");
+
+    RsuOrganization rsuOrg1 = new RsuOrganization();
+    rsuOrg1.setRsu(existingRsu);
+    rsuOrg1.setOrganization(org1);
+
+    RsuOrganization rsuOrg2 = new RsuOrganization();
+    rsuOrg2.setRsu(existingRsu);
+    rsuOrg2.setOrganization(org2);
+
+    List<String> authorizedOrgs = Arrays.asList("Org1", "Org2", "Org3");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuOrganizationRepository.findByRsuIpv4AddressAndOrganization_Name(inetAddress, "Org1"))
+            .thenReturn(Optional.of(rsuOrg1));
+    when(rsuOrganizationRepository.findByRsuIpv4AddressAndOrganization_Name(inetAddress, "Org2"))
+            .thenReturn(Optional.of(rsuOrg2));
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository).delete(rsuOrg1);
+    verify(rsuOrganizationRepository).delete(rsuOrg2);
+}
+
+@Test
+void testHandleOrganizationChanges_RemoveOrganizations_NotFound() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToRemove(Arrays.asList("Org1"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuOrganizationRepository.findByRsuIpv4AddressAndOrganization_Name(inetAddress, "Org1"))
+            .thenReturn(Optional.empty());
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_RemoveOrganizations_Unauthorized() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToRemove(Arrays.asList("UnauthorizedOrg"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1", "Org2");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
+
+    assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    assertTrue(exception.getMessage().contains("User does not have permission to remove RSU from organization(s)"));
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg"));
+    verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_AddAndRemoveOrganizations() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(Arrays.asList("NewOrg"));
+    patch.setOrganizationsToRemove(Arrays.asList("OldOrg"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    Organization newOrg = new Organization();
+    newOrg.setName("NewOrg");
+    Organization oldOrg = new Organization();
+    oldOrg.setName("OldOrg");
+
+    RsuOrganization rsuOrgToRemove = new RsuOrganization();
+    rsuOrgToRemove.setRsu(existingRsu);
+    rsuOrgToRemove.setOrganization(oldOrg);
+
+    List<String> authorizedOrgs = Arrays.asList("NewOrg", "OldOrg");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.existsByIpAndOrganizations(inetAddress, List.of("NewOrg")))
+            .thenReturn(false);
+    when(organizationRepository.findByName("NewOrg")).thenReturn(Optional.of(newOrg));
+    when(rsuOrganizationRepository.findByRsuIpv4AddressAndOrganization_Name(inetAddress, "OldOrg"))
+            .thenReturn(Optional.of(rsuOrgToRemove));
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository).save(any(RsuOrganization.class));
+    verify(rsuOrganizationRepository).delete(rsuOrgToRemove);
+}
+
+@Test
+void testHandleOrganizationChanges_AddMultipleOrganizations_PartiallyUnauthorized() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(Arrays.asList("Org1", "UnauthorizedOrg1", "UnauthorizedOrg2"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    ResponseStatusException exception = assertThrows(
+                    ResponseStatusException.class,
+            () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
+
+    assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg1"));
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg2"));
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_RemoveMultipleOrganizations_PartiallyUnauthorized() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToRemove(Arrays.asList("Org1", "UnauthorizedOrg1", "UnauthorizedOrg2"));
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    List<String> authorizedOrgs = Arrays.asList("Org1");
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(authorizedOrgs);
+
+    ResponseStatusException exception = assertThrows(
+                    ResponseStatusException.class,
+            () -> rsuManagementService.modifyRsu(rsuIp, patch, username));
+
+    assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg1"));
+    assertTrue(exception.getMessage().contains("UnauthorizedOrg2"));
+    verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_NoOrganizationChanges() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    // No organization changes
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of());
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+    verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_EmptyAddList() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToAdd(List.of());
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of());
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, never()).save(any(RsuOrganization.class));
+}
+
+@Test
+void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException {
+    String rsuIp = "192.168.1.100";
+    InetAddress inetAddress = InetAddress.getByName(rsuIp);
+    String username = "testuser@example.com";
+
+    RsuPatch patch = new RsuPatch();
+    patch.setOrganizationsToRemove(List.of());
+
+    Rsu existingRsu = new Rsu();
+    existingRsu.setIpv4Address(inetAddress);
+    existingRsu.setRsuOrganizations(new ArrayList<>());
+
+    when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+    when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+    when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+    when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of());
+
+    rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+    verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
+}
+
 
     // ==================== DELETE RSU TESTS ====================
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -1,0 +1,695 @@
+package us.dot.its.jpo.ode.api.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import us.dot.its.jpo.ode.api.mappers.RsuInfoMapper;
+import us.dot.its.jpo.ode.api.mappers.RsuPatchMapper;
+import us.dot.its.jpo.ode.api.models.devices.management.ModifyRsuAllowedSelections;
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
+import us.dot.its.jpo.ode.api.models.SimplePosition;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
+import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
+import us.dot.its.jpo.ode.api.repositories.OrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.PingRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpMsgfwdConfigRepository;
+import us.dot.its.jpo.ode.api.repositories.SnmpProtocolRepository;
+import us.dot.its.jpo.ode.api.repositories.UserRepository;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RsuManagementServiceTest {
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private PingRepository pingRepository;
+
+    @Mock
+    private RsuCredentialRepository rsuCredentialRepository;
+
+    @Mock
+    private RsuOrganizationRepository rsuOrganizationRepository;
+
+    @Mock
+    private RsuModelRepository rsuModelRepository;
+
+    @Mock
+    private RsuRepository rsuRepository;
+
+    @Mock
+    private ScmsHealthRepository scmsHealthRepository;
+
+    @Mock
+    private SnmpCredentialRepository snmpCredentialRepository;
+
+    @Mock
+    private SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
+
+    @Mock
+    private SnmpProtocolRepository snmpProtocolRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RsuInfoMapper rsuMapper;
+
+    @Mock
+    private RsuPatchMapper rsuPatchMapper;
+
+    @InjectMocks
+    private RsuManagementService rsuManagementService;
+
+    // ==================== GET RSU INFO TESTS ====================
+
+    @Test
+    void testGetRsuInfo_Success() throws UnknownHostException {
+        // Arrange
+        String ipAddress = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(ipAddress);
+
+        Rsu mockRsu = new Rsu();
+        RsuInfoDto mockDto = new RsuInfoDto(
+                ipAddress,
+                new SimplePosition(39.7392, -105.0844),
+                123.4,
+                "I-25",
+                "RSU123",
+                "SCMS123",
+                "Model X",
+                "ssh-group",
+                "snmp-group",
+                "v3",
+                Arrays.asList("Org1", "Org2"));
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(mockRsu);
+        when(rsuMapper.toDto(mockRsu)).thenReturn(mockDto);
+
+        // Act
+        RsuInfoDto result = rsuManagementService.getRsuInfo(ipAddress);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(ipAddress, result.getIpv4Address());
+        assertEquals(123.4, result.getMilepost());
+        assertEquals("I-25", result.getPrimaryRoute());
+        verify(rsuRepository).findByIpv4Address(inetAddress);
+        verify(rsuMapper).toDto(mockRsu);
+    }
+
+    @Test
+    void testGetRsuInfo_NotFound() throws UnknownHostException {
+        // Arrange
+        String ipAddress = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(ipAddress);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
+
+        // Act
+        RsuInfoDto result = rsuManagementService.getRsuInfo(ipAddress);
+
+        // Assert
+        assertNull(result);
+        verify(rsuRepository).findByIpv4Address(inetAddress);
+        verify(rsuMapper, never()).toDto(any());
+    }
+
+    @Test
+    void testGetRsuInfo_InvalidIpAddress() {
+        // Arrange
+        String invalidIpAddress = "invalid-ip";
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.getRsuInfo(invalidIpAddress));
+
+        assertTrue(exception.getMessage().contains("Invalid IP address"));
+        assertTrue(exception.getCause() instanceof UnknownHostException);
+        verify(rsuRepository, never()).findByIpv4Address(any());
+    }
+
+    // ==================== GET ALL RSU INFO TESTS ====================
+
+    @Test
+    void testGetAllRsuInfo_Success() {
+        // Arrange
+        String orgName = "TestOrg";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Rsu rsu1 = new Rsu();
+        Rsu rsu2 = new Rsu();
+        List<Rsu> rsuList = Arrays.asList(rsu1, rsu2);
+        Page<Rsu> rsuPage = new PageImpl<>(rsuList, pageable, 2);
+
+        RsuInfoDto dto1 = new RsuInfoDto(
+                "192.168.1.100",
+                new SimplePosition(39.7392, -105.0844),
+                123.4,
+                "I-25",
+                "RSU1",
+                "SCMS1",
+                "Model X",
+                "ssh1",
+                "snmp1",
+                "v3",
+                Arrays.asList("TestOrg"));
+        RsuInfoDto dto2 = new RsuInfoDto(
+                "192.168.1.101",
+                new SimplePosition(39.7400, -105.0850),
+                124.5,
+                "I-70",
+                "RSU2",
+                "SCMS2",
+                "Model Y",
+                "ssh2",
+                "snmp2",
+                "v2c",
+                Arrays.asList("TestOrg"));
+
+        when(rsuRepository.findAllByOrganization(orgName, pageable)).thenReturn(rsuPage);
+        when(rsuMapper.toDto(rsu1)).thenReturn(dto1);
+        when(rsuMapper.toDto(rsu2)).thenReturn(dto2);
+
+        // Act
+        Page<RsuInfoDto> result = rsuManagementService.getAllRsuInfo(orgName, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.getContent().size());
+        assertEquals("192.168.1.100", result.getContent().get(0).getIpv4Address());
+        assertEquals("192.168.1.101", result.getContent().get(1).getIpv4Address());
+        verify(rsuRepository).findAllByOrganization(orgName, pageable);
+        verify(rsuMapper, times(2)).toDto(any(Rsu.class));
+    }
+
+    @Test
+    void testGetAllRsuInfo_EmptyResult() {
+        // Arrange
+        String orgName = "EmptyOrg";
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Rsu> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(rsuRepository.findAllByOrganization(orgName, pageable)).thenReturn(emptyPage);
+
+        // Act
+        Page<RsuInfoDto> result = rsuManagementService.getAllRsuInfo(orgName, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+        verify(rsuRepository).findAllByOrganization(orgName, pageable);
+        verify(rsuMapper, never()).toDto(any());
+    }
+
+    // ==================== GET ALLOWED SELECTIONS TESTS ====================
+
+    @Test
+    void testGetAllowedSelections_Success() {
+        // Arrange
+        String username = "testuser@example.com";
+
+        List<String> primaryRoutes = Arrays.asList("I-25", "I-70", "US-36");
+
+        List<RsuRepository.RsuModelProjection> rsuModels = Arrays.asList(
+                createRsuModelProjection("Commsignia", "ITS-RS4-M"),
+                createRsuModelProjection("Yunex", "RSU-2X"));
+
+        List<String> sshCredentials = Arrays.asList("ssh-group-1", "ssh-group-2");
+        List<String> snmpCredentials = Arrays.asList("snmp-group-1", "snmp-group-2");
+        List<String> snmpVersions = Arrays.asList("v2c", "v3");
+
+        List<UserRepository.UserOrgRoleProjection> userOrgRoles = Arrays.asList(
+                createUserOrgRoleProjection("testuser@example.com", "Org1", "Admin"),
+                createUserOrgRoleProjection("testuser@example.com", "Org2", "User"));
+
+        when(rsuRepository.findAllPrimaryRoutes()).thenReturn(primaryRoutes);
+        when(rsuRepository.findAllRsuModels()).thenReturn(rsuModels);
+        when(rsuCredentialRepository.findAllNicknames()).thenReturn(sshCredentials);
+        when(snmpCredentialRepository.findAllNicknames()).thenReturn(snmpCredentials);
+        when(snmpProtocolRepository.findAllNicknames()).thenReturn(snmpVersions);
+        when(userRepository.findUserOrgRoles(username)).thenReturn(userOrgRoles);
+
+        // Act
+        ModifyRsuAllowedSelections result = rsuManagementService.getAllowedSelections(username);
+
+        // Assert
+        assertNotNull(result);
+
+        assertEquals(3, result.getPrimaryRoutes().size());
+        assertTrue(result.getPrimaryRoutes().contains("I-25"));
+
+        assertEquals(2, result.getRsuModels().size());
+        assertTrue(result.getRsuModels().contains("Commsignia ITS-RS4-M"));
+        assertTrue(result.getRsuModels().contains("Yunex RSU-2X"));
+
+        assertEquals(2, result.getSshCredentialGroups().size());
+        assertTrue(result.getSshCredentialGroups().contains("ssh-group-1"));
+
+        assertEquals(2, result.getSnmpCredentialGroups().size());
+        assertTrue(result.getSnmpCredentialGroups().contains("snmp-group-1"));
+
+        assertEquals(2, result.getSnmpVersionGroups().size());
+        assertTrue(result.getSnmpVersionGroups().contains("v2c"));
+
+        assertEquals(2, result.getOrganizations().size());
+        assertTrue(result.getOrganizations().contains("Org1"));
+        assertTrue(result.getOrganizations().contains("Org2"));
+
+        verify(rsuRepository).findAllPrimaryRoutes();
+        verify(rsuRepository).findAllRsuModels();
+        verify(rsuCredentialRepository).findAllNicknames();
+        verify(snmpCredentialRepository).findAllNicknames();
+        verify(snmpProtocolRepository).findAllNicknames();
+        verify(userRepository).findUserOrgRoles(username);
+    }
+
+    @Test
+    void testGetAllowedSelections_EmptyResults() {
+        // Arrange
+        String username = "newuser@example.com";
+
+        when(rsuRepository.findAllPrimaryRoutes()).thenReturn(List.of());
+        when(rsuRepository.findAllRsuModels()).thenReturn(List.of());
+        when(rsuCredentialRepository.findAllNicknames()).thenReturn(List.of());
+        when(snmpCredentialRepository.findAllNicknames()).thenReturn(List.of());
+        when(snmpProtocolRepository.findAllNicknames()).thenReturn(List.of());
+        when(userRepository.findUserOrgRoles(username)).thenReturn(List.of());
+
+        // Act
+        ModifyRsuAllowedSelections result = rsuManagementService.getAllowedSelections(username);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.getPrimaryRoutes().isEmpty());
+        assertTrue(result.getRsuModels().isEmpty());
+        assertTrue(result.getSshCredentialGroups().isEmpty());
+        assertTrue(result.getSnmpCredentialGroups().isEmpty());
+        assertTrue(result.getSnmpVersionGroups().isEmpty());
+        assertTrue(result.getOrganizations().isEmpty());
+    }
+
+    // ==================== MODIFY RSU TESTS ====================
+
+    @Test
+    void testModifyRsu_Success() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setMilepost(150.0);
+        patch.setPrimaryRoute("I-70");
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setMilepost(123.4);
+        existingRsu.setPrimaryRoute("I-25");
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        RsuInfoDto expectedDto = new RsuInfoDto(
+                rsuIp,
+                new SimplePosition(39.7392, -105.0844),
+                150.0,
+                "I-70",
+                "RSU123",
+                "SCMS123",
+                "Model X",
+                "ssh-group",
+                "snmp-group",
+                "v3",
+                Arrays.asList("Org1"));
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        doNothing().when(rsuPatchMapper).updateRsuFromPatch(patch, existingRsu);
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(expectedDto);
+
+        // Act
+        RsuInfoDto result = rsuManagementService.modifyRsu(rsuIp, patch);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(150.0, result.getMilepost());
+        assertEquals("I-70", result.getPrimaryRoute());
+        verify(rsuRepository).findByIpv4Address(inetAddress);
+        verify(rsuPatchMapper).updateRsuFromPatch(patch, existingRsu);
+        verify(rsuRepository).save(existingRsu);
+        verify(rsuMapper).toDto(existingRsu);
+    }
+
+    @Test
+    void testModifyRsu_WithModelUpdate() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setModel("Yunex RSU-2X");
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        RsuModel newModel = new RsuModel();
+        newModel.setName("RSU-2X");
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuModelRepository.findByNameAndManufacturerName("RSU-2X", "Yunex"))
+                .thenReturn(Optional.of(newModel));
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+
+        // Act
+        rsuManagementService.modifyRsu(rsuIp, patch);
+
+        // Assert
+        verify(rsuModelRepository).findByNameAndManufacturerName("RSU-2X", "Yunex");
+        verify(rsuRepository).save(existingRsu);
+    }
+
+    @Test
+    void testModifyRsu_WithCredentialUpdates() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setSshCredentialGroup("ssh-group-new");
+        patch.setSnmpCredentialGroup("snmp-group-new");
+        patch.setSnmpVersionGroup("v3");
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        RsuCredential sshCred = new RsuCredential();
+        SnmpCredential snmpCred = new SnmpCredential();
+        SnmpProtocol snmpProtocol = new SnmpProtocol();
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuCredentialRepository.findByNickname("ssh-group-new")).thenReturn(Optional.of(sshCred));
+        when(snmpCredentialRepository.findByNickname("snmp-group-new")).thenReturn(Optional.of(snmpCred));
+        when(snmpProtocolRepository.findByNickname("v3")).thenReturn(Optional.of(snmpProtocol));
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+
+        // Act
+        rsuManagementService.modifyRsu(rsuIp, patch);
+
+        // Assert
+        verify(rsuCredentialRepository).findByNickname("ssh-group-new");
+        verify(snmpCredentialRepository).findByNickname("snmp-group-new");
+        verify(snmpProtocolRepository).findByNickname("v3");
+    }
+
+    @Test
+    void testModifyRsu_WithOrganizationAdditions() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setOrganizationsToAdd(Arrays.asList("NewOrg"));
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        Organization org = new Organization();
+        org.setName("NewOrg");
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(organizationRepository.findByName("NewOrg")).thenReturn(Optional.of(org));
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+
+        // Act
+        rsuManagementService.modifyRsu(rsuIp, patch);
+
+        // Assert
+        verify(organizationRepository).findByName("NewOrg");
+        assertEquals(1, existingRsu.getRsuOrganizations().size());
+    }
+
+    @Test
+    void testModifyRsu_RsuNotFound() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.123";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        RsuPatch patch = new RsuPatch();
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+
+        assertTrue(exception.getMessage().contains("RSU not found"));
+        verify(rsuRepository, never()).save(any());
+    }
+
+    @Test
+    void testModifyRsu_InvalidIpAddress() {
+        // Arrange
+        String invalidIp = "invalid-ip";
+        RsuPatch patch = new RsuPatch();
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.modifyRsu(invalidIp, patch));
+
+        assertTrue(exception.getMessage().contains("Invalid IP address"));
+        verify(rsuRepository, never()).save(any());
+    }
+
+    @Test
+    void testModifyRsu_ModelNotFound() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setModel("Unknown Model");
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuModelRepository.findByNameAndManufacturerName(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+
+        assertTrue(exception.getMessage().contains("Model not found"));
+    }
+
+    @Test
+    void testModifyRsu_InvalidModelFormat() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setModel("InvalidFormat");
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setRsuOrganizations(new ArrayList<>());
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.modifyRsu(rsuIp, patch));
+
+        assertTrue(exception.getMessage().contains("Invalid model format"));
+    }
+
+    // ==================== DELETE RSU TESTS ====================
+
+    @Test
+    void testDeleteRsuByIpv4Address_Success() throws UnknownHostException {
+        // Arrange
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        doNothing().when(pingRepository).removePingByIpv4Address(inetAddress);
+        doNothing().when(rsuOrganizationRepository).removeRsuOrganizationByIpv4Address(inetAddress);
+        doNothing().when(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
+        doNothing().when(snmpMsgfwdConfigRepository).removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
+        doNothing().when(rsuRepository).removeRsuByIpv4Address(inetAddress);
+
+        // Act
+        rsuManagementService.deleteRsuByIpv4Address(rsuIp);
+
+        // Assert
+        verify(pingRepository).removePingByIpv4Address(inetAddress);
+        verify(rsuOrganizationRepository).removeRsuOrganizationByIpv4Address(inetAddress);
+        verify(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
+        verify(snmpMsgfwdConfigRepository).removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
+        verify(rsuRepository).removeRsuByIpv4Address(inetAddress);
+    }
+
+    @Test
+    void testDeleteRsuByIpv4Address_InvalidIpAddress() {
+        // Arrange
+        String invalidIp = "invalid-ip";
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.deleteRsuByIpv4Address(invalidIp));
+
+        assertTrue(exception.getMessage().contains("Invalid IP address"));
+        verify(rsuRepository, never()).removeRsuByIpv4Address(any());
+    }
+
+    // ==================== DELETE MULTIPLE RSUS TESTS ====================
+
+    @Test
+    void testDeleteMultipleRsusByIpv4Address_Success() throws UnknownHostException {
+        // Arrange
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "192.168.1.101", "192.168.1.102");
+
+        doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
+        doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
+        doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
+        doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+
+        // Act
+        rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
+
+        // Assert
+        verify(pingRepository).removeMultiplePingsByIpv4Address(anyList());
+        verify(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
+        verify(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
+        verify(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+    }
+
+    @Test
+    void testDeleteMultipleRsusByIpv4Address_EmptyList() {
+        // Arrange
+        List<String> emptyList = Arrays.asList();
+
+        doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
+        doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
+        doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
+        doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+
+        // Act
+        rsuManagementService.deleteMultipleRsusByIpv4Address(emptyList);
+
+        // Assert
+        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+    }
+
+    @Test
+    void testDeleteMultipleRsusByIpv4Address_InvalidIpInList() {
+        // Arrange
+        List<String> rsuIps = Arrays.asList("192.168.1.100", "invalid-ip", "192.168.1.101");
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps));
+
+        assertTrue(exception.getMessage().contains("Invalid IP address"));
+        verify(rsuRepository, never()).deleteByIpv4AddressIn(anyList());
+    }
+
+    @Test
+    void testDeleteMultipleRsusByIpv4Address_SingleRsu() throws UnknownHostException {
+        // Arrange
+        List<String> rsuIps = Arrays.asList("192.168.1.100");
+
+        doNothing().when(pingRepository).removeMultiplePingsByIpv4Address(anyList());
+        doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
+        doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
+        doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+
+        // Act
+        rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
+
+        // Assert
+        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private RsuRepository.RsuModelProjection createRsuModelProjection(String manufacturer, String model) {
+        return new RsuRepository.RsuModelProjection() {
+            @Override
+            public String getManufacturer() {
+                return manufacturer;
+            }
+
+            @Override
+            public String getModel() {
+                return model;
+            }
+        };
+    }
+
+    private UserRepository.UserOrgRoleProjection createUserOrgRoleProjection(String email, String org, String role) {
+        return new UserRepository.UserOrgRoleProjection() {
+            @Override
+            public String getEmail() {
+                return email;
+            }
+
+            @Override
+            public String getOrganizationName() {
+                return org;
+            }
+
+            @Override
+            public String getRoleName() {
+                return role;
+            }
+        };
+    }
+}

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -158,8 +158,8 @@ class RsuManagementServiceTest {
     void testGetRsuInfo_InvalidIpAddress() {
         String invalidIpAddress = "invalid-ip";
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                        ResponseStatusException.class,
                 () -> rsuManagementService.getRsuInfo(invalidIpAddress));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
@@ -456,8 +456,8 @@ class RsuManagementServiceTest {
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
 
         assertTrue(exception.getMessage().contains("RSU not found"));
@@ -469,8 +469,8 @@ class RsuManagementServiceTest {
         String invalidIp = "invalid-ip";
         RsuPatch patch = new RsuPatch();
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.modifyRsu(invalidIp, patch));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
@@ -492,8 +492,8 @@ class RsuManagementServiceTest {
         when(rsuModelRepository.findByNameAndManufacturerName(anyString(), anyString()))
                 .thenReturn(Optional.empty());
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
 
         assertTrue(exception.getMessage().contains("Model not found"));
@@ -512,8 +512,8 @@ class RsuManagementServiceTest {
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.modifyRsu(rsuIp, patch));
 
         assertTrue(exception.getMessage().contains("Invalid model format"));
@@ -555,8 +555,8 @@ class RsuManagementServiceTest {
     void testDeleteRsuByIpv4Address_InvalidIpAddress() {
         String invalidIp = "invalid-ip";
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.deleteRsuByIpv4Address(invalidIp));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
@@ -633,8 +633,8 @@ class RsuManagementServiceTest {
     void testDeleteMultipleRsusByIpv4Address_InvalidIpInList() {
         List<String> rsuIps = Arrays.asList("192.168.1.100", "invalid-ip", "192.168.1.101");
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
                 () -> rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -169,7 +169,7 @@ class RsuManagementServiceTest {
                 () -> rsuManagementService.getRsuInfo(invalidIpAddress));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
-        assertTrue(exception.getCause() instanceof UnknownHostException);
+        assertInstanceOf(UnknownHostException.class, exception.getCause());
         verify(rsuRepository, never()).findByIpv4Address(any());
     }
 
@@ -584,6 +584,10 @@ class RsuManagementServiceTest {
         verify(rsuOrganizationRepository).removeRsuOrganizationByIpv4Address(inetAddress);
         verify(scmsHealthRepository).removeScmsHealthByIpv4Address(inetAddress);
         verify(snmpMsgfwdConfigRepository).removeSnmpMsgfwdConfigByIpv4Address(inetAddress);
+        verify(rsuIntersectionRepository).removeRsuIntersectionByIpv4Address(inetAddress);
+        verify(consecutiveFirmwareUpgradeFailureRepository)
+                .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
+        verify(maxRetryLimitReachedInstanceRepository).removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
         verify(rsuRepository).removeRsuByIpv4Address(inetAddress);
     }
 
@@ -617,17 +621,22 @@ class RsuManagementServiceTest {
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
         doNothing().when(maxRetryLimitReachedInstanceRepository)
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
-        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+        doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
         // Act
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
 
         // Assert
         verify(pingRepository).removeMultiplePingsByIpv4Address(anyList());
+        verify(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
         verify(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
+        verify(maxRetryLimitReachedInstanceRepository)
+                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
         verify(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
+        verify(consecutiveFirmwareUpgradeFailureRepository)
+                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
         verify(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
-        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+        verify(rsuRepository).removeByIpv4AddressIn(anyList());
     }
 
     @Test
@@ -644,13 +653,13 @@ class RsuManagementServiceTest {
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
         doNothing().when(maxRetryLimitReachedInstanceRepository)
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
-        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+        doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
         // Act
         rsuManagementService.deleteMultipleRsusByIpv4Address(emptyList);
 
         // Assert
-        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+        verify(rsuRepository).removeByIpv4AddressIn(anyList());
     }
 
     @Test
@@ -664,11 +673,11 @@ class RsuManagementServiceTest {
                 () -> rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps));
 
         assertTrue(exception.getMessage().contains("Invalid IP address"));
-        verify(rsuRepository, never()).deleteByIpv4AddressIn(anyList());
+        verify(rsuRepository, never()).removeByIpv4AddressIn(anyList());
     }
 
     @Test
-    void testDeleteMultipleRsusByIpv4Address_SingleRsu() throws UnknownHostException {
+    void testDeleteMultipleRsusByIpv4Address_SingleRsu() {
         // Arrange
         List<String> rsuIps = Arrays.asList("192.168.1.100");
 
@@ -676,13 +685,18 @@ class RsuManagementServiceTest {
         doNothing().when(rsuOrganizationRepository).removeMultipleRsuOrganizationsByIpv4Address(anyList());
         doNothing().when(scmsHealthRepository).removeMultipleScmsHealthByIpv4Address(anyList());
         doNothing().when(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
-        doNothing().when(rsuRepository).deleteByIpv4AddressIn(anyList());
+        doNothing().when(rsuIntersectionRepository).removeMultipleRsuIntersectionsByIpv4Address(anyList());
+        doNothing().when(consecutiveFirmwareUpgradeFailureRepository)
+                .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
+        doNothing().when(maxRetryLimitReachedInstanceRepository)
+                .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
+        doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
         // Act
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
 
         // Assert
-        verify(rsuRepository).deleteByIpv4AddressIn(anyList());
+        verify(rsuRepository).removeByIpv4AddressIn(anyList());
     }
 
     // ==================== HELPER METHODS ====================


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

Migrating Admin RSU endpoints from the python API to the Java Intersection API
This migration includes the following changes:

- Adding JPA postgres queries and repositories to the Intersection API
- Adding all RSU-related postgres tables and objects to IAPI
- Adding the following REST endpoints to the Intersection API:
    - GET /devices/rsus
    - GET /devices/rsus?rsu_ip=
    - GET /devices/rsus/allowed-selections?rsu_ip=
    - PATCH /devices/rsus?rsu_ip=
    - DELET /devices/rsus?rsu_ip=

## How Has This Been Tested?

This was tested both through directly calling the new Intersection-API endpoints through postman

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
