### PR TITLE
Restore RSU Admin Support for `tim_deposit` and `snmp_monitoring` in Intersection API

### DIFF
--- a/resources/sql_scripts/CVManager_SampleData.sql
+++ b/resources/sql_scripts/CVManager_SampleData.sql
@@ -35,6 +35,10 @@ INSERT INTO public.rsus(
 	VALUES (ST_GeomFromText('POINT(-105.0135030 39.7405654)'), 1, '10.0.0.180', 'E5672', 'E5672', 'I999', 1, 1, 1, 1, 1, 1), 
 	(ST_GeomFromText('POINT(-104.987775 39.981805)'), 2, '10.0.0.78', 'E5321', 'E5321', 'I999', 1, 1, 1, 2, 2, 2);
 
+INSERT INTO public.rsu_options(
+	rsu_id, tim_deposit, snmp_monitoring)
+	VALUES (1, TRUE, TRUE), (2, FALSE, TRUE);
+
 INSERT INTO public.organizations(
 	name)
 	VALUES ('Test Org'), ('Test Org 2');

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -115,6 +115,7 @@ public class RsuController {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = PermissionService.getUsername(auth);
         rsuManagementService.modifyRsu(rsuIp, body, username);
+        rsuManagementService.modifyRsuOption(rsuIp, body);
 
         return ResponseEntity.noContent().build();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/devices/RsuController.java
@@ -34,6 +34,7 @@ import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
 import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
 import us.dot.its.jpo.ode.api.services.PermissionService;
 import us.dot.its.jpo.ode.api.services.RsuManagementService;
+import us.dot.its.jpo.ode.api.services.RsuOptionManagementService;
 
 @Slf4j
 @RestController
@@ -46,6 +47,7 @@ import us.dot.its.jpo.ode.api.services.RsuManagementService;
 @RequiredArgsConstructor
 public class RsuController {
     private final RsuManagementService rsuManagementService;
+    private final RsuOptionManagementService rsuOptionManagementService;
 
     private static final Map<String, String> SORT_FIELD_MAPPING = Map.of(
             "ip", "ipv4Address",
@@ -115,7 +117,7 @@ public class RsuController {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = PermissionService.getUsername(auth);
         rsuManagementService.modifyRsu(rsuIp, body, username);
-        rsuManagementService.modifyRsuOption(rsuIp, body);
+        rsuOptionManagementService.modifyRsuOption(rsuIp, body);
 
         return ResponseEntity.noContent().build();
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -31,6 +31,8 @@ public interface RsuInfoMapper {
     @Mapping(source = "snmpCredential.nickname", target = "snmpCredentialGroup")
     @Mapping(source = "snmpProtocol.nickname", target = "snmpVersionGroup")
     @Mapping(source = "rsuOrganizations", target = "organizations", qualifiedByName = "mapOrganizationNames")
+    @Mapping(source = "rsuOption.timDeposit", target = "timDeposit")
+    @Mapping(source = "rsuOption.snmpMonitoring", target = "snmpMonitoring")
     RsuInfoDto toDto(Rsu rsu);
 
     /**

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/mappers/RsuInfoMapper.java
@@ -2,6 +2,7 @@ package us.dot.its.jpo.ode.api.mappers;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.locationtech.jts.geom.Point;
@@ -71,7 +72,7 @@ public interface RsuInfoMapper {
      * Returns a list of organization name strings
      */
     @Named("mapOrganizationNames")
-    default List<String> mapOrganizationNames(List<RsuOrganization> rsuOrganizations) {
+    default List<String> mapOrganizationNames(Set<RsuOrganization> rsuOrganizations) {
         if (rsuOrganizations == null) {
             return null;
         }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/RsuPatch.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/devices/management/RsuPatch.java
@@ -55,4 +55,10 @@ public class RsuPatch {
 
     @JsonProperty("organizations_to_remove")
     List<String> organizationsToRemove;
+
+    @JsonProperty("tim_deposit")
+    Boolean timDeposit;
+
+    @JsonProperty("snmp_monitoring")
+    Boolean snmpMonitoring;
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/dtos/RsuInfoDto.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/dtos/RsuInfoDto.java
@@ -57,4 +57,10 @@ public class RsuInfoDto implements Serializable {
 
     @JsonProperty("organizations")
     List<String> organizations;
+
+    @JsonProperty("tim_deposit")
+    Boolean timDeposit;
+
+    @JsonProperty("snmp_monitoring")
+    Boolean snmpMonitoring;
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/Rsu.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/Rsu.java
@@ -80,13 +80,13 @@ public class Rsu {
     @OneToOne(mappedBy = "rsu")
     private ConsecutiveFirmwareUpgradeFailure consecutiveFirmwareUpgradeFailure;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<MaxRetryLimitReachedInstance> maxRetryLimitReachedInstances = new LinkedHashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<Ping> pings = new LinkedHashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<RsuIntersection> rsuIntersections = new LinkedHashSet<>();
 
     @OneToOne(mappedBy = "rsu")
@@ -95,9 +95,9 @@ public class Rsu {
     @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<RsuOrganization> rsuOrganizations = new LinkedHashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<ScmsHealth> scmsHealths = new LinkedHashSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
     private Set<SnmpMsgfwdConfig> snmpMsgfwdConfigs = new LinkedHashSet<>();
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/Rsu.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/Rsu.java
@@ -7,14 +7,15 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.net.InetAddress;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.locationtech.jts.geom.Point;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "rsus")
+@Table(name = "rsus", schema = "public")
 public class Rsu {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rsus_id_gen")
@@ -76,7 +77,27 @@ public class Rsu {
     @JoinColumn(name = "target_firmware_version")
     private FirmwareImage targetFirmwareVersion;
 
-    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
-    private List<RsuOrganization> rsuOrganizations;
+    @OneToOne(mappedBy = "rsu")
+    private ConsecutiveFirmwareUpgradeFailure consecutiveFirmwareUpgradeFailure;
 
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<MaxRetryLimitReachedInstance> maxRetryLimitReachedInstances = new LinkedHashSet<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<Ping> pings = new LinkedHashSet<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<RsuIntersection> rsuIntersections = new LinkedHashSet<>();
+
+    @OneToOne(mappedBy = "rsu")
+    private RsuOption rsuOption;
+
+    @OneToMany(mappedBy = "rsu", fetch = FetchType.LAZY)
+    private Set<RsuOrganization> rsuOrganizations = new LinkedHashSet<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<ScmsHealth> scmsHealths = new LinkedHashSet<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<SnmpMsgfwdConfig> snmpMsgfwdConfigs = new LinkedHashSet<>();
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/RsuOption.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/postgres/tables/RsuOption.java
@@ -1,0 +1,33 @@
+package us.dot.its.jpo.ode.api.models.postgres.tables;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "rsu_options", schema = "public")
+public class RsuOption {
+    @Id
+    @Column(name = "rsu_id", nullable = false)
+    private Integer id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "rsu_id", nullable = false)
+    private Rsu rsu;
+
+    @NotNull
+    @ColumnDefault("false")
+    @Column(name = "tim_deposit", nullable = false)
+    private Boolean timDeposit = false;
+
+    @NotNull
+    @ColumnDefault("false")
+    @Column(name = "snmp_monitoring", nullable = false)
+    private Boolean snmpMonitoring = false;
+
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOptionRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOptionRepository.java
@@ -1,14 +1,30 @@
 package us.dot.its.jpo.ode.api.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
 
+import java.net.InetAddress;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RsuOptionRepository extends JpaRepository<RsuOption, Integer> {
     Optional<RsuOption> findByRsuId(Integer rsuId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RsuOption ro WHERE ro.rsu.ipv4Address = :ipv4Address")
+    void removeRsuOptionByIpv4Address(@Param("ipv4Address") InetAddress ipv4Address);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RsuOption ro WHERE ro.rsu.ipv4Address IN :ipv4Addresses")
+    void removeMultipleRsuOptionsByIpv4Address(@Param("ipv4Addresses") List<InetAddress> ipv4Addresses);
 }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOptionRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/repositories/RsuOptionRepository.java
@@ -1,0 +1,14 @@
+package us.dot.its.jpo.ode.api.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
+
+import java.util.Optional;
+
+@Repository
+public interface RsuOptionRepository extends JpaRepository<RsuOption, Integer> {
+    Optional<RsuOption> findByRsuId(Integer rsuId);
+}
+

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -26,6 +26,7 @@ import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
 import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
@@ -35,6 +36,7 @@ import us.dot.its.jpo.ode.api.repositories.UserRepository;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
@@ -54,7 +56,7 @@ public class RsuManagementService {
     private final RsuOrganizationRepository rsuOrganizationRepository;
     private final RsuModelRepository rsuModelRepository;
     private final RsuRepository rsuRepository;
-    // TODO: add RsuOptionsRepository
+    private final RsuOptionRepository rsuOptionRepository;
     private final ScmsHealthRepository scmsHealthRepository;
     private final SnmpCredentialRepository snmpCredentialRepository;
     private final SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
@@ -111,15 +113,18 @@ public class RsuManagementService {
             rsuPatchMapper.updateRsuFromPatch(rsuPatch, existingRsu);
 
             // 3. Update relationships that require database lookups
-            updateRelationships(existingRsu, rsuPatch); // TODO: account for rsu options
+            updateRelationships(existingRsu, rsuPatch);
 
-            // 4. Handle organization additions/removals
+            // 4. Handle RSU options (tim_deposit, snmp_monitoring)
+            updateRsuOptions(existingRsu, rsuPatch);
+
+            // 5. Handle organization additions/removals
             handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);
 
-            // 5. Save updated entity (JPA handles UPDATE SQL)
+            // 6. Save updated entity (JPA handles UPDATE SQL)
             Rsu savedRsu = rsuRepository.save(existingRsu);
 
-            // 6. Return DTO
+            // 7. Return DTO
             return rsuMapper.toDto(savedRsu);
 
         } catch (UnknownHostException e) {
@@ -159,6 +164,34 @@ public class RsuManagementService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                             "SNMP protocol not found: " + patch.getSnmpVersionGroup()));
             rsu.setSnmpProtocol(snmpProtocol);
+        }
+    }
+
+    private void updateRsuOptions(Rsu rsu, RsuPatch patch) {
+        // Only update if at least one option field is provided
+        if (patch.getTimDeposit() != null || patch.getSnmpMonitoring() != null) {
+            // Find or create RsuOption
+            RsuOption rsuOption = rsuOptionRepository.findByRsuId(rsu.getId())
+                    .orElseGet(() -> {
+                        RsuOption newOption = new RsuOption();
+                        newOption.setId(rsu.getId());
+                        newOption.setRsu(rsu);
+                        // Set defaults for new options
+                        newOption.setTimDeposit(false);
+                        newOption.setSnmpMonitoring(false);
+                        return newOption;
+                    });
+
+            // Update only provided fields
+            if (patch.getTimDeposit() != null) {
+                rsuOption.setTimDeposit(patch.getTimDeposit());
+            }
+            if (patch.getSnmpMonitoring() != null) {
+                rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
+            }
+
+            // Save the options
+            rsuOptionRepository.save(rsuOption);
         }
     }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -115,14 +115,14 @@ public class RsuManagementService {
             // 3. Update relationships that require database lookups
             updateRelationships(existingRsu, rsuPatch);
 
-            // 4. Handle RSU options (tim_deposit, snmp_monitoring)
-            updateRsuOptions(existingRsu, rsuPatch);
-
-            // 5. Handle organization additions/removals
+            // 4. Handle organization additions/removals
             handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);
 
-            // 6. Save updated entity (JPA handles UPDATE SQL)
+            // 5. Save updated entity (JPA handles UPDATE SQL)
             Rsu savedRsu = rsuRepository.save(existingRsu);
+
+            // 6. Handle RSU options (tim_deposit, snmp_monitoring) after RSU is saved
+            updateRsuOptions(savedRsu, rsuPatch);
 
             // 7. Return DTO
             return rsuMapper.toDto(savedRsu);
@@ -169,30 +169,32 @@ public class RsuManagementService {
 
     private void updateRsuOptions(Rsu rsu, RsuPatch patch) {
         // Only update if at least one option field is provided
-        if (patch.getTimDeposit() != null || patch.getSnmpMonitoring() != null) {
-            // Find or create RsuOption
-            RsuOption rsuOption = rsuOptionRepository.findByRsuId(rsu.getId())
-                    .orElseGet(() -> {
-                        RsuOption newOption = new RsuOption();
-                        newOption.setId(rsu.getId());
-                        newOption.setRsu(rsu);
-                        // Set defaults for new options
-                        newOption.setTimDeposit(false);
-                        newOption.setSnmpMonitoring(false);
-                        return newOption;
-                    });
-
-            // Update only provided fields
-            if (patch.getTimDeposit() != null) {
-                rsuOption.setTimDeposit(patch.getTimDeposit());
-            }
-            if (patch.getSnmpMonitoring() != null) {
-                rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
-            }
-
-            // Save the options
-            rsuOptionRepository.save(rsuOption);
+        if (patch.getTimDeposit() == null && patch.getSnmpMonitoring() == null) {
+            return;
         }
+        
+        // Find or create RsuOption
+        RsuOption rsuOption = rsuOptionRepository.findById(rsu.getId())
+                .orElseGet(() -> {
+                    RsuOption newOption = new RsuOption();
+                    newOption.setId(rsu.getId());
+                    newOption.setRsu(rsu);
+                    // Set defaults for new options
+                    newOption.setTimDeposit(false);
+                    newOption.setSnmpMonitoring(false);
+                    return newOption;
+                });
+
+        // Update only provided fields
+        if (patch.getTimDeposit() != null) {
+            rsuOption.setTimDeposit(patch.getTimDeposit());
+        }
+        if (patch.getSnmpMonitoring() != null) {
+            rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
+        }
+
+        // Save the options and flush to database immediately
+        rsuOptionRepository.saveAndFlush(rsuOption);
     }
 
     private void handleOrganizationChanges(Rsu rsu, RsuPatch patch, List<String> authorizedOrgs) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -115,16 +115,13 @@ public class RsuManagementService {
             // 3. Update relationships that require database lookups
             updateRelationships(existingRsu, rsuPatch);
 
-            // 4. Handle RSU options (tim_deposit, snmp_monitoring)
-            updateRsuOptions(existingRsu, rsuPatch);
-
-            // 5. Handle organization additions/removals
+            // 4. Handle organization additions/removals
             handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);
 
-            // 6. Save updated entity (JPA handles UPDATE SQL)
+            // 5. Save updated entity (JPA handles UPDATE SQL)
             Rsu savedRsu = rsuRepository.save(existingRsu);
 
-            // 7. Return DTO
+            // 6. Return DTO
             return rsuMapper.toDto(savedRsu);
 
         } catch (UnknownHostException e) {
@@ -164,36 +161,6 @@ public class RsuManagementService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                             "SNMP protocol not found: " + patch.getSnmpVersionGroup()));
             rsu.setSnmpProtocol(snmpProtocol);
-        }
-    }
-
-    private void updateRsuOptions(Rsu rsu, RsuPatch patch) {
-        // Only update if at least one option field is provided
-        if (patch.getTimDeposit() != null || patch.getSnmpMonitoring() != null) {
-            // Find or create RsuOption
-            RsuOption rsuOption = rsuOptionRepository.findByRsuId(rsu.getId())
-                    .orElseGet(() -> {
-                        RsuOption newOption = new RsuOption();
-                        newOption.setId(rsu.getId());
-                        newOption.setRsu(rsu);
-                        // Set the bidirectional association
-                    rsu.setRsuOption(newOption);
-                    // Set defaults for new options
-                        newOption.setTimDeposit(false);
-                        newOption.setSnmpMonitoring(false);
-                        return newOption;
-                    });
-
-            // Update only provided fields
-            if (patch.getTimDeposit() != null) {
-                rsuOption.setTimDeposit(patch.getTimDeposit());
-            }
-            if (patch.getSnmpMonitoring() != null) {
-                rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
-            }
-
-            // Save the options
-            rsuOptionRepository.save(rsuOption);
         }
     }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -3,7 +3,6 @@ package us.dot.its.jpo.ode.api.services;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -38,7 +37,6 @@ import us.dot.its.jpo.ode.api.repositories.UserRepository;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
-import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
@@ -133,89 +131,6 @@ public class RsuManagementService {
             log.error("RSU Modification failed due to unknown host exception: {}", e.getMessage());
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
         }
-    }
-
-    public void modifyRsuOption(String rsuIp, RsuPatch rsuPatch) {
-        log.info("Modifying Rsu option with IP: {}", rsuIp);
-        InetAddress inetAddress = null;
-        try {
-            inetAddress = InetAddress.getByName(rsuIp);
-        } catch (UnknownHostException e) {
-            log.error("RSU Modification failed due to unknown host exception: {}", e.getMessage());
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
-        }
-        Rsu existingRsu = rsuRepository.findByIpv4Address(inetAddress);
-
-        if (existingRsu == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found with IP: " + rsuIp);
-        }
-
-        Boolean proposedTimDepositValue = rsuPatch.getTimDeposit();
-        Boolean proposedSnmpMonitoringValue = rsuPatch.getSnmpMonitoring();
-
-        // If neither field is present, no modification is necessary
-        if (proposedTimDepositValue == null && proposedSnmpMonitoringValue == null) {
-            log.info("Patch does not contain tim_deposit or snmp_monitoring values, no modification necessary");
-            return;
-        }
-
-        Optional<RsuOption> rsuOptionOptional = rsuOptionRepository.findByRsuId(existingRsu.getId());
-        RsuOption rsuOption;
-        boolean isNewOption = false;
-
-        if (rsuOptionOptional.isPresent()) {
-            rsuOption = rsuOptionOptional.get();
-            log.info("Found existing rsu_option for RSU with ID: {}", existingRsu.getId());
-        } else {
-            rsuOption = new RsuOption();
-            rsuOption.setRsu(existingRsu);
-            isNewOption = true;
-            log.info("Creating new rsu_option for RSU with ID: {}", existingRsu.getId());
-        }
-
-        boolean modified = false;
-
-        // Handle tim_deposit field
-        if (proposedTimDepositValue != null) {
-            log.info("Proposed tim_deposit value: {}", proposedTimDepositValue);
-            if (isNewOption || !rsuOption.getTimDeposit().equals(proposedTimDepositValue)) {
-                if (!isNewOption) {
-                    log.info("Current tim_deposit value: {}, changing to: {}",
-                            rsuOption.getTimDeposit(), proposedTimDepositValue);
-                }
-                rsuOption.setTimDeposit(proposedTimDepositValue);
-                modified = true;
-            } else {
-                log.info("tim_deposit value unchanged: {}", proposedTimDepositValue);
-            }
-        }
-
-        // Handle snmp_monitoring field
-        if (proposedSnmpMonitoringValue != null) {
-            log.info("Proposed snmp_monitoring value: {}", proposedSnmpMonitoringValue);
-            if (isNewOption || !rsuOption.getSnmpMonitoring().equals(proposedSnmpMonitoringValue)) {
-                if (!isNewOption) {
-                    log.info("Current snmp_monitoring value: {}, changing to: {}",
-                            rsuOption.getSnmpMonitoring(), proposedSnmpMonitoringValue);
-                }
-                rsuOption.setSnmpMonitoring(proposedSnmpMonitoringValue);
-                modified = true;
-            } else {
-                log.info("snmp_monitoring value unchanged: {}", proposedSnmpMonitoringValue);
-            }
-        }
-
-        if (modified) {
-            log.info("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",
-                    isNewOption ? "new" : "modified",
-                    rsuOption.getTimDeposit(),
-                    rsuOption.getSnmpMonitoring());
-            rsuOptionRepository.save(rsuOption);
-        } else {
-            log.info("No changes detected, skipping save");
-        }
-
-        log.info("Done modifying Rsu option with IP: {}", rsuIp);
     }
 
     private void updateRelationships(Rsu rsu, RsuPatch patch) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -4,7 +4,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -44,7 +43,6 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class RsuManagementService {
 
     private final ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
@@ -99,7 +97,6 @@ public class RsuManagementService {
 
     @Transactional
     public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch, String username) {
-        log.info("Modifying RSU with IP: {}", rsuIp);
         try {
             List<String> authorizedOrgs = permissionService.getQualifiedOrgList(username, "ADMIN");
 
@@ -124,11 +121,9 @@ public class RsuManagementService {
             Rsu savedRsu = rsuRepository.save(existingRsu);
 
             // 6. Return DTO
-            log.info("Done modifying RSU. Returning DTO");
             return rsuMapper.toDto(savedRsu);
 
         } catch (UnknownHostException e) {
-            log.error("RSU Modification failed due to unknown host exception: {}", e.getMessage());
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
         }
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -115,14 +115,14 @@ public class RsuManagementService {
             // 3. Update relationships that require database lookups
             updateRelationships(existingRsu, rsuPatch);
 
-            // 4. Handle organization additions/removals
+            // 4. Handle RSU options (tim_deposit, snmp_monitoring)
+            updateRsuOptions(existingRsu, rsuPatch);
+
+            // 5. Handle organization additions/removals
             handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);
 
-            // 5. Save updated entity (JPA handles UPDATE SQL)
+            // 6. Save updated entity (JPA handles UPDATE SQL)
             Rsu savedRsu = rsuRepository.save(existingRsu);
-
-            // 6. Handle RSU options (tim_deposit, snmp_monitoring) after RSU is saved
-            updateRsuOptions(savedRsu, rsuPatch);
 
             // 7. Return DTO
             return rsuMapper.toDto(savedRsu);
@@ -169,34 +169,32 @@ public class RsuManagementService {
 
     private void updateRsuOptions(Rsu rsu, RsuPatch patch) {
         // Only update if at least one option field is provided
-        if (patch.getTimDeposit() == null && patch.getSnmpMonitoring() == null) {
-            return;
-        }
-        
-        // Find or create RsuOption
-        RsuOption rsuOption = rsuOptionRepository.findById(rsu.getId())
-                .orElseGet(() -> {
-                    RsuOption newOption = new RsuOption();
-                    newOption.setId(rsu.getId());
-                    newOption.setRsu(rsu);
-                    // Set the bidirectional association
+        if (patch.getTimDeposit() != null || patch.getSnmpMonitoring() != null) {
+            // Find or create RsuOption
+            RsuOption rsuOption = rsuOptionRepository.findByRsuId(rsu.getId())
+                    .orElseGet(() -> {
+                        RsuOption newOption = new RsuOption();
+                        newOption.setId(rsu.getId());
+                        newOption.setRsu(rsu);
+                        // Set the bidirectional association
                     rsu.setRsuOption(newOption);
                     // Set defaults for new options
-                    newOption.setTimDeposit(false);
-                    newOption.setSnmpMonitoring(false);
-                    return newOption;
-                });
+                        newOption.setTimDeposit(false);
+                        newOption.setSnmpMonitoring(false);
+                        return newOption;
+                    });
 
-        // Update only provided fields
-        if (patch.getTimDeposit() != null) {
-            rsuOption.setTimDeposit(patch.getTimDeposit());
-        }
-        if (patch.getSnmpMonitoring() != null) {
-            rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
-        }
+            // Update only provided fields
+            if (patch.getTimDeposit() != null) {
+                rsuOption.setTimDeposit(patch.getTimDeposit());
+            }
+            if (patch.getSnmpMonitoring() != null) {
+                rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
+            }
 
-        // Save the options (flush happens at transaction commit)
-        rsuOptionRepository.save(rsuOption);
+            // Save the options
+            rsuOptionRepository.save(rsuOption);
+        }
     }
 
     private void handleOrganizationChanges(Rsu rsu, RsuPatch patch, List<String> authorizedOrgs) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -250,6 +250,7 @@ public class RsuManagementService {
             consecutiveFirmwareUpgradeFailureRepository
                     .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
             maxRetryLimitReachedInstanceRepository.removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
+            rsuOptionRepository.removeRsuOptionByIpv4Address(inetAddress);
 
             // Finally, delete the RSU itself
             rsuRepository.removeRsuByIpv4Address(inetAddress);
@@ -293,6 +294,7 @@ public class RsuManagementService {
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(inetAddresses);
         maxRetryLimitReachedInstanceRepository
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(inetAddresses);
+        rsuOptionRepository.removeMultipleRsuOptionsByIpv4Address(inetAddresses);
         rsuRepository.removeByIpv4AddressIn(inetAddresses);
 
     }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -151,34 +151,71 @@ public class RsuManagementService {
         }
 
         Boolean proposedTimDepositValue = rsuPatch.getTimDeposit();
+        Boolean proposedSnmpMonitoringValue = rsuPatch.getSnmpMonitoring();
+
+        // If neither field is present, no modification is necessary
+        if (proposedTimDepositValue == null && proposedSnmpMonitoringValue == null) {
+            log.info("Patch does not contain tim_deposit or snmp_monitoring values, no modification necessary");
+            return;
+        }
+
+        Optional<RsuOption> rsuOptionOptional = rsuOptionRepository.findByRsuId(existingRsu.getId());
+        RsuOption rsuOption;
+        boolean isNewOption = false;
+
+        if (rsuOptionOptional.isPresent()) {
+            rsuOption = rsuOptionOptional.get();
+            log.info("Found existing rsu_option for RSU with ID: {}", existingRsu.getId());
+        } else {
+            rsuOption = new RsuOption();
+            rsuOption.setRsu(existingRsu);
+            isNewOption = true;
+            log.info("Creating new rsu_option for RSU with ID: {}", existingRsu.getId());
+        }
+
+        boolean modified = false;
+
+        // Handle tim_deposit field
         if (proposedTimDepositValue != null) {
             log.info("Proposed tim_deposit value: {}", proposedTimDepositValue);
-
-            Optional<RsuOption> rsuOption = rsuOptionRepository.findByRsuId(existingRsu.getId());
-            if (rsuOption.isPresent()) {
-                log.info("Current tim_deposit value: {}", rsuOption.get().getTimDeposit());
-
-                if (rsuOption.get().getTimDeposit() != proposedTimDepositValue) {
-                    log.info("Proposed value is different than existing value.");
-                    rsuOption.get().setTimDeposit(proposedTimDepositValue);
-                    log.info("Saving modified rsu option entry with tim_deposit value: {}", rsuOption.get().getTimDeposit());
-                    rsuOptionRepository.save(rsuOption.get());
+            if (isNewOption || !rsuOption.getTimDeposit().equals(proposedTimDepositValue)) {
+                if (!isNewOption) {
+                    log.info("Current tim_deposit value: {}, changing to: {}",
+                            rsuOption.getTimDeposit(), proposedTimDepositValue);
                 }
+                rsuOption.setTimDeposit(proposedTimDepositValue);
+                modified = true;
+            } else {
+                log.info("tim_deposit value unchanged: {}", proposedTimDepositValue);
             }
-            else {
-                log.info("No tim_deposit value found for RSU with ID: {}", existingRsu.getId());
+        }
 
-                RsuOption newRsuOption = new RsuOption();
-                newRsuOption.setRsu(existingRsu);
-                newRsuOption.setTimDeposit(proposedTimDepositValue);
-                log.info("Saving new rsu option entry with tim_deposit value: {}", newRsuOption.getTimDeposit());
-                rsuOptionRepository.save(newRsuOption);
+        // Handle snmp_monitoring field
+        if (proposedSnmpMonitoringValue != null) {
+            log.info("Proposed snmp_monitoring value: {}", proposedSnmpMonitoringValue);
+            if (isNewOption || !rsuOption.getSnmpMonitoring().equals(proposedSnmpMonitoringValue)) {
+                if (!isNewOption) {
+                    log.info("Current snmp_monitoring value: {}, changing to: {}",
+                            rsuOption.getSnmpMonitoring(), proposedSnmpMonitoringValue);
+                }
+                rsuOption.setSnmpMonitoring(proposedSnmpMonitoringValue);
+                modified = true;
+            } else {
+                log.info("snmp_monitoring value unchanged: {}", proposedSnmpMonitoringValue);
             }
-            log.info("Done modifying Rsu option with IP: {}", rsuIp);
         }
-        else {
-            log.info("Patch does not contain tim_deposit value, no modification necessary");
+
+        if (modified) {
+            log.info("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",
+                    isNewOption ? "new" : "modified",
+                    rsuOption.getTimDeposit(),
+                    rsuOption.getSnmpMonitoring());
+            rsuOptionRepository.save(rsuOption);
+        } else {
+            log.info("No changes detected, skipping save");
         }
+
+        log.info("Done modifying Rsu option with IP: {}", rsuIp);
     }
 
     private void updateRelationships(Rsu rsu, RsuPatch patch) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -54,6 +54,7 @@ public class RsuManagementService {
     private final RsuOrganizationRepository rsuOrganizationRepository;
     private final RsuModelRepository rsuModelRepository;
     private final RsuRepository rsuRepository;
+    // TODO: add RsuOptionsRepository
     private final ScmsHealthRepository scmsHealthRepository;
     private final SnmpCredentialRepository snmpCredentialRepository;
     private final SnmpMsgfwdConfigRepository snmpMsgfwdConfigRepository;
@@ -110,7 +111,7 @@ public class RsuManagementService {
             rsuPatchMapper.updateRsuFromPatch(rsuPatch, existingRsu);
 
             // 3. Update relationships that require database lookups
-            updateRelationships(existingRsu, rsuPatch);
+            updateRelationships(existingRsu, rsuPatch); // TODO: account for rsu options
 
             // 4. Handle organization additions/removals
             handleOrganizationChanges(existingRsu, rsuPatch, authorizedOrgs);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -3,7 +3,9 @@ package us.dot.its.jpo.ode.api.services;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Optional;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -44,6 +46,7 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RsuManagementService {
 
     private final ConsecutiveFirmwareUpgradeFailureRepository consecutiveFirmwareUpgradeFailureRepository;
@@ -98,6 +101,7 @@ public class RsuManagementService {
 
     @Transactional
     public RsuInfoDto modifyRsu(String rsuIp, RsuPatch rsuPatch, String username) {
+        log.info("Modifying RSU with IP: {}", rsuIp);
         try {
             List<String> authorizedOrgs = permissionService.getQualifiedOrgList(username, "ADMIN");
 
@@ -122,10 +126,58 @@ public class RsuManagementService {
             Rsu savedRsu = rsuRepository.save(existingRsu);
 
             // 6. Return DTO
+            log.info("Done modifying RSU. Returning DTO");
             return rsuMapper.toDto(savedRsu);
 
         } catch (UnknownHostException e) {
+            log.error("RSU Modification failed due to unknown host exception: {}", e.getMessage());
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
+        }
+    }
+
+    public void modifyRsuOption(String rsuIp, RsuPatch rsuPatch) {
+        log.info("Modifying Rsu option with IP: {}", rsuIp);
+        InetAddress inetAddress = null;
+        try {
+            inetAddress = InetAddress.getByName(rsuIp);
+        } catch (UnknownHostException e) {
+            log.error("RSU Modification failed due to unknown host exception: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
+        }
+        Rsu existingRsu = rsuRepository.findByIpv4Address(inetAddress);
+
+        if (existingRsu == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found with IP: " + rsuIp);
+        }
+
+        Boolean proposedTimDepositValue = rsuPatch.getTimDeposit();
+        if (proposedTimDepositValue != null) {
+            log.info("Proposed tim_deposit value: {}", proposedTimDepositValue);
+
+            Optional<RsuOption> rsuOption = rsuOptionRepository.findByRsuId(existingRsu.getId());
+            if (rsuOption.isPresent()) {
+                log.info("Current tim_deposit value: {}", rsuOption.get().getTimDeposit());
+
+                if (rsuOption.get().getTimDeposit() != proposedTimDepositValue) {
+                    log.info("Proposed value is different than existing value.");
+                    rsuOption.get().setTimDeposit(proposedTimDepositValue);
+                    log.info("Saving modified rsu option entry with tim_deposit value: {}", rsuOption.get().getTimDeposit());
+                    rsuOptionRepository.save(rsuOption.get());
+                }
+            }
+            else {
+                log.info("No tim_deposit value found for RSU with ID: {}", existingRsu.getId());
+
+                RsuOption newRsuOption = new RsuOption();
+                newRsuOption.setRsu(existingRsu);
+                newRsuOption.setTimDeposit(proposedTimDepositValue);
+                log.info("Saving new rsu option entry with tim_deposit value: {}", newRsuOption.getTimDeposit());
+                rsuOptionRepository.save(newRsuOption);
+            }
+            log.info("Done modifying Rsu option with IP: {}", rsuIp);
+        }
+        else {
+            log.info("Patch does not contain tim_deposit value, no modification necessary");
         }
     }
 

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuManagementService.java
@@ -179,6 +179,8 @@ public class RsuManagementService {
                     RsuOption newOption = new RsuOption();
                     newOption.setId(rsu.getId());
                     newOption.setRsu(rsu);
+                    // Set the bidirectional association
+                    rsu.setRsuOption(newOption);
                     // Set defaults for new options
                     newOption.setTimDeposit(false);
                     newOption.setSnmpMonitoring(false);
@@ -193,8 +195,8 @@ public class RsuManagementService {
             rsuOption.setSnmpMonitoring(patch.getSnmpMonitoring());
         }
 
-        // Save the options and flush to database immediately
-        rsuOptionRepository.saveAndFlush(rsuOption);
+        // Save the options (flush happens at transaction commit)
+        rsuOptionRepository.save(rsuOption);
     }
 
     private void handleOrganizationChanges(Rsu rsu, RsuPatch patch, List<String> authorizedOrgs) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
@@ -39,13 +39,13 @@ public class RsuOptionManagementService {
      * @throws ResponseStatusException if the RSU is not found or the IP is invalid
      */
     public void modifyRsuOption(String rsuIp, RsuPatch rsuPatch) {
-        log.info("Modifying Rsu option with IP: {}", rsuIp);
+        log.debug("Modifying Rsu option with IP: {}", rsuIp);
 
         Rsu existingRsu = findRsuByIp(rsuIp);
 
         // Early return if no option fields are provided
         if (rsuPatch.getTimDeposit() == null && rsuPatch.getSnmpMonitoring() == null) {
-            log.info("Patch does not contain tim_deposit or snmp_monitoring values, no modification necessary");
+            log.trace("Patch does not contain tim_deposit or snmp_monitoring values, no modification necessary");
             return;
         }
 
@@ -56,7 +56,7 @@ public class RsuOptionManagementService {
 
         saveRsuOptionIfModified(rsuOption, modified, isNewOption);
 
-        log.info("Done modifying Rsu option with IP: {}", rsuIp);
+        log.debug("Done modifying Rsu option with IP: {}", rsuIp);
     }
 
     /**
@@ -92,10 +92,10 @@ public class RsuOptionManagementService {
         Optional<RsuOption> rsuOptionOptional = rsuOptionRepository.findByRsuId(rsu.getId());
 
         if (rsuOptionOptional.isPresent()) {
-            log.info("Found existing rsu_option for RSU with ID: {}", rsu.getId());
+            log.trace("Found existing rsu_option for RSU with ID: {}", rsu.getId());
             return rsuOptionOptional.get();
         } else {
-            log.info("Creating new rsu_option for RSU with ID: {}", rsu.getId());
+            log.trace("Creating new rsu_option for RSU with ID: {}", rsu.getId());
             RsuOption newOption = new RsuOption();
             newOption.setRsu(rsu);
             return newOption;
@@ -132,17 +132,17 @@ public class RsuOptionManagementService {
             return false;
         }
 
-        log.info("Proposed tim_deposit value: {}", proposedValue);
+        log.trace("Proposed tim_deposit value: {}", proposedValue);
 
         if (isNewOption || !rsuOption.getTimDeposit().equals(proposedValue)) {
             if (!isNewOption) {
-                log.info("Current tim_deposit value: {}, changing to: {}",
+                log.trace("Current tim_deposit value: {}, changing to: {}",
                         rsuOption.getTimDeposit(), proposedValue);
             }
             rsuOption.setTimDeposit(proposedValue);
             return true;
         } else {
-            log.info("tim_deposit value unchanged: {}", proposedValue);
+            log.trace("tim_deposit value unchanged: {}", proposedValue);
             return false;
         }
     }
@@ -160,17 +160,17 @@ public class RsuOptionManagementService {
             return false;
         }
 
-        log.info("Proposed snmp_monitoring value: {}", proposedValue);
+        log.trace("Proposed snmp_monitoring value: {}", proposedValue);
 
         if (isNewOption || !rsuOption.getSnmpMonitoring().equals(proposedValue)) {
             if (!isNewOption) {
-                log.info("Current snmp_monitoring value: {}, changing to: {}",
+                log.trace("Current snmp_monitoring value: {}, changing to: {}",
                         rsuOption.getSnmpMonitoring(), proposedValue);
             }
             rsuOption.setSnmpMonitoring(proposedValue);
             return true;
         } else {
-            log.info("snmp_monitoring value unchanged: {}", proposedValue);
+            log.trace("snmp_monitoring value unchanged: {}", proposedValue);
             return false;
         }
     }
@@ -184,13 +184,13 @@ public class RsuOptionManagementService {
      */
     private void saveRsuOptionIfModified(RsuOption rsuOption, boolean modified, boolean isNewOption) {
         if (modified) {
-            log.info("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",
+            log.debug("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",
                     isNewOption ? "new" : "modified",
                     rsuOption.getTimDeposit(),
                     rsuOption.getSnmpMonitoring());
             rsuOptionRepository.save(rsuOption);
         } else {
-            log.info("No changes detected, skipping save");
+            log.trace("No changes detected, skipping save");
         }
     }
 }

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
@@ -102,7 +102,7 @@ public class RsuOptionManagementService {
 
         log.trace("Proposed tim_deposit value: {}", proposedValue);
 
-        if (isNewOption || !rsuOption.getTimDeposit().equals(proposedValue)) {
+        if (isNewOption || !proposedValue.equals(rsuOption.getTimDeposit())) {
             if (!isNewOption) {
                 log.trace("Current tim_deposit value: {}, changing to: {}",
                         rsuOption.getTimDeposit(), proposedValue);
@@ -123,7 +123,7 @@ public class RsuOptionManagementService {
 
         log.trace("Proposed snmp_monitoring value: {}", proposedValue);
 
-        if (isNewOption || !rsuOption.getSnmpMonitoring().equals(proposedValue)) {
+        if (isNewOption || !proposedValue.equals(rsuOption.getSnmpMonitoring())) {
             if (!isNewOption) {
                 log.trace("Current snmp_monitoring value: {}, changing to: {}",
                         rsuOption.getSnmpMonitoring(), proposedValue);

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
@@ -1,0 +1,197 @@
+package us.dot.its.jpo.ode.api.services;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
+import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+
+/**
+ * Service for managing RSU options including TIM deposit and SNMP monitoring settings.
+ * This service handles the lifecycle of RSU option configurations independently from
+ * core RSU management operations.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RsuOptionManagementService {
+
+    private final RsuRepository rsuRepository;
+    private final RsuOptionRepository rsuOptionRepository;
+
+    /**
+     * Modifies RSU options (tim_deposit and snmp_monitoring) for a given RSU.
+     * Creates a new RsuOption entry if one doesn't exist, or updates the existing one.
+     * Only saves to the database if actual changes are detected.
+     *
+     * @param rsuIp The IPv4 address of the RSU
+     * @param rsuPatch The patch object containing the new option values
+     * @throws ResponseStatusException if the RSU is not found or the IP is invalid
+     */
+    public void modifyRsuOption(String rsuIp, RsuPatch rsuPatch) {
+        log.info("Modifying Rsu option with IP: {}", rsuIp);
+
+        Rsu existingRsu = findRsuByIp(rsuIp);
+
+        // Early return if no option fields are provided
+        if (rsuPatch.getTimDeposit() == null && rsuPatch.getSnmpMonitoring() == null) {
+            log.info("Patch does not contain tim_deposit or snmp_monitoring values, no modification necessary");
+            return;
+        }
+
+        RsuOption rsuOption = getOrCreateRsuOption(existingRsu);
+        boolean isNewOption = rsuOption.getId() == null;
+
+        boolean modified = updateRsuOptionFields(rsuOption, rsuPatch, isNewOption);
+
+        saveRsuOptionIfModified(rsuOption, modified, isNewOption);
+
+        log.info("Done modifying Rsu option with IP: {}", rsuIp);
+    }
+
+    /**
+     * Finds an RSU by its IPv4 address.
+     *
+     * @param rsuIp The IPv4 address string
+     * @return The RSU entity
+     * @throws ResponseStatusException if the IP is invalid or RSU not found
+     */
+    private Rsu findRsuByIp(String rsuIp) {
+        try {
+            InetAddress inetAddress = InetAddress.getByName(rsuIp);
+            Rsu rsu = rsuRepository.findByIpv4Address(inetAddress);
+
+            if (rsu == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RSU not found with IP: " + rsuIp);
+            }
+
+            return rsu;
+        } catch (UnknownHostException e) {
+            log.error("Invalid IP address: {}", rsuIp);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid IP address: " + rsuIp, e);
+        }
+    }
+
+    /**
+     * Retrieves an existing RsuOption for the given RSU or creates a new one if it doesn't exist.
+     *
+     * @param rsu The RSU entity
+     * @return The existing or newly created RsuOption
+     */
+    private RsuOption getOrCreateRsuOption(Rsu rsu) {
+        Optional<RsuOption> rsuOptionOptional = rsuOptionRepository.findByRsuId(rsu.getId());
+
+        if (rsuOptionOptional.isPresent()) {
+            log.info("Found existing rsu_option for RSU with ID: {}", rsu.getId());
+            return rsuOptionOptional.get();
+        } else {
+            log.info("Creating new rsu_option for RSU with ID: {}", rsu.getId());
+            RsuOption newOption = new RsuOption();
+            newOption.setRsu(rsu);
+            return newOption;
+        }
+    }
+
+    /**
+     * Updates the RSU option fields based on the patch values.
+     *
+     * @param rsuOption The RsuOption to update
+     * @param rsuPatch The patch containing new values
+     * @param isNewOption Whether this is a new option being created
+     * @return true if any changes were made, false otherwise
+     */
+    private boolean updateRsuOptionFields(RsuOption rsuOption, RsuPatch rsuPatch, boolean isNewOption) {
+        boolean modified = false;
+
+        modified |= updateTimDepositField(rsuOption, rsuPatch.getTimDeposit(), isNewOption);
+        modified |= updateSnmpMonitoringField(rsuOption, rsuPatch.getSnmpMonitoring(), isNewOption);
+
+        return modified;
+    }
+
+    /**
+     * Updates the tim_deposit field if a new value is provided and different from current.
+     *
+     * @param rsuOption The RsuOption to update
+     * @param proposedValue The proposed new value (may be null)
+     * @param isNewOption Whether this is a new option being created
+     * @return true if the field was modified, false otherwise
+     */
+    private boolean updateTimDepositField(RsuOption rsuOption, Boolean proposedValue, boolean isNewOption) {
+        if (proposedValue == null) {
+            return false;
+        }
+
+        log.info("Proposed tim_deposit value: {}", proposedValue);
+
+        if (isNewOption || !rsuOption.getTimDeposit().equals(proposedValue)) {
+            if (!isNewOption) {
+                log.info("Current tim_deposit value: {}, changing to: {}",
+                        rsuOption.getTimDeposit(), proposedValue);
+            }
+            rsuOption.setTimDeposit(proposedValue);
+            return true;
+        } else {
+            log.info("tim_deposit value unchanged: {}", proposedValue);
+            return false;
+        }
+    }
+
+    /**
+     * Updates the snmp_monitoring field if a new value is provided and different from current.
+     *
+     * @param rsuOption The RsuOption to update
+     * @param proposedValue The proposed new value (may be null)
+     * @param isNewOption Whether this is a new option being created
+     * @return true if the field was modified, false otherwise
+     */
+    private boolean updateSnmpMonitoringField(RsuOption rsuOption, Boolean proposedValue, boolean isNewOption) {
+        if (proposedValue == null) {
+            return false;
+        }
+
+        log.info("Proposed snmp_monitoring value: {}", proposedValue);
+
+        if (isNewOption || !rsuOption.getSnmpMonitoring().equals(proposedValue)) {
+            if (!isNewOption) {
+                log.info("Current snmp_monitoring value: {}, changing to: {}",
+                        rsuOption.getSnmpMonitoring(), proposedValue);
+            }
+            rsuOption.setSnmpMonitoring(proposedValue);
+            return true;
+        } else {
+            log.info("snmp_monitoring value unchanged: {}", proposedValue);
+            return false;
+        }
+    }
+
+    /**
+     * Saves the RsuOption to the database if modifications were detected.
+     *
+     * @param rsuOption The RsuOption to save
+     * @param modified Whether any modifications were made
+     * @param isNewOption Whether this is a new option being created
+     */
+    private void saveRsuOptionIfModified(RsuOption rsuOption, boolean modified, boolean isNewOption) {
+        if (modified) {
+            log.info("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",
+                    isNewOption ? "new" : "modified",
+                    rsuOption.getTimDeposit(),
+                    rsuOption.getSnmpMonitoring());
+            rsuOptionRepository.save(rsuOption);
+        } else {
+            log.info("No changes detected, skipping save");
+        }
+    }
+}
+

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementService.java
@@ -17,9 +17,7 @@ import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 
 /**
- * Service for managing RSU options including TIM deposit and SNMP monitoring settings.
- * This service handles the lifecycle of RSU option configurations independently from
- * core RSU management operations.
+ * Service for managing RSU options (TIM deposit and SNMP monitoring).
  */
 @Service
 @RequiredArgsConstructor
@@ -30,13 +28,8 @@ public class RsuOptionManagementService {
     private final RsuOptionRepository rsuOptionRepository;
 
     /**
-     * Modifies RSU options (tim_deposit and snmp_monitoring) for a given RSU.
-     * Creates a new RsuOption entry if one doesn't exist, or updates the existing one.
-     * Only saves to the database if actual changes are detected.
-     *
-     * @param rsuIp The IPv4 address of the RSU
-     * @param rsuPatch The patch object containing the new option values
-     * @throws ResponseStatusException if the RSU is not found or the IP is invalid
+     * Modifies RSU options for the given RSU IP. Creates a new entry if needed.
+     * Only saves if changes are detected.
      */
     public void modifyRsuOption(String rsuIp, RsuPatch rsuPatch) {
         log.debug("Modifying Rsu option with IP: {}", rsuIp);
@@ -59,13 +52,7 @@ public class RsuOptionManagementService {
         log.debug("Done modifying Rsu option with IP: {}", rsuIp);
     }
 
-    /**
-     * Finds an RSU by its IPv4 address.
-     *
-     * @param rsuIp The IPv4 address string
-     * @return The RSU entity
-     * @throws ResponseStatusException if the IP is invalid or RSU not found
-     */
+    // Finds RSU by IP address or throws NOT_FOUND/BAD_REQUEST
     private Rsu findRsuByIp(String rsuIp) {
         try {
             InetAddress inetAddress = InetAddress.getByName(rsuIp);
@@ -82,12 +69,7 @@ public class RsuOptionManagementService {
         }
     }
 
-    /**
-     * Retrieves an existing RsuOption for the given RSU or creates a new one if it doesn't exist.
-     *
-     * @param rsu The RSU entity
-     * @return The existing or newly created RsuOption
-     */
+    // Gets existing RsuOption or creates a new one
     private RsuOption getOrCreateRsuOption(Rsu rsu) {
         Optional<RsuOption> rsuOptionOptional = rsuOptionRepository.findByRsuId(rsu.getId());
 
@@ -102,14 +84,7 @@ public class RsuOptionManagementService {
         }
     }
 
-    /**
-     * Updates the RSU option fields based on the patch values.
-     *
-     * @param rsuOption The RsuOption to update
-     * @param rsuPatch The patch containing new values
-     * @param isNewOption Whether this is a new option being created
-     * @return true if any changes were made, false otherwise
-     */
+    // Updates option fields from patch, returns true if any changes made
     private boolean updateRsuOptionFields(RsuOption rsuOption, RsuPatch rsuPatch, boolean isNewOption) {
         boolean modified = false;
 
@@ -119,14 +94,7 @@ public class RsuOptionManagementService {
         return modified;
     }
 
-    /**
-     * Updates the tim_deposit field if a new value is provided and different from current.
-     *
-     * @param rsuOption The RsuOption to update
-     * @param proposedValue The proposed new value (may be null)
-     * @param isNewOption Whether this is a new option being created
-     * @return true if the field was modified, false otherwise
-     */
+    // Updates tim_deposit if provided and different from current
     private boolean updateTimDepositField(RsuOption rsuOption, Boolean proposedValue, boolean isNewOption) {
         if (proposedValue == null) {
             return false;
@@ -147,14 +115,7 @@ public class RsuOptionManagementService {
         }
     }
 
-    /**
-     * Updates the snmp_monitoring field if a new value is provided and different from current.
-     *
-     * @param rsuOption The RsuOption to update
-     * @param proposedValue The proposed new value (may be null)
-     * @param isNewOption Whether this is a new option being created
-     * @return true if the field was modified, false otherwise
-     */
+    // Updates snmp_monitoring if provided and different from current
     private boolean updateSnmpMonitoringField(RsuOption rsuOption, Boolean proposedValue, boolean isNewOption) {
         if (proposedValue == null) {
             return false;
@@ -175,13 +136,7 @@ public class RsuOptionManagementService {
         }
     }
 
-    /**
-     * Saves the RsuOption to the database if modifications were detected.
-     *
-     * @param rsuOption The RsuOption to save
-     * @param modified Whether any modifications were made
-     * @param isNewOption Whether this is a new option being created
-     */
+    // Saves to database only if modifications were detected
     private void saveRsuOptionIfModified(RsuOption rsuOption, boolean modified, boolean isNewOption) {
         if (modified) {
             log.debug("Saving {} rsu_option entry - tim_deposit: {}, snmp_monitoring: {}",

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
@@ -63,7 +63,9 @@ class RsuControllerTest {
                 "ssh-group-1",
                 "snmp-group-1",
                 "v3",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         RsuInfoDto rsu2 = new RsuInfoDto(
                 "192.168.1.101",
@@ -76,7 +78,9 @@ class RsuControllerTest {
                 "ssh-group-2",
                 "snmp-group-2",
                 "v2c",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         List<RsuInfoDto> rsuList = Arrays.asList(rsu1, rsu2);
         Page<RsuInfoDto> rsuPage = new PageImpl<>(rsuList, pageable, 2);
@@ -127,7 +131,9 @@ class RsuControllerTest {
                 "ssh-group",
                 "snmp-group",
                 "v3",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         Page<RsuInfoDto> rsuPage = new PageImpl<>(List.of(rsu1), pageable, 1);
 
@@ -159,7 +165,9 @@ class RsuControllerTest {
                 "ssh-group-1",
                 "snmp-group-1",
                 "v3",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         when(rsuManagementService.getRsuInfo(rsuIp)).thenReturn(rsuInfo);
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/devices/RsuControllerTest.java
@@ -22,6 +22,7 @@ import us.dot.its.jpo.ode.api.models.postgres.dtos.RsuInfoDto;
 import us.dot.its.jpo.ode.api.models.SimplePosition;
 import us.dot.its.jpo.ode.api.services.PermissionService;
 import us.dot.its.jpo.ode.api.services.RsuManagementService;
+import us.dot.its.jpo.ode.api.services.RsuOptionManagementService;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +36,9 @@ class RsuControllerTest {
 
     @Mock
     private RsuManagementService rsuManagementService;
+
+    @Mock
+    private RsuOptionManagementService rsuOptionManagementService;
 
     @Mock
     private PermissionService permissionService;
@@ -255,6 +259,7 @@ class RsuControllerTest {
         String username = "testuser@example.com";
 
         doReturn(null).when(rsuManagementService).modifyRsu(rsuIp, patch, username);
+        doNothing().when(rsuOptionManagementService).modifyRsuOption(rsuIp, patch);
 
         try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
             mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
@@ -265,6 +270,7 @@ class RsuControllerTest {
             assertNull(result.getBody());
 
             verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+            verify(rsuOptionManagementService).modifyRsuOption(rsuIp, patch);
         }
     }
 
@@ -279,13 +285,14 @@ class RsuControllerTest {
 
         try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
             mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
-        assertThrows(
-                ResponseStatusException.class,
-                        () -> rsuController.modifyRsu(rsuIp, patch));
+            assertThrows(
+                    ResponseStatusException.class,
+                    () -> rsuController.modifyRsu(rsuIp, patch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+            verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+            verify(rsuOptionManagementService, never()).modifyRsuOption(any(), any());
+        }
     }
-}
 
     @Test
     void testModifyRsu_InvalidPatch() {
@@ -299,13 +306,14 @@ class RsuControllerTest {
 
         try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
             mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
-        assertThrows(
-                ResponseStatusException.class,
-                        () -> rsuController.modifyRsu(rsuIp, invalidPatch));
+            assertThrows(
+                    ResponseStatusException.class,
+                    () -> rsuController.modifyRsu(rsuIp, invalidPatch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch, username);
+            verify(rsuManagementService).modifyRsu(rsuIp, invalidPatch, username);
+            verify(rsuOptionManagementService, never()).modifyRsuOption(any(), any());
+        }
     }
-}
 
     @Test
     void testModifyRsu_ServiceException() {
@@ -318,13 +326,14 @@ class RsuControllerTest {
 
         try (MockedStatic<PermissionService> mockedStatic = Mockito.mockStatic(PermissionService.class)) {
             mockedStatic.when(() -> PermissionService.getUsername(any())).thenReturn(username);
-        assertThrows(
-                RuntimeException.class,
-                () -> rsuController.modifyRsu(rsuIp, patch));
+            assertThrows(
+                    RuntimeException.class,
+                    () -> rsuController.modifyRsu(rsuIp, patch));
 
-        verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+            verify(rsuManagementService).modifyRsu(rsuIp, patch, username);
+            verify(rsuOptionManagementService, never()).modifyRsuOption(any(), any());
+        }
     }
-}
 
     // ==================== DELETE SINGLE RSU TESTS ====================
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -22,6 +22,7 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
@@ -33,6 +34,7 @@ import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
 import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
@@ -85,6 +87,9 @@ class RsuManagementServiceTest {
 
     @Mock
     private RsuRepository rsuRepository;
+
+    @Mock
+    private RsuOptionRepository rsuOptionRepository;
 
     @Mock
     private ScmsHealthRepository scmsHealthRepository;
@@ -907,6 +912,173 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
 
     verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
 }
+
+    // ==================== RSU OPTIONS TESTS ====================
+
+    @Test
+    void testModifyRsu_CreateNewRsuOptions_BothFields() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+        patch.setSnmpMonitoring(true);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(1);
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new HashSet<>());
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findById(1)).thenReturn(Optional.empty());
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
+
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+        // Verify that RsuOption was created and saved with correct values
+        verify(rsuOptionRepository).findById(1);
+        verify(rsuOptionRepository).save(any(RsuOption.class));
+
+        // Verify the bidirectional association was set
+        assertNotNull(existingRsu.getRsuOption());
+        assertEquals(true, existingRsu.getRsuOption().getTimDeposit());
+        assertEquals(true, existingRsu.getRsuOption().getSnmpMonitoring());
+    }
+
+    @Test
+    void testModifyRsu_CreateNewRsuOptions_SingleField() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+        // snmpMonitoring is not set
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(2);
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new HashSet<>());
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findById(2)).thenReturn(Optional.empty());
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
+
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+        // Verify that RsuOption was created with default for unset field
+        verify(rsuOptionRepository).findById(2);
+        verify(rsuOptionRepository).save(any(RsuOption.class));
+
+        // Verify the bidirectional association was set and defaults applied
+        assertNotNull(existingRsu.getRsuOption());
+        assertEquals(true, existingRsu.getRsuOption().getTimDeposit());
+        assertEquals(false, existingRsu.getRsuOption().getSnmpMonitoring()); // default value
+    }
+
+    @Test
+    void testModifyRsu_UpdateExistingRsuOptions_BothFields() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(false);
+        patch.setSnmpMonitoring(true);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(3);
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new HashSet<>());
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(3);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // old value
+        existingOption.setSnmpMonitoring(false); // old value
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findById(3)).thenReturn(Optional.of(existingOption));
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
+
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+        // Verify that existing RsuOption was updated
+        verify(rsuOptionRepository).findById(3);
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(false, existingOption.getTimDeposit());
+        assertEquals(true, existingOption.getSnmpMonitoring());
+    }
+
+    @Test
+    void testModifyRsu_UpdateExistingRsuOptions_PartialUpdate() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setSnmpMonitoring(true);
+        // timDeposit is not set, should not change existing value
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(4);
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new HashSet<>());
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(4);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // should remain unchanged
+        existingOption.setSnmpMonitoring(false); // should be updated
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findById(4)).thenReturn(Optional.of(existingOption));
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
+
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+        // Verify that only snmpMonitoring was updated
+        verify(rsuOptionRepository).findById(4);
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(true, existingOption.getTimDeposit()); // unchanged
+        assertEquals(true, existingOption.getSnmpMonitoring()); // updated
+    }
+
+    @Test
+    void testModifyRsu_NoRsuOptionsProvided_SkipsUpdate() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+        String username = "testuser@example.com";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setMilepost(150.0);
+        // No timDeposit or snmpMonitoring set
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(5);
+        existingRsu.setIpv4Address(inetAddress);
+        existingRsu.setRsuOrganizations(new HashSet<>());
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
+        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
+        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
+
+        rsuManagementService.modifyRsu(rsuIp, patch, username);
+
+        // Verify that RsuOption repository was never accessed
+        verify(rsuOptionRepository, never()).findById(any());
+        verify(rsuOptionRepository, never()).save(any());
+    }
 
 
     // ==================== DELETE RSU TESTS ====================

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -129,7 +129,9 @@ class RsuManagementServiceTest {
                 "ssh-group",
                 "snmp-group",
                 "v3",
-                Arrays.asList("Org1", "Org2"));
+                Arrays.asList("Org1", "Org2"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(mockRsu);
         when(rsuMapper.toDto(mockRsu)).thenReturn(mockDto);
@@ -194,7 +196,9 @@ class RsuManagementServiceTest {
                 "ssh1",
                 "snmp1",
                 "v3",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
         RsuInfoDto dto2 = new RsuInfoDto(
                 "192.168.1.101",
                 new SimplePosition(39.7400, -105.0850),
@@ -206,7 +210,9 @@ class RsuManagementServiceTest {
                 "ssh2",
                 "snmp2",
                 "v2c",
-                Arrays.asList("TestOrg"));
+                Arrays.asList("TestOrg"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         when(rsuRepository.findAllByOrganization(orgName, pageable)).thenReturn(rsuPage);
         when(rsuMapper.toDto(rsu1)).thenReturn(dto1);
@@ -337,7 +343,7 @@ class RsuManagementServiceTest {
         existingRsu.setIpv4Address(inetAddress);
         existingRsu.setMilepost(123.4);
         existingRsu.setPrimaryRoute("I-25");
-        existingRsu.setRsuOrganizations(new ArrayList<>());
+        existingRsu.setRsuOrganizations(new HashSet<>());
 
         RsuInfoDto expectedDto = new RsuInfoDto(
                 rsuIp,
@@ -350,7 +356,9 @@ class RsuManagementServiceTest {
                 "ssh-group",
                 "snmp-group",
                 "v3",
-                Arrays.asList("Org1"));
+                Arrays.asList("Org1"),
+                Boolean.TRUE,
+                Boolean.TRUE);
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
         doNothing().when(rsuPatchMapper).updateRsuFromPatch(patch, existingRsu);
@@ -380,7 +388,7 @@ class RsuManagementServiceTest {
 
         Rsu existingRsu = new Rsu();
         existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new ArrayList<>());
+        existingRsu.setRsuOrganizations(new HashSet<>());
 
         RsuModel newModel = new RsuModel();
         newModel.setName("RSU-2X");
@@ -411,7 +419,7 @@ class RsuManagementServiceTest {
 
         Rsu existingRsu = new Rsu();
         existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new ArrayList<>());
+        existingRsu.setRsuOrganizations(new HashSet<>());
 
         RsuCredential sshCred = new RsuCredential();
         SnmpCredential snmpCred = new SnmpCredential();
@@ -473,7 +481,7 @@ class RsuManagementServiceTest {
         patch.setModel("Unknown Model");
 
         Rsu existingRsu = new Rsu();
-        existingRsu.setRsuOrganizations(new ArrayList<>());
+        existingRsu.setRsuOrganizations(new HashSet<>());
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
         when(rsuModelRepository.findByNameAndManufacturerName(anyString(), anyString()))
@@ -496,7 +504,7 @@ class RsuManagementServiceTest {
         patch.setModel("InvalidFormat");
 
         Rsu existingRsu = new Rsu();
-        existingRsu.setRsuOrganizations(new ArrayList<>());
+        existingRsu.setRsuOrganizations(new HashSet<>());
 
         when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
 
@@ -522,7 +530,7 @@ class RsuManagementServiceTest {
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     Organization org1 = new Organization();
     org1.setName("Org1");
@@ -560,7 +568,7 @@ void testHandleOrganizationChanges_AddOrganizations_AlreadyExists() throws Unkno
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1");
 
@@ -588,7 +596,7 @@ void testHandleOrganizationChanges_AddOrganizations_Unauthorized() throws Unknow
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1", "Org2");
 
@@ -616,7 +624,7 @@ void testHandleOrganizationChanges_AddOrganizations_OrganizationNotFound() throw
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("NonExistentOrg");
 
@@ -646,7 +654,7 @@ void testHandleOrganizationChanges_RemoveOrganizations_Success() throws UnknownH
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     Organization org1 = new Organization();
     org1.setName("Org1");
@@ -689,7 +697,7 @@ void testHandleOrganizationChanges_RemoveOrganizations_NotFound() throws Unknown
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1");
 
@@ -716,7 +724,7 @@ void testHandleOrganizationChanges_RemoveOrganizations_Unauthorized() throws Unk
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1", "Org2");
 
@@ -745,7 +753,7 @@ void testHandleOrganizationChanges_AddAndRemoveOrganizations() throws UnknownHos
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     Organization newOrg = new Organization();
     newOrg.setName("NewOrg");
@@ -785,7 +793,7 @@ void testHandleOrganizationChanges_AddMultipleOrganizations_PartiallyUnauthorize
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1");
 
@@ -813,7 +821,7 @@ void testHandleOrganizationChanges_RemoveMultipleOrganizations_PartiallyUnauthor
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     List<String> authorizedOrgs = Arrays.asList("Org1");
 
@@ -841,7 +849,7 @@ void testHandleOrganizationChanges_NoOrganizationChanges() throws UnknownHostExc
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
     when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
@@ -865,7 +873,7 @@ void testHandleOrganizationChanges_EmptyAddList() throws UnknownHostException {
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
     when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
@@ -888,7 +896,7 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
 
     Rsu existingRsu = new Rsu();
     existingRsu.setIpv4Address(inetAddress);
-    existingRsu.setRsuOrganizations(new ArrayList<>());
+    existingRsu.setRsuOrganizations(new HashSet<>());
 
     when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
     when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -42,7 +42,7 @@ import us.dot.its.jpo.ode.api.repositories.UserRepository;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -33,6 +33,7 @@ import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
 import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
@@ -86,6 +87,8 @@ class RsuManagementServiceTest {
     @Mock
     private RsuRepository rsuRepository;
 
+    @Mock
+    private RsuOptionRepository rsuOptionRepository;
 
     @Mock
     private ScmsHealthRepository scmsHealthRepository;
@@ -928,6 +931,7 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
                 .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
         doNothing().when(maxRetryLimitReachedInstanceRepository)
                 .removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
+        doNothing().when(rsuOptionRepository).removeRsuOptionByIpv4Address(inetAddress);
 
         rsuManagementService.deleteRsuByIpv4Address(rsuIp);
 
@@ -939,6 +943,7 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
         verify(consecutiveFirmwareUpgradeFailureRepository)
                 .removeConsecutiveFirmwareUpgradeFailureByIpv4Address(inetAddress);
         verify(maxRetryLimitReachedInstanceRepository).removeMaxRetryLimitReachedInstanceByIpv4Address(inetAddress);
+        verify(rsuOptionRepository).removeRsuOptionByIpv4Address(inetAddress);
         verify(rsuRepository).removeRsuByIpv4Address(inetAddress);
     }
 
@@ -970,6 +975,7 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
         doNothing().when(maxRetryLimitReachedInstanceRepository)
                 .removeMultipleMaxRetryLimitReachedInstancesByIpv4Address(anyList());
+        doNothing().when(rsuOptionRepository).removeMultipleRsuOptionsByIpv4Address(anyList());
         doNothing().when(rsuRepository).removeByIpv4AddressIn(anyList());
 
         rsuManagementService.deleteMultipleRsusByIpv4Address(rsuIps);
@@ -983,6 +989,7 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
         verify(consecutiveFirmwareUpgradeFailureRepository)
                 .removeMultipleConsecutiveFirmwareUpgradeFailuresByIpv4Address(anyList());
         verify(snmpMsgfwdConfigRepository).removeMultipleSnmpMsgfwdConfigByIpv4Address(anyList());
+        verify(rsuOptionRepository).removeMultipleRsuOptionsByIpv4Address(anyList());
         verify(rsuRepository).removeByIpv4AddressIn(anyList());
     }
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuManagementServiceTest.java
@@ -22,7 +22,6 @@ import us.dot.its.jpo.ode.api.models.postgres.tables.Organization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuModel;
-import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
 import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOrganization;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpCredential;
 import us.dot.its.jpo.ode.api.models.postgres.tables.SnmpProtocol;
@@ -34,7 +33,6 @@ import us.dot.its.jpo.ode.api.repositories.RsuCredentialRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuIntersectionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuOrganizationRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuModelRepository;
-import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
 import us.dot.its.jpo.ode.api.repositories.RsuRepository;
 import us.dot.its.jpo.ode.api.repositories.ScmsHealthRepository;
 import us.dot.its.jpo.ode.api.repositories.SnmpCredentialRepository;
@@ -88,8 +86,6 @@ class RsuManagementServiceTest {
     @Mock
     private RsuRepository rsuRepository;
 
-    @Mock
-    private RsuOptionRepository rsuOptionRepository;
 
     @Mock
     private ScmsHealthRepository scmsHealthRepository;
@@ -912,173 +908,6 @@ void testHandleOrganizationChanges_EmptyRemoveList() throws UnknownHostException
 
     verify(rsuOrganizationRepository, never()).delete(any(RsuOrganization.class));
 }
-
-    // ==================== RSU OPTIONS TESTS ====================
-
-    @Test
-    void testModifyRsu_CreateNewRsuOptions_BothFields() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-        String username = "testuser@example.com";
-
-        RsuPatch patch = new RsuPatch();
-        patch.setTimDeposit(true);
-        patch.setSnmpMonitoring(true);
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setId(1);
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new HashSet<>());
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(rsuOptionRepository.findById(1)).thenReturn(Optional.empty());
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
-
-        rsuManagementService.modifyRsu(rsuIp, patch, username);
-
-        // Verify that RsuOption was created and saved with correct values
-        verify(rsuOptionRepository).findById(1);
-        verify(rsuOptionRepository).save(any(RsuOption.class));
-
-        // Verify the bidirectional association was set
-        assertNotNull(existingRsu.getRsuOption());
-        assertEquals(true, existingRsu.getRsuOption().getTimDeposit());
-        assertEquals(true, existingRsu.getRsuOption().getSnmpMonitoring());
-    }
-
-    @Test
-    void testModifyRsu_CreateNewRsuOptions_SingleField() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-        String username = "testuser@example.com";
-
-        RsuPatch patch = new RsuPatch();
-        patch.setTimDeposit(true);
-        // snmpMonitoring is not set
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setId(2);
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new HashSet<>());
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(rsuOptionRepository.findById(2)).thenReturn(Optional.empty());
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
-
-        rsuManagementService.modifyRsu(rsuIp, patch, username);
-
-        // Verify that RsuOption was created with default for unset field
-        verify(rsuOptionRepository).findById(2);
-        verify(rsuOptionRepository).save(any(RsuOption.class));
-
-        // Verify the bidirectional association was set and defaults applied
-        assertNotNull(existingRsu.getRsuOption());
-        assertEquals(true, existingRsu.getRsuOption().getTimDeposit());
-        assertEquals(false, existingRsu.getRsuOption().getSnmpMonitoring()); // default value
-    }
-
-    @Test
-    void testModifyRsu_UpdateExistingRsuOptions_BothFields() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-        String username = "testuser@example.com";
-
-        RsuPatch patch = new RsuPatch();
-        patch.setTimDeposit(false);
-        patch.setSnmpMonitoring(true);
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setId(3);
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new HashSet<>());
-
-        RsuOption existingOption = new RsuOption();
-        existingOption.setId(3);
-        existingOption.setRsu(existingRsu);
-        existingOption.setTimDeposit(true); // old value
-        existingOption.setSnmpMonitoring(false); // old value
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(rsuOptionRepository.findById(3)).thenReturn(Optional.of(existingOption));
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
-
-        rsuManagementService.modifyRsu(rsuIp, patch, username);
-
-        // Verify that existing RsuOption was updated
-        verify(rsuOptionRepository).findById(3);
-        verify(rsuOptionRepository).save(existingOption);
-        assertEquals(false, existingOption.getTimDeposit());
-        assertEquals(true, existingOption.getSnmpMonitoring());
-    }
-
-    @Test
-    void testModifyRsu_UpdateExistingRsuOptions_PartialUpdate() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-        String username = "testuser@example.com";
-
-        RsuPatch patch = new RsuPatch();
-        patch.setSnmpMonitoring(true);
-        // timDeposit is not set, should not change existing value
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setId(4);
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new HashSet<>());
-
-        RsuOption existingOption = new RsuOption();
-        existingOption.setId(4);
-        existingOption.setRsu(existingRsu);
-        existingOption.setTimDeposit(true); // should remain unchanged
-        existingOption.setSnmpMonitoring(false); // should be updated
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(rsuOptionRepository.findById(4)).thenReturn(Optional.of(existingOption));
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
-
-        rsuManagementService.modifyRsu(rsuIp, patch, username);
-
-        // Verify that only snmpMonitoring was updated
-        verify(rsuOptionRepository).findById(4);
-        verify(rsuOptionRepository).save(existingOption);
-        assertEquals(true, existingOption.getTimDeposit()); // unchanged
-        assertEquals(true, existingOption.getSnmpMonitoring()); // updated
-    }
-
-    @Test
-    void testModifyRsu_NoRsuOptionsProvided_SkipsUpdate() throws UnknownHostException {
-        String rsuIp = "192.168.1.100";
-        InetAddress inetAddress = InetAddress.getByName(rsuIp);
-        String username = "testuser@example.com";
-
-        RsuPatch patch = new RsuPatch();
-        patch.setMilepost(150.0);
-        // No timDeposit or snmpMonitoring set
-
-        Rsu existingRsu = new Rsu();
-        existingRsu.setId(5);
-        existingRsu.setIpv4Address(inetAddress);
-        existingRsu.setRsuOrganizations(new HashSet<>());
-
-        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
-        when(rsuRepository.save(existingRsu)).thenReturn(existingRsu);
-        when(rsuMapper.toDto(existingRsu)).thenReturn(null);
-        when(permissionService.getQualifiedOrgList(username, "ADMIN")).thenReturn(List.of("Org1"));
-
-        rsuManagementService.modifyRsu(rsuIp, patch, username);
-
-        // Verify that RsuOption repository was never accessed
-        verify(rsuOptionRepository, never()).findById(any());
-        verify(rsuOptionRepository, never()).save(any());
-    }
 
 
     // ==================== DELETE RSU TESTS ====================

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementServiceTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/services/RsuOptionManagementServiceTest.java
@@ -1,0 +1,381 @@
+package us.dot.its.jpo.ode.api.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import us.dot.its.jpo.ode.api.models.devices.management.RsuPatch;
+import us.dot.its.jpo.ode.api.models.postgres.tables.Rsu;
+import us.dot.its.jpo.ode.api.models.postgres.tables.RsuOption;
+import us.dot.its.jpo.ode.api.repositories.RsuOptionRepository;
+import us.dot.its.jpo.ode.api.repositories.RsuRepository;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RsuOptionManagementServiceTest {
+
+    @Mock
+    private RsuRepository rsuRepository;
+
+    @Mock
+    private RsuOptionRepository rsuOptionRepository;
+
+    @InjectMocks
+    private RsuOptionManagementService rsuOptionManagementService;
+
+    // ==================== CREATE NEW RSU OPTION TESTS ====================
+
+    @Test
+    void testModifyRsuOption_CreateNewRsuOption_BothFields() throws UnknownHostException {
+        String rsuIp = "192.168.1.100";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+        patch.setSnmpMonitoring(true);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(1);
+        existingRsu.setIpv4Address(inetAddress);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(1)).thenReturn(Optional.empty());
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that RsuOption was created and saved with correct values
+        verify(rsuOptionRepository).findByRsuId(1);
+
+        ArgumentCaptor<RsuOption> optionCaptor = ArgumentCaptor.forClass(RsuOption.class);
+        verify(rsuOptionRepository).save(optionCaptor.capture());
+
+        RsuOption savedOption = optionCaptor.getValue();
+        assertNotNull(savedOption);
+        assertEquals(true, savedOption.getTimDeposit());
+        assertEquals(true, savedOption.getSnmpMonitoring());
+        assertEquals(existingRsu, savedOption.getRsu());
+    }
+
+    @Test
+    void testModifyRsuOption_CreateNewRsuOption_TimDepositOnly() throws UnknownHostException {
+        String rsuIp = "192.168.1.101";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+        // snmpMonitoring is not set
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(2);
+        existingRsu.setIpv4Address(inetAddress);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(2)).thenReturn(Optional.empty());
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that RsuOption was created with tim_deposit set and default for snmp_monitoring
+        verify(rsuOptionRepository).findByRsuId(2);
+
+        ArgumentCaptor<RsuOption> optionCaptor = ArgumentCaptor.forClass(RsuOption.class);
+        verify(rsuOptionRepository).save(optionCaptor.capture());
+
+        RsuOption savedOption = optionCaptor.getValue();
+        assertNotNull(savedOption);
+        assertEquals(true, savedOption.getTimDeposit());
+        assertEquals(false, savedOption.getSnmpMonitoring()); // default value
+        assertEquals(existingRsu, savedOption.getRsu());
+    }
+
+    @Test
+    void testModifyRsuOption_CreateNewRsuOption_SnmpMonitoringOnly() throws UnknownHostException {
+        String rsuIp = "192.168.1.102";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setSnmpMonitoring(true);
+        // timDeposit is not set
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(3);
+        existingRsu.setIpv4Address(inetAddress);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(3)).thenReturn(Optional.empty());
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that RsuOption was created with snmp_monitoring set and default for tim_deposit
+        verify(rsuOptionRepository).findByRsuId(3);
+
+        ArgumentCaptor<RsuOption> optionCaptor = ArgumentCaptor.forClass(RsuOption.class);
+        verify(rsuOptionRepository).save(optionCaptor.capture());
+
+        RsuOption savedOption = optionCaptor.getValue();
+        assertNotNull(savedOption);
+        assertEquals(false, savedOption.getTimDeposit()); // default value
+        assertEquals(true, savedOption.getSnmpMonitoring());
+        assertEquals(existingRsu, savedOption.getRsu());
+    }
+
+    // ==================== UPDATE EXISTING RSU OPTION TESTS ====================
+
+    @Test
+    void testModifyRsuOption_UpdateExistingOption_BothFields() throws UnknownHostException {
+        String rsuIp = "192.168.1.103";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(false);
+        patch.setSnmpMonitoring(true);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(4);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(4);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // old value
+        existingOption.setSnmpMonitoring(false); // old value
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(4)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that existing RsuOption was updated
+        verify(rsuOptionRepository).findByRsuId(4);
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(false, existingOption.getTimDeposit());
+        assertEquals(true, existingOption.getSnmpMonitoring());
+    }
+
+    @Test
+    void testModifyRsuOption_UpdateExistingOption_TimDepositOnly() throws UnknownHostException {
+        String rsuIp = "192.168.1.104";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(false);
+        // snmpMonitoring is not set, should not change existing value
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(5);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(5);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // should be updated
+        existingOption.setSnmpMonitoring(true); // should remain unchanged
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(5)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that only timDeposit was updated
+        verify(rsuOptionRepository).findByRsuId(5);
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(false, existingOption.getTimDeposit()); // updated
+        assertEquals(true, existingOption.getSnmpMonitoring()); // unchanged
+    }
+
+    @Test
+    void testModifyRsuOption_UpdateExistingOption_SnmpMonitoringOnly() throws UnknownHostException {
+        String rsuIp = "192.168.1.105";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setSnmpMonitoring(false);
+        // timDeposit is not set, should not change existing value
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(6);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(6);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // should remain unchanged
+        existingOption.setSnmpMonitoring(true); // should be updated
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(6)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that only snmpMonitoring was updated
+        verify(rsuOptionRepository).findByRsuId(6);
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(true, existingOption.getTimDeposit()); // unchanged
+        assertEquals(false, existingOption.getSnmpMonitoring()); // updated
+    }
+
+    @Test
+    void testModifyRsuOption_UpdateExistingOption_NoChanges() throws UnknownHostException {
+        String rsuIp = "192.168.1.106";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+        patch.setSnmpMonitoring(false);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(7);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(7);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true); // same as patch
+        existingOption.setSnmpMonitoring(false); // same as patch
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(7)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that no save occurred since values are unchanged
+        verify(rsuOptionRepository).findByRsuId(7);
+        verify(rsuOptionRepository, never()).save(any());
+    }
+
+    // ==================== EARLY RETURN TESTS ====================
+
+    @Test
+    void testModifyRsuOption_NoOptionsProvided_EarlyReturn() throws UnknownHostException {
+        String rsuIp = "192.168.1.107";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        // No timDeposit or snmpMonitoring set
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(8);
+        existingRsu.setIpv4Address(inetAddress);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that RsuOption repository was never accessed
+        verify(rsuOptionRepository, never()).findByRsuId(any());
+        verify(rsuOptionRepository, never()).save(any());
+    }
+
+    // ==================== ERROR HANDLING TESTS ====================
+
+    @Test
+    void testModifyRsuOption_InvalidIpAddress_ThrowsBadRequest() {
+        String invalidIp = "invalid-ip";
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            rsuOptionManagementService.modifyRsuOption(invalidIp, patch);
+        });
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertTrue(exception.getReason().contains("Invalid IP address"));
+        verify(rsuOptionRepository, never()).findByRsuId(any());
+        verify(rsuOptionRepository, never()).save(any());
+    }
+
+    @Test
+    void testModifyRsuOption_RsuNotFound_ThrowsNotFound() throws UnknownHostException {
+        String rsuIp = "192.168.1.108";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(true);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertTrue(exception.getReason().contains("RSU not found"));
+        verify(rsuOptionRepository, never()).findByRsuId(any());
+        verify(rsuOptionRepository, never()).save(any());
+    }
+
+    // ==================== EDGE CASE TESTS ====================
+
+    @Test
+    void testModifyRsuOption_SetBothFieldsToFalse() throws UnknownHostException {
+        String rsuIp = "192.168.1.109";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(false);
+        patch.setSnmpMonitoring(false);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(9);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(9);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true);
+        existingOption.setSnmpMonitoring(true);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(9)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that both fields were set to false
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(false, existingOption.getTimDeposit());
+        assertEquals(false, existingOption.getSnmpMonitoring());
+    }
+
+    @Test
+    void testModifyRsuOption_ToggleValues() throws UnknownHostException {
+        String rsuIp = "192.168.1.110";
+        InetAddress inetAddress = InetAddress.getByName(rsuIp);
+
+        RsuPatch patch = new RsuPatch();
+        patch.setTimDeposit(false);
+        patch.setSnmpMonitoring(true);
+
+        Rsu existingRsu = new Rsu();
+        existingRsu.setId(10);
+        existingRsu.setIpv4Address(inetAddress);
+
+        RsuOption existingOption = new RsuOption();
+        existingOption.setId(10);
+        existingOption.setRsu(existingRsu);
+        existingOption.setTimDeposit(true);
+        existingOption.setSnmpMonitoring(false);
+
+        when(rsuRepository.findByIpv4Address(inetAddress)).thenReturn(existingRsu);
+        when(rsuOptionRepository.findByRsuId(10)).thenReturn(Optional.of(existingOption));
+
+        rsuOptionManagementService.modifyRsuOption(rsuIp, patch);
+
+        // Verify that values were toggled
+        verify(rsuOptionRepository).save(existingOption);
+        assertEquals(false, existingOption.getTimDeposit());
+        assertEquals(true, existingOption.getSnmpMonitoring());
+    }
+}
+

--- a/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
+++ b/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
@@ -183,12 +183,12 @@ const AdminEditRsu = () => {
       }
 
       // Check if tim_deposit changed
-      if (data.tim_deposit !== rsuInfo?.tim_deposit) {
+      if (data.tim_deposit !== (rsuInfo?.tim_deposit ?? false)) {
         patch.tim_deposit = data.tim_deposit
       }
 
       // Check if snmp_monitoring changed
-      if (data.snmp_monitoring !== rsuInfo?.snmp_monitoring) {
+      if (data.snmp_monitoring !== (rsuInfo?.snmp_monitoring ?? false)) {
         patch.snmp_monitoring = data.snmp_monitoring
       }
 

--- a/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
+++ b/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
@@ -96,8 +96,6 @@ const AdminEditRsu = () => {
   const watchedSnmpGroup = watch('snmp_credential_group')
   const watchedSnmpVersion = watch('snmp_version_group')
   const watchedOrganizations = watch('organizations')
-  const watchedTimDeposit = watch('tim_deposit')
-  const watchedSnmpMonitoring = watch('snmp_monitoring')
 
   // Initialize form when RSU data loads
   useEffect(() => {
@@ -119,6 +117,8 @@ const AdminEditRsu = () => {
         snmp_credential_group: rsuInfo.snmp_credential_group,
         snmp_version_group: rsuInfo.snmp_version_group,
         organizations: rsuInfo.organizations,
+        tim_deposit: rsuInfo.tim_deposit ?? false,
+        snmp_monitoring: rsuInfo.snmp_monitoring ?? false,
       })
     }
   }, [rsuInfo, reset])
@@ -180,6 +180,16 @@ const AdminEditRsu = () => {
 
       if (orgsChanged) {
         patch.organizations = data.organizations
+      }
+
+      // Check if tim_deposit changed
+      if (data.tim_deposit !== rsuInfo?.tim_deposit) {
+        patch.tim_deposit = data.tim_deposit
+      }
+
+      // Check if snmp_monitoring changed
+      if (data.snmp_monitoring !== rsuInfo?.snmp_monitoring) {
+        patch.snmp_monitoring = data.snmp_monitoring
       }
 
       await patchRsu({ rsuIp: data.orig_ip, patch }).unwrap()

--- a/webapp/src/models/Rsu.d.ts
+++ b/webapp/src/models/Rsu.d.ts
@@ -17,6 +17,7 @@ export type AdminRsu = {
   snmp_version_group: string
   organizations: string[]
   tim_deposit: boolean
+  snmp_monitoring: boolean
 }
 
 export type AdminRsuAllowedSelections = {


### PR DESCRIPTION
# PR Details

## Description

### Problem  
RSU admin endpoints were migrated from the Python API to the Intersection API, and the webapp was updated to use the new service for RSU admin operations. As a result, the functionality introduced in #279 (support for `tim_deposit` and `snmp_monitoring`) was broken because the Intersection API did not expose or persist these fields.

### Solution  
The Intersection API has been updated to read and expose the `tim_deposit` and `snmp_monitoring` fields, restoring full functionality in the RSU admin workflow.

## How Has This Been Tested?

### Local Testing  
- Verified that toggling `tim_deposit` and `snmp_monitoring` on and off via the RSU admin page works as expected.
- Confirmed that changes persist and are reflected correctly in subsequent reads.
- Verified that deleting an RSU results in the corresponding `rsu_options` record being deleted also.

### Dev Environment Testing
- Verified that enabling `tim_deposit` through RSU admin page results in UI changing

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
