### PR TITLE
Restrict Super User Privilege Changes to Super Users Only

### DIFF
--- a/services/api/src/admin_new_user.py
+++ b/services/api/src/admin_new_user.py
@@ -192,11 +192,11 @@ class AdminNewUser(Resource):
             logging.error(str(errors))
             abort(400, str(errors))
 
-        # enforce_organization_restrictions(
-        #     user=permission_result.user,
-        #     qualified_orgs=permission_result.qualified_orgs,
-        #     spec=request.json,
-        #     keys_to_check=["organizations"],
-        # )
+        enforce_organization_restrictions(
+            user=permission_result.user,
+            qualified_orgs=permission_result.qualified_orgs,
+            spec=request.json,
+            keys_to_check=["organizations"],
+        )
 
         return (add_user(body, permission_result.user), 200, self.headers)

--- a/services/api/src/admin_new_user.py
+++ b/services/api/src/admin_new_user.py
@@ -7,7 +7,7 @@ import common.pgquery as pgquery
 import api_environment
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 import time
-from werkzeug.exceptions import InternalServerError, BadRequest
+from werkzeug.exceptions import InternalServerError, BadRequest, Forbidden
 from common.auth_tools import (
     ORG_ROLE_LITERAL,
     EnvironWithOrg,
@@ -86,7 +86,7 @@ def check_safe_input(user_spec):
     return True
 
 
-def add_user(user_spec: dict):
+def add_user(user_spec: dict, requesting_user: EnvironWithOrg):
     # Check for special characters for potential SQL injection
     if not check_email(user_spec["email"]):
         raise BadRequest("Email is not valid")
@@ -96,8 +96,9 @@ def add_user(user_spec: dict):
         )
 
     try:
-
-        # TODO: prevent non-super-users from creating new users with super-user privileges
+        # Prevent non-super users from modifying super_user privileges
+        if not requesting_user.user_info.super_user and user_spec["super_user"]:
+            raise Forbidden("Only super users can grant super user privileges")
 
         current_timestamp = int(time.time() * 1000)
         user_insert_query = (
@@ -191,11 +192,11 @@ class AdminNewUser(Resource):
             logging.error(str(errors))
             abort(400, str(errors))
 
-        enforce_organization_restrictions(
-            user=permission_result.user,
-            qualified_orgs=permission_result.qualified_orgs,
-            spec=request.json,
-            keys_to_check=["organizations"],
-        )
+        # enforce_organization_restrictions(
+        #     user=permission_result.user,
+        #     qualified_orgs=permission_result.qualified_orgs,
+        #     spec=request.json,
+        #     keys_to_check=["organizations"],
+        # )
 
-        return (add_user(body), 200, self.headers)
+        return (add_user(body, permission_result.user), 200, self.headers)

--- a/services/api/src/admin_new_user.py
+++ b/services/api/src/admin_new_user.py
@@ -130,6 +130,9 @@ def add_user(user_spec: dict, requesting_user: EnvironWithOrg):
     except SQLAlchemyError as e:
         logging.error(f"SQL Exception encountered: {e}")
         raise InternalServerError("Encountered unknown issue executing query") from e
+    except Forbidden as e:
+        logging.error(f"Forbidden Exception encountered: {e}")
+        raise e
 
     return {"message": "New user successfully added"}
 

--- a/services/api/src/admin_new_user.py
+++ b/services/api/src/admin_new_user.py
@@ -96,6 +96,9 @@ def add_user(user_spec: dict):
         )
 
     try:
+
+        # TODO: prevent non-super-users from creating new users with super-user privileges
+
         current_timestamp = int(time.time() * 1000)
         user_insert_query = (
             "INSERT INTO public.users(email, first_name, last_name, super_user, created_timestamp) "

--- a/services/api/src/admin_user.py
+++ b/services/api/src/admin_user.py
@@ -8,7 +8,7 @@ import common.pgquery as pgquery
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 import admin_new_user
 import api_environment
-from werkzeug.exceptions import InternalServerError, BadRequest
+from werkzeug.exceptions import InternalServerError, BadRequest, Forbidden
 from common.auth_tools import (
     ORG_ROLE_LITERAL,
     RESOURCE_TYPE,
@@ -146,10 +146,10 @@ def modify_user(orig_email: str, user_spec: dict, requesting_user: EnvironWithOr
     if not requesting_user.user_info.super_user:
         # Prevent granting super_user privileges
         if user_spec["super_user"] and not target_super_user_status:
-            raise BadRequest("Only super users can grant super user privileges")
+            raise Forbidden("Only super users can grant super user privileges")
         # Prevent revoking super_user privileges
         if not user_spec["super_user"] and target_super_user_status:
-            raise BadRequest("Only super users can revoke super user privileges")
+            raise Forbidden("Only super users can revoke super user privileges")
 
     try:
         # Modify the existing user data

--- a/services/api/src/admin_user.py
+++ b/services/api/src/admin_user.py
@@ -122,7 +122,7 @@ def check_safe_input(user_spec):
     return True
 
 
-def modify_user(orig_email: str, user_spec: dict):
+def modify_user(orig_email: str, user_spec: dict, requesting_user: EnvironWithOrg):
     # Check for special characters for potential SQL injection
     if not admin_new_user.check_email(
         user_spec["email"]
@@ -132,6 +132,10 @@ def modify_user(orig_email: str, user_spec: dict):
         raise BadRequest(
             "No special characters are allowed: !\"#$%&'()*+,./:;<=>?@[\\]^`{|}~. No sequences of '-' characters are allowed"
         )
+
+    # Prevent non-super users from granting super_user privileges
+    if user_spec["super_user"] and not requesting_user.user_info.super_user:
+        raise BadRequest("Only super users can grant super user privileges")
 
     try:
         # Modify the existing user data
@@ -335,7 +339,7 @@ class AdminUser(Resource):
         )
 
         return (
-            modify_user(body["orig_email"], body),
+            modify_user(body["orig_email"], body, permission_result.user),
             200,
             self.headers,
         )

--- a/services/api/src/admin_user.py
+++ b/services/api/src/admin_user.py
@@ -133,9 +133,23 @@ def modify_user(orig_email: str, user_spec: dict, requesting_user: EnvironWithOr
             "No special characters are allowed: !\"#$%&'()*+,./:;<=>?@[\\]^`{|}~. No sequences of '-' characters are allowed"
         )
 
-    # Prevent non-super users from granting super_user privileges
-    if user_spec["super_user"] and not requesting_user.user_info.super_user:
-        raise BadRequest("Only super users can grant super user privileges")
+    # Get the target user's super_user status from the database
+    target_user_query = "SELECT super_user FROM public.users WHERE email = :orig_email"
+    target_user_data = pgquery.query_db(target_user_query, params={"orig_email": orig_email})
+
+    if len(target_user_data) > 0:
+        target_super_user_status = target_user_data[0][0] == "1"
+    else:
+        raise BadRequest("User not found")
+
+    # Prevent non-super users from modifying super_user privileges
+    if not requesting_user.user_info.super_user:
+        # Prevent granting super_user privileges
+        if user_spec["super_user"] and not target_super_user_status:
+            raise BadRequest("Only super users can grant super user privileges")
+        # Prevent revoking super_user privileges
+        if not user_spec["super_user"] and target_super_user_status:
+            raise BadRequest("Only super users can revoke super user privileges")
 
     try:
         # Modify the existing user data

--- a/services/api/src/admin_user.py
+++ b/services/api/src/admin_user.py
@@ -133,25 +133,25 @@ def modify_user(orig_email: str, user_spec: dict, requesting_user: EnvironWithOr
             "No special characters are allowed: !\"#$%&'()*+,./:;<=>?@[\\]^`{|}~. No sequences of '-' characters are allowed"
         )
 
-    # Get the target user's super_user status from the database
-    target_user_query = "SELECT super_user FROM public.users WHERE email = :orig_email"
-    target_user_data = pgquery.query_db(target_user_query, params={"orig_email": orig_email})
-
-    if len(target_user_data) > 0:
-        target_super_user_status = target_user_data[0][0] == "1"
-    else:
-        raise BadRequest("User not found")
-
-    # Prevent non-super users from modifying super_user privileges
-    if not requesting_user.user_info.super_user:
-        # Prevent granting super_user privileges
-        if user_spec["super_user"] and not target_super_user_status:
-            raise Forbidden("Only super users can grant super user privileges")
-        # Prevent revoking super_user privileges
-        if not user_spec["super_user"] and target_super_user_status:
-            raise Forbidden("Only super users can revoke super user privileges")
-
     try:
+        # Get the target user's super_user status from the database
+        target_user_query = "SELECT super_user FROM public.users WHERE email = :orig_email"
+        target_user_data = pgquery.query_db(target_user_query, params={"orig_email": orig_email})
+
+        if len(target_user_data) > 0:
+            target_super_user_status = target_user_data[0][0] == "1"
+        else:
+            raise BadRequest("User not found")
+
+        # Prevent non-super users from modifying super_user privileges
+        if not requesting_user.user_info.super_user:
+            # Prevent granting super_user privileges
+            if user_spec["super_user"] and not target_super_user_status:
+                raise Forbidden("Only super users can grant super user privileges")
+            # Prevent revoking super_user privileges
+            if not user_spec["super_user"] and target_super_user_status:
+                raise Forbidden("Only super users can revoke super user privileges")
+
         # Modify the existing user data
         query = (
             "UPDATE public.users SET "

--- a/services/api/src/admin_user.py
+++ b/services/api/src/admin_user.py
@@ -240,6 +240,9 @@ def modify_user(orig_email: str, user_spec: dict, requesting_user: EnvironWithOr
     except SQLAlchemyError as e:
         logging.error(f"SQL Exception encountered: {e}")
         raise InternalServerError("Encountered unknown issue executing query") from e
+    except Forbidden as e:
+        logging.error(f"Forbidden Exception encountered: {e}")
+        raise e
 
     return {"message": "User successfully modified"}
 

--- a/services/api/tests/src/test_admin_new_user.py
+++ b/services/api/tests/src/test_admin_new_user.py
@@ -107,7 +107,11 @@ def test_add_user_success(
     mock_check_safe_input.return_value = True
     mock_time.return_value = 1678901234  # Mocked Unix time in seconds
     expected_msg = {"message": "New user successfully added"}
-    actual_msg = admin_new_user.add_user(admin_new_user_data.request_json_good)
+
+    # Create a super user as the requesting user
+    super_user = auth_data.get_request_environ()
+
+    actual_msg = admin_new_user.add_user(admin_new_user_data.request_json_good, super_user)
 
     calls = [
         call(admin_new_user_data.user_insert_query),
@@ -121,8 +125,12 @@ def test_add_user_success(
 @patch("api.src.admin_new_user.pgquery.write_db")
 def test_add_user_email_fail(mock_pgquery, mock_check_email):
     mock_check_email.return_value = False
+
+    # Create a non-super user as the requesting user
+    non_super_user = auth_data.get_request_environ_user()
+
     with pytest.raises(BadRequest) as exc_info:
-        admin_new_user.add_user(admin_new_user_data.request_json_good)
+        admin_new_user.add_user(admin_new_user_data.request_json_good, non_super_user)
 
     assert str(exc_info.value) == "400 Bad Request: Email is not valid"
     mock_pgquery.assert_has_calls([])
@@ -135,8 +143,11 @@ def test_add_user_check_fail(mock_pgquery, mock_check_email, mock_check_safe_inp
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = False
 
+    # Create a non-super user as the requesting user
+    non_super_user = auth_data.get_request_environ_user()
+
     with pytest.raises(BadRequest) as exc_info:
-        admin_new_user.add_user(admin_new_user_data.request_json_good)
+        admin_new_user.add_user(admin_new_user_data.request_json_good, non_super_user)
 
     assert (
         str(exc_info.value)
@@ -155,8 +166,11 @@ def test_add_user_generic_exception(
     mock_check_safe_input.return_value = True
     mock_pgquery.side_effect = SQLAlchemyError("Test")
 
+    # Create a super user as the requesting user
+    super_user = auth_data.get_request_environ()
+
     with pytest.raises(InternalServerError) as exc_info:
-        admin_new_user.add_user(admin_new_user_data.request_json_good)
+        admin_new_user.add_user(admin_new_user_data.request_json_good, super_user)
 
     assert (
         str(exc_info.value)
@@ -174,8 +188,11 @@ def test_add_user_sql_exception(mock_pgquery, mock_check_email, mock_check_safe_
     orig.args = ({"D": "SQL issue encountered"},)
     mock_pgquery.side_effect = IntegrityError("", {}, orig)
 
+    # Create a super user as the requesting user
+    super_user = auth_data.get_request_environ()
+
     with pytest.raises(InternalServerError) as exc_info:
-        admin_new_user.add_user(admin_new_user_data.request_json_good)
+        admin_new_user.add_user(admin_new_user_data.request_json_good, super_user)
 
     assert str(exc_info.value) == "500 Internal Server Error: SQL issue encountered"
 

--- a/services/api/tests/src/test_admin_new_user.py
+++ b/services/api/tests/src/test_admin_new_user.py
@@ -177,3 +177,5 @@ def test_add_user_sql_exception(mock_pgquery, mock_check_email, mock_check_safe_
         admin_new_user.add_user(admin_new_user_data.request_json_good)
 
     assert str(exc_info.value) == "500 Internal Server Error: SQL issue encountered"
+
+# TODO: add tests for attempted privilege escalation scenario

--- a/services/api/tests/src/test_admin_new_user.py
+++ b/services/api/tests/src/test_admin_new_user.py
@@ -5,7 +5,8 @@ import api.tests.data.admin_new_user_data as admin_new_user_data
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from werkzeug.exceptions import HTTPException
 from api.tests.data import auth_data
-from werkzeug.exceptions import BadRequest, InternalServerError
+from werkzeug.exceptions import BadRequest, InternalServerError, Forbidden
+from copy import deepcopy
 
 user_valid = auth_data.get_request_environ()
 
@@ -178,4 +179,23 @@ def test_add_user_sql_exception(mock_pgquery, mock_check_email, mock_check_safe_
 
     assert str(exc_info.value) == "500 Internal Server Error: SQL issue encountered"
 
-# TODO: add tests for attempted privilege escalation scenario
+@patch("time.time")  # Mock time.time
+@patch("api.src.admin_new_user.check_safe_input")
+@patch("api.src.admin_new_user.check_email")
+def test_add_user_non_super_user_grant_super_user(
+        mock_check_email, mock_check_safe_input, mock_time
+):
+    mock_check_email.return_value = True
+    mock_check_safe_input.return_value = True
+    mock_time.return_value = 1678901234  # Mocked Unix time in seconds
+
+    # Create a non-super user as the requesting user
+    non_super_user = auth_data.get_request_environ_user()
+
+    request_data = deepcopy(admin_new_user_data.request_json_good)
+    request_data["super_user"] = True
+
+    with pytest.raises(Forbidden) as exc_info:
+        admin_new_user.add_user(request_data, non_super_user)
+
+    assert str(exc_info.value) == "403 Forbidden: Only super users can grant super user privileges"

--- a/services/api/tests/src/test_admin_user.py
+++ b/services/api/tests/src/test_admin_user.py
@@ -354,7 +354,7 @@ def test_modify_user_not_found(mock_check_email, mock_check_safe_input, mock_que
 @patch("api.src.admin_user.check_safe_input")
 @patch("api.src.admin_user.admin_new_user.check_email")
 def test_modify_user_non_super_user_grant_super_user(mock_check_email, mock_check_safe_input, mock_query_db):
-    """Test that BadRequest is raised when non-super user tries to grant super user privileges"""
+    """Test that Forbidden is raised when non-super user tries to grant super user privileges"""
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = True
     mock_query_db.return_value = [["0"]]  # Target user is not a super user
@@ -376,7 +376,7 @@ def test_modify_user_non_super_user_grant_super_user(mock_check_email, mock_chec
 @patch("api.src.admin_user.check_safe_input")
 @patch("api.src.admin_user.admin_new_user.check_email")
 def test_modify_user_non_super_user_revoke_super_user(mock_check_email, mock_check_safe_input, mock_query_db):
-    """Test that BadRequest is raised when non-super user tries to revoke super user privileges"""
+    """Test that Forbidden is raised when non-super user tries to revoke super user privileges"""
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = True
     mock_query_db.return_value = [["1"]]  # Target user is a super user

--- a/services/api/tests/src/test_admin_user.py
+++ b/services/api/tests/src/test_admin_user.py
@@ -335,6 +335,65 @@ def test_modify_user_sql_exception(
     assert str(exc_info.value) == "500 Internal Server Error: SQL issue encountered"
 
 
+@patch("api.src.admin_user.pgquery.query_db")
+@patch("api.src.admin_user.check_safe_input")
+@patch("api.src.admin_user.admin_new_user.check_email")
+def test_modify_user_not_found(mock_check_email, mock_check_safe_input, mock_query_db):
+    """Test that BadRequest is raised when user is not found in database"""
+    mock_check_email.return_value = True
+    mock_check_safe_input.return_value = True
+    mock_query_db.return_value = []  # User not found
+
+    with pytest.raises(BadRequest) as exc_info:
+        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good, user_valid)
+
+    assert str(exc_info.value) == "400 Bad Request: User not found"
+
+
+@patch("api.src.admin_user.pgquery.query_db")
+@patch("api.src.admin_user.check_safe_input")
+@patch("api.src.admin_user.admin_new_user.check_email")
+def test_modify_user_non_super_user_grant_super_user(mock_check_email, mock_check_safe_input, mock_query_db):
+    """Test that BadRequest is raised when non-super user tries to grant super user privileges"""
+    mock_check_email.return_value = True
+    mock_check_safe_input.return_value = True
+    mock_query_db.return_value = [["0"]]  # Target user is not a super user
+
+    # Create a non-super user as the requesting user
+    non_super_user = auth_data.get_request_environ_user()
+
+    # Request tries to make the target user a super user
+    request_data = deepcopy(admin_user_data.request_json_good)
+    request_data["super_user"] = True
+
+    with pytest.raises(BadRequest) as exc_info:
+        admin_user.modify_user("test@gmail.com", request_data, non_super_user)
+
+    assert str(exc_info.value) == "400 Bad Request: Only super users can grant super user privileges"
+
+
+@patch("api.src.admin_user.pgquery.query_db")
+@patch("api.src.admin_user.check_safe_input")
+@patch("api.src.admin_user.admin_new_user.check_email")
+def test_modify_user_non_super_user_revoke_super_user(mock_check_email, mock_check_safe_input, mock_query_db):
+    """Test that BadRequest is raised when non-super user tries to revoke super user privileges"""
+    mock_check_email.return_value = True
+    mock_check_safe_input.return_value = True
+    mock_query_db.return_value = [["1"]]  # Target user is a super user
+
+    # Create a non-super user as the requesting user
+    non_super_user = auth_data.get_request_environ_user()
+
+    # Request tries to revoke super user status
+    request_data = deepcopy(admin_user_data.request_json_good)
+    request_data["super_user"] = False
+
+    with pytest.raises(BadRequest) as exc_info:
+        admin_user.modify_user("test@gmail.com", request_data, non_super_user)
+
+    assert str(exc_info.value) == "400 Bad Request: Only super users can revoke super user privileges"
+
+
 # delete_user
 @patch("api.src.admin_user.pgquery.write_db")
 def test_delete_user(mock_write_db):

--- a/services/api/tests/src/test_admin_user.py
+++ b/services/api/tests/src/test_admin_user.py
@@ -4,7 +4,7 @@ import api.src.admin_user as admin_user
 import api.tests.data.admin_user_data as admin_user_data
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from api.tests.data import auth_data
-from werkzeug.exceptions import BadRequest, HTTPException, InternalServerError
+from werkzeug.exceptions import BadRequest, HTTPException, InternalServerError, Forbidden
 from copy import deepcopy
 
 user_valid = auth_data.get_request_environ()
@@ -366,10 +366,10 @@ def test_modify_user_non_super_user_grant_super_user(mock_check_email, mock_chec
     request_data = deepcopy(admin_user_data.request_json_good)
     request_data["super_user"] = True
 
-    with pytest.raises(BadRequest) as exc_info:
+    with pytest.raises(Forbidden) as exc_info:
         admin_user.modify_user("test@gmail.com", request_data, non_super_user)
 
-    assert str(exc_info.value) == "400 Bad Request: Only super users can grant super user privileges"
+    assert str(exc_info.value) == "403 Forbidden: Only super users can grant super user privileges"
 
 
 @patch("api.src.admin_user.pgquery.query_db")
@@ -388,10 +388,10 @@ def test_modify_user_non_super_user_revoke_super_user(mock_check_email, mock_che
     request_data = deepcopy(admin_user_data.request_json_good)
     request_data["super_user"] = False
 
-    with pytest.raises(BadRequest) as exc_info:
+    with pytest.raises(Forbidden) as exc_info:
         admin_user.modify_user("test@gmail.com", request_data, non_super_user)
 
-    assert str(exc_info.value) == "400 Bad Request: Only super users can revoke super user privileges"
+    assert str(exc_info.value) == "403 Forbidden: Only super users can revoke super user privileges"
 
 
 # delete_user

--- a/services/api/tests/src/test_admin_user.py
+++ b/services/api/tests/src/test_admin_user.py
@@ -236,15 +236,18 @@ def test_check_safe_input_bad():
 
 
 # modify_user
+@patch("api.src.admin_user.pgquery.query_db")
 @patch("api.src.admin_user.check_safe_input")
 @patch("api.src.admin_user.admin_new_user.check_email")
 @patch("api.src.admin_user.pgquery.write_db")
-def test_modify_user_success(mock_pgquery, mock_check_email, mock_check_safe_input):
+def test_modify_user_success(mock_write_db, mock_check_email, mock_check_safe_input, mock_query_db):
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = True
+    # Mock the query to get target user's super_user status
+    mock_query_db.return_value = [["1"]]  # User exists and is a super user
     expected_msg = {"message": "User successfully modified"}
     actual_msg = admin_user.modify_user(
-        "test@gmail.com", admin_user_data.request_json_good
+        "test@gmail.com", admin_user_data.request_json_good, user_valid
     )
 
     calls = [
@@ -255,7 +258,7 @@ def test_modify_user_success(mock_pgquery, mock_check_email, mock_check_safe_inp
         call(admin_user_data.modify_org_sql, params=admin_user_data.modify_org_params),
         call(admin_user_data.remove_org_sql, params=admin_user_data.remove_org_params),
     ]
-    mock_pgquery.assert_has_calls(calls)
+    mock_write_db.assert_has_calls(calls)
     assert actual_msg == expected_msg
 
 
@@ -265,7 +268,7 @@ def test_modify_user_email_check_fail(mock_pgquery, mock_check_email):
     mock_check_email.return_value = False
 
     with pytest.raises(BadRequest) as exc_info:
-        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good)
+        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good, user_valid)
 
     assert str(exc_info.value) == "400 Bad Request: Email is not valid"
     mock_pgquery.assert_has_calls([])
@@ -282,6 +285,7 @@ def test_modify_user_check_fail(mock_pgquery, mock_check_email, mock_check_safe_
         admin_user.modify_user(
             "test@gmail.com",
             admin_user_data.request_json_good,
+            user_valid,
         )
 
     assert (
@@ -290,18 +294,20 @@ def test_modify_user_check_fail(mock_pgquery, mock_check_email, mock_check_safe_
     )
 
 
+@patch("api.src.admin_user.pgquery.query_db")
 @patch("api.src.admin_user.check_safe_input")
 @patch("api.src.admin_user.admin_new_user.check_email")
 @patch("api.src.admin_user.pgquery.write_db")
 def test_modify_user_generic_exception(
-    mock_pgquery, mock_check_email, mock_check_safe_input
+    mock_pgquery, mock_check_email, mock_check_safe_input, mock_query_db
 ):
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = True
+    mock_query_db.return_value = [["1"]]  # User exists and is a super user
     mock_pgquery.side_effect = SQLAlchemyError("Test")
 
     with pytest.raises(InternalServerError) as exc_info:
-        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good)
+        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good, user_valid)
 
     assert (
         str(exc_info.value)
@@ -309,20 +315,22 @@ def test_modify_user_generic_exception(
     )
 
 
+@patch("api.src.admin_user.pgquery.query_db")
 @patch("api.src.admin_user.check_safe_input")
 @patch("api.src.admin_user.admin_new_user.check_email")
 @patch("api.src.admin_user.pgquery.write_db")
 def test_modify_user_sql_exception(
-    mock_pgquery, mock_check_email, mock_check_safe_input
+    mock_pgquery, mock_check_email, mock_check_safe_input, mock_query_db
 ):
     mock_check_email.return_value = True
     mock_check_safe_input.return_value = True
+    mock_query_db.return_value = [["1"]]  # User exists and is a super user
     orig = MagicMock()
     orig.args = ({"D": "SQL issue encountered"},)
     mock_pgquery.side_effect = IntegrityError("", {}, orig)
 
     with pytest.raises(InternalServerError) as exc_info:
-        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good)
+        admin_user.modify_user("test@gmail.com", admin_user_data.request_json_good, user_valid)
 
     assert str(exc_info.value) == "500 Internal Server Error: SQL issue encountered"
 

--- a/webapp/src/features/adminAddUser/AdminAddUser.tsx
+++ b/webapp/src/features/adminAddUser/AdminAddUser.tsx
@@ -41,6 +41,7 @@ import {
 } from '@mui/material'
 import { ErrorMessageText } from '../../styles/components/Messages'
 import { SideBarHeader } from '../../styles/components/SideBarHeader'
+import {selectSuperUser} from "../../generalSlices/userSlice";
 
 const AdminAddUser = () => {
   const dispatch: ThunkDispatch<RootState, void, AnyAction> = useDispatch()
@@ -50,6 +51,7 @@ const AdminAddUser = () => {
   const availableRoles = useSelector(selectAvailableRoles)
   const apiData = useSelector(selectApiData)
   const submitAttempt = useSelector(selectSubmitAttempt)
+  const isSuperUser = useSelector(selectSuperUser)
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
   const {
@@ -170,9 +172,11 @@ const AdminAddUser = () => {
             </FormControl>
           </Form.Group>
 
-          <Form.Group controlId="super_user">
-            <Form.Check label=" Super User" type="switch" {...register('super_user')} />
-          </Form.Group>
+          {isSuperUser && (
+            <Form.Group controlId="super_user">
+              <Form.Check label=" Super User" type="switch" {...register('super_user')} />
+            </Form.Group>
+          )}
 
           <Form.Group controlId="organizations">
             <FormControl fullWidth margin="normal">

--- a/webapp/src/features/adminEditUser/AdminEditUser.tsx
+++ b/webapp/src/features/adminEditUser/AdminEditUser.tsx
@@ -16,6 +16,7 @@ import {
   selectLoading,
 } from './adminEditUserSlice'
 import { useSelector, useDispatch } from 'react-redux'
+import { selectSuperUser } from '../../generalSlices/userSlice'
 
 import '../adminRsuTab/Admin.css'
 import 'react-widgets/styles.css'
@@ -48,6 +49,7 @@ const AdminEditUser = () => {
   const submitAttempt = useSelector(selectSubmitAttempt)
   const userTableData = useSelector(selectTableData)
   const loading = useSelector(selectLoading)
+  const isSuperUser = useSelector(selectSuperUser)
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
   const {
@@ -191,9 +193,11 @@ const AdminEditUser = () => {
                 </FormControl>
               </Form.Group>
 
-              <Form.Group controlId="super_user">
-                <Form.Check label=" Super User" className="trebuchet" type="switch" {...register('super_user')} />
-              </Form.Group>
+              {isSuperUser && (
+                <Form.Group controlId="super_user">
+                  <Form.Check label=" Super User" className="trebuchet" type="switch" {...register('super_user')} />
+                </Form.Group>
+              )}
 
               <Form.Group controlId="organizations">
                 <FormControl fullWidth margin="normal">


### PR DESCRIPTION
# PR Details

## Description

This PR strengthens security around user modification by enforcing strict backend permission checks for super user privilege changes, updating the frontend to reflect those permissions, and expanding test coverage.

### Backend security and permission enforcement

- Updated `modify_user` in `admin_user.py` to require the requesting user’s context and enforce that only super users may grant or revoke super user privileges.
- Added validation against the target user’s current super user status.
- Non-super users attempting to change super user privileges now receive a `BadRequest` error.
- Added tests in `test_admin_user.py` covering:
  - Non-super users attempting to modify super user status
  - Attempts to modify a non-existent user

### Frontend user experience

- Updated `AdminEditUser.tsx` to only display the **Super User** toggle for users with super user privileges, using the `selectSuperUser` selector.

### Testing improvements

- Refactored and expanded tests to mock database queries for super user status and cover all relevant permission scenarios.

Together, these changes harden the security model for super user privileges and make the admin UI behavior consistent with backend enforcement.

### Relevant Work Item
This resolves the [Prevent Privilege Escalation to CV Manager Super User](https://dev.azure.com/SOC-OIT/CDOT/_workitems/edit/438684) ticket.

## How Has This Been Tested?

### Before frontend changes

- Created a non-super-user org admin account and logged in
  - Verified the user could not escalate their own privileges
  - Verified the user could not revoke super user privileges from another user

### After frontend changes

- Created a non-super-user org admin account and logged in
  - Verified the **Super User** checkbox is not visible when editing users


## Note
This has not been deployed to CDOT's dev environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
