### PR TITLE
Fixed issue where dismissing a notification returns a 500 error

### DIFF
--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
@@ -20,11 +20,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.util.StringUtils;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.notifications.Notification;
 import us.dot.its.jpo.ode.api.accessors.notifications.active_notification.ActiveNotificationRepository;
@@ -106,12 +106,19 @@ public class ActiveNotificationController {
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role"),
             @ApiResponse(responseCode = "500", description = "Internal Server Error")
     })
-    public @ResponseBody ResponseEntity<String> deleteActiveNotification(@RequestBody String key) {
+    public @ResponseBody ResponseEntity<String> deleteActiveNotification(
+            @RequestParam(name = "key") String key) {
         try {
-            long count = activeNotificationRepo.delete(key.replace("\"", ""));
+            if (!StringUtils.hasText(key)) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("Missing required notification key");
+            }
+
+            String normalizedKey = key.replace("\"", "").trim();
+            long count = activeNotificationRepo.delete(normalizedKey);
             if (count == 0) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body("Active Notification with key " + key + " not found");
+                        .body("Active Notification with key " + normalizedKey + " not found");
             }
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (Exception e) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationController.java
@@ -102,7 +102,7 @@ public class ActiveNotificationController {
     @DeleteMapping(produces = "application/json")
     @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('OPERATOR')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "204", description = "Success"),
             @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or OPERATOR role"),
             @ApiResponse(responseCode = "500", description = "Internal Server Error")
     })

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/IntersectionController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/IntersectionController.java
@@ -87,8 +87,8 @@ public class IntersectionController {
         })
         public ResponseEntity<List<IntersectionReferenceData>> getIntersectionsByLocation(
                         @RequestHeader(name = "Organization", required = false) String organization,
-                        @RequestParam(name = "longitude", defaultValue = "false") Double longitude,
-                        @RequestParam(name = "latitude", defaultValue = "false") Double latitude,
+                        @RequestParam(name = "longitude", required = true) double longitude,
+                        @RequestParam(name = "latitude", required = true) double latitude,
                         @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
                 if (testData) {

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/IntersectionController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/intersections/IntersectionController.java
@@ -26,96 +26,101 @@ import us.dot.its.jpo.ode.api.services.PermissionService;
 @RestController
 @ConditionalOnProperty(name = "enable.api", havingValue = "true", matchIfMissing = false)
 @ApiResponses(value = {
-        @ApiResponse(responseCode = "401", description = "Unauthorized"),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 @RequestMapping("/intersections")
 @RequiredArgsConstructor
 public class IntersectionController {
 
-    private final ProcessedMapRepository processedMapRepo;
-    private final PermissionService permissionService;
+        private final ProcessedMapRepository processedMapRepo;
+        private final PermissionService permissionService;
 
-    @Operation(summary = "List Intersections", description = "Returns a list of intersections")
-    @RequestMapping(method = RequestMethod.GET, produces = "application/json")
-    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Success"),
-            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
-    })
-    public ResponseEntity<List<IntersectionReferenceData>> getIntersections(
-            @RequestHeader(name = "Organization", required = false) String organization,
-            @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
+        @Operation(summary = "List Intersections", description = "Returns a list of intersections")
+        @RequestMapping(method = RequestMethod.GET, produces = "application/json")
+        @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Success"),
+                        @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+        })
+        public ResponseEntity<List<IntersectionReferenceData>> getIntersections(
+                        @RequestHeader(name = "Organization", required = false) String organization,
+                        @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
-        if (testData) {
-            IntersectionReferenceData ref = new IntersectionReferenceData();
-            ref.setRsuIP("1.1.1.1");
-            ref.setIntersectionID(12109);
+                if (testData) {
+                        IntersectionReferenceData ref = new IntersectionReferenceData();
+                        ref.setRsuIP("1.1.1.1");
+                        ref.setIntersectionID(12109);
 
-            List<IntersectionReferenceData> refList = new ArrayList<>();
-            refList.add(ref);
+                        List<IntersectionReferenceData> refList = new ArrayList<>();
+                        refList.add(ref);
 
-            return ResponseEntity.ok(refList);
-        } else {
-            List<IntersectionReferenceData> allIntersections = processedMapRepo.getIntersectionIDs();
-            if (organization == null) {
-                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-                String username = PermissionService.getUsername(auth);
-                List<Integer> allowedIntersectionIds = permissionService.getAllowedIntersectionIdsByEmail(username);
-                return ResponseEntity.ok(allIntersections.stream()
-                        .filter(intersection -> allowedIntersectionIds.contains(intersection.getIntersectionID()))
-                        .collect(Collectors.toList()));
-            } else {
-                List<Integer> allowedIntersectionIds = permissionService
-                        .getAllowedIntersectionIdsByOrganization(organization);
-                return ResponseEntity.ok(allIntersections.stream()
-                        .filter(intersection -> allowedIntersectionIds.contains(intersection.getIntersectionID()))
-                        .collect(Collectors.toList()));
-            }
+                        return ResponseEntity.ok(refList);
+                } else {
+                        List<IntersectionReferenceData> allIntersections = processedMapRepo.getIntersectionIDs();
+                        if (organization == null) {
+                                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                                String username = PermissionService.getUsername(auth);
+                                List<Integer> allowedIntersectionIds = permissionService
+                                                .getAllowedIntersectionIdsByEmail(username);
+                                return ResponseEntity.ok(allIntersections.stream()
+                                                .filter(intersection -> allowedIntersectionIds
+                                                                .contains(intersection.getIntersectionID()))
+                                                .collect(Collectors.toList()));
+                        } else {
+                                List<Integer> allowedIntersectionIds = permissionService
+                                                .getAllowedIntersectionIdsByOrganization(organization);
+                                return ResponseEntity.ok(allIntersections.stream()
+                                                .filter(intersection -> allowedIntersectionIds
+                                                                .contains(intersection.getIntersectionID()))
+                                                .collect(Collectors.toList()));
+                        }
+                }
         }
-    }
 
-    @Operation(summary = "List Intersections by Location", description = "Returns a list of intersections whose bounding box contains the request point, in latitude and longitude")
-    @RequestMapping(value = "/location", method = RequestMethod.GET, produces = "application/json")
-    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Success"),
-            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
-    })
-    public ResponseEntity<List<IntersectionReferenceData>> getIntersectionsByLocation(
-            @RequestHeader(name = "Organization", required = false) String organization,
-            @RequestParam(name = "longitude", defaultValue = "false") Double longitude,
-            @RequestParam(name = "latitude", defaultValue = "false") Double latitude,
-            @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
+        @Operation(summary = "List Intersections by Location", description = "Returns a list of intersections whose bounding box contains the request point, in latitude and longitude")
+        @RequestMapping(value = "/location", method = RequestMethod.GET, produces = "application/json")
+        @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Success"),
+                        @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+        })
+        public ResponseEntity<List<IntersectionReferenceData>> getIntersectionsByLocation(
+                        @RequestHeader(name = "Organization", required = false) String organization,
+                        @RequestParam(name = "longitude", defaultValue = "false") Double longitude,
+                        @RequestParam(name = "latitude", defaultValue = "false") Double latitude,
+                        @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
-        if (testData) {
-            IntersectionReferenceData ref = new IntersectionReferenceData();
-            ref.setRsuIP("1.1.1.1");
-            ref.setIntersectionID(12109);
+                if (testData) {
+                        IntersectionReferenceData ref = new IntersectionReferenceData();
+                        ref.setRsuIP("1.1.1.1");
+                        ref.setIntersectionID(12109);
 
-            List<IntersectionReferenceData> refList = new ArrayList<>();
-            refList.add(ref);
+                        List<IntersectionReferenceData> refList = new ArrayList<>();
+                        refList.add(ref);
 
-            return ResponseEntity.ok(refList);
-        } else {
+                        return ResponseEntity.ok(refList);
+                } else {
 
-            List<IntersectionReferenceData> allIntersections = processedMapRepo
-                    .getIntersectionsContainingPoint(longitude, latitude);
-            if (organization == null) {
-                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-                String username = PermissionService.getUsername(auth);
-                List<Integer> allowedIntersectionIds = permissionService
-                        .getAllowedIntersectionIdsByEmail(username);
-                return ResponseEntity.ok(allIntersections.stream()
-                        .filter(intersection -> allowedIntersectionIds.contains(intersection.getIntersectionID()))
-                        .collect(Collectors.toList()));
-            } else {
-                List<Integer> allowedIntersectionIds = permissionService
-                        .getAllowedIntersectionIdsByOrganization(organization);
-                return ResponseEntity.ok(allIntersections.stream()
-                        .filter(intersection -> allowedIntersectionIds.contains(intersection.getIntersectionID()))
-                        .collect(Collectors.toList()));
-            }
+                        List<IntersectionReferenceData> allIntersections = processedMapRepo
+                                        .getIntersectionsContainingPoint(longitude, latitude);
+                        if (organization == null) {
+                                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                                String username = PermissionService.getUsername(auth);
+                                List<Integer> allowedIntersectionIds = permissionService
+                                                .getAllowedIntersectionIdsByEmail(username);
+                                return ResponseEntity.ok(allIntersections.stream()
+                                                .filter(intersection -> allowedIntersectionIds
+                                                                .contains(intersection.getIntersectionID()))
+                                                .collect(Collectors.toList()));
+                        } else {
+                                List<Integer> allowedIntersectionIds = permissionService
+                                                .getAllowedIntersectionIdsByOrganization(organization);
+                                return ResponseEntity.ok(allIntersections.stream()
+                                                .filter(intersection -> allowedIntersectionIds
+                                                                .contains(intersection.getIntersectionID()))
+                                                .collect(Collectors.toList()));
+                        }
+                }
         }
-    }
 }

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
@@ -58,9 +58,6 @@ public class ActiveNotificationControllerTest {
 
         @Test
         public void testActiveNotification() {
-                List<Integer> allowedInteresections = new ArrayList<>();
-                allowedInteresections.add(null);
-
                 when(permissionService.hasIntersection(null, "USER")).thenReturn(true);
                 when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
 

--- a/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
+++ b/services/intersection-api/api/src/test/java/us/dot/its/jpo/ode/api/controllers/intersections/ActiveNotificationControllerTest.java
@@ -43,186 +43,186 @@ import us.dot.its.jpo.ode.mockdata.MockNotificationGenerator;
 @Import(TestcontainersConfiguration.class)
 public class ActiveNotificationControllerTest {
 
-    private final ActiveNotificationController controller;
+        private final ActiveNotificationController controller;
 
-    @MockitoBean
-    ActiveNotificationRepository activeNotificationRepo;
+        @MockitoBean
+        ActiveNotificationRepository activeNotificationRepo;
 
-    @MockitoBean
-    PermissionService permissionService;
+        @MockitoBean
+        PermissionService permissionService;
 
-    @Autowired
-    public ActiveNotificationControllerTest(ActiveNotificationController controller) {
-        this.controller = controller;
-    }
+        @Autowired
+        public ActiveNotificationControllerTest(ActiveNotificationController controller) {
+                this.controller = controller;
+        }
 
-    @Test
-    public void testActiveNotification() {
-        List<Integer> allowedInteresections = new ArrayList<>();
-        allowedInteresections.add(null);
+        @Test
+        public void testActiveNotification() {
+                List<Integer> allowedInteresections = new ArrayList<>();
+                allowedInteresections.add(null);
 
-        when(permissionService.hasIntersection(null, "USER")).thenReturn(true);
-        when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
+                when(permissionService.hasIntersection(null, "USER")).thenReturn(true);
+                when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
 
-        SpatBroadcastRateNotification spatBroadcastRateNotification = MockNotificationGenerator
-                .getSpatBroadcastRateNotification();
-        SignalStateConflictNotification signalStateConflictNotification = MockNotificationGenerator
-                .getSignalStateConflictNotification();
-        SignalGroupAlignmentNotification signalGroupAlignmentNotification = MockNotificationGenerator
-                .getSignalGroupAlignmentNotification();
-        MapBroadcastRateNotification mapBroadcastRateNotification = MockNotificationGenerator
-                .getMapBroadcastRateNotification();
-        LaneDirectionOfTravelNotification laneDirectionOfTravelNotification = MockNotificationGenerator
-                .getLaneDirectionOfTravelNotification();
-        ConnectionOfTravelNotification connectionOfTravelNotification = MockNotificationGenerator
-                .getConnectionOfTravelNotification();
+                SpatBroadcastRateNotification spatBroadcastRateNotification = MockNotificationGenerator
+                                .getSpatBroadcastRateNotification();
+                SignalStateConflictNotification signalStateConflictNotification = MockNotificationGenerator
+                                .getSignalStateConflictNotification();
+                SignalGroupAlignmentNotification signalGroupAlignmentNotification = MockNotificationGenerator
+                                .getSignalGroupAlignmentNotification();
+                MapBroadcastRateNotification mapBroadcastRateNotification = MockNotificationGenerator
+                                .getMapBroadcastRateNotification();
+                LaneDirectionOfTravelNotification laneDirectionOfTravelNotification = MockNotificationGenerator
+                                .getLaneDirectionOfTravelNotification();
+                ConnectionOfTravelNotification connectionOfTravelNotification = MockNotificationGenerator
+                                .getConnectionOfTravelNotification();
 
-        List<Notification> notifications = new ArrayList<>();
-        notifications.add(spatBroadcastRateNotification);
-        notifications.add(signalStateConflictNotification);
-        notifications.add(signalGroupAlignmentNotification);
-        notifications.add(mapBroadcastRateNotification);
-        notifications.add(laneDirectionOfTravelNotification);
-        notifications.add(connectionOfTravelNotification);
+                List<Notification> notifications = new ArrayList<>();
+                notifications.add(spatBroadcastRateNotification);
+                notifications.add(signalStateConflictNotification);
+                notifications.add(signalGroupAlignmentNotification);
+                notifications.add(mapBroadcastRateNotification);
+                notifications.add(laneDirectionOfTravelNotification);
+                notifications.add(connectionOfTravelNotification);
 
-        PageRequest page = PageRequest.of(1, 1);
-        when(activeNotificationRepo.find(null,
-                null,
-                null, PageRequest.of(1, 1)))
-                .thenReturn(new PageImpl<>(notifications, page, 1L));
+                PageRequest page = PageRequest.of(1, 1);
+                when(activeNotificationRepo.find(null,
+                                null,
+                                null, PageRequest.of(1, 1)))
+                                .thenReturn(new PageImpl<>(notifications, page, 1L));
 
-        ResponseEntity<Page<Notification>> result = controller
-                .findActiveNotifications(
-                        null, null, null, 1, 1, false);
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody().getContent()).isEqualTo(notifications);
-    }
+                ResponseEntity<Page<Notification>> result = controller
+                                .findActiveNotifications(
+                                                null, null, null, 1, 1, false);
+                assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(result.getBody().getContent()).isEqualTo(notifications);
+        }
 
-    @Test
-    void testFindActiveNotificationWithTestData() {
-        Notification event = MockNotificationGenerator.getConnectionOfTravelNotification();
+        @Test
+        void testFindActiveNotificationWithTestData() {
+                Notification event = MockNotificationGenerator.getConnectionOfTravelNotification();
 
-        List<Notification> events = new ArrayList<>();
-        events.add(event);
+                List<Notification> events = new ArrayList<>();
+                events.add(event);
 
-        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-        when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
-        boolean testData = true;
+                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+                when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
+                boolean testData = true;
 
-        ResponseEntity<Page<Notification>> response = controller
-                .findActiveNotifications(event.getIntersectionID(), null, null,
-                        0, 10,
-                        testData);
+                ResponseEntity<Page<Notification>> response = controller
+                                .findActiveNotifications(event.getIntersectionID(), null, null,
+                                                0, 10,
+                                                testData);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertFalse(response.getBody().getContent().isEmpty());
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertFalse(response.getBody().getContent().isEmpty());
+        }
 
-    @Test
-    void testFindActiveNotificationsWithPagination() {
-        Notification event = MockNotificationGenerator.getConnectionOfTravelNotification();
+        @Test
+        void testFindActiveNotificationsWithPagination() {
+                Notification event = MockNotificationGenerator.getConnectionOfTravelNotification();
 
-        List<Notification> events = new ArrayList<>();
-        events.add(event);
+                List<Notification> events = new ArrayList<>();
+                events.add(event);
 
-        when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
-        when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
+                when(permissionService.hasIntersection(event.getIntersectionID(), "USER")).thenReturn(true);
+                when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
 
-        Page<Notification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
-        when(activeNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
-                any(PageRequest.class)))
-                .thenReturn(mockPage);
+                Page<Notification> mockPage = new PageImpl<>(events, PageRequest.of(0, 10), 1);
+                when(activeNotificationRepo.find(eq(event.getIntersectionID()), any(), any(),
+                                any(PageRequest.class)))
+                                .thenReturn(mockPage);
 
-        ResponseEntity<Page<Notification>> response = controller
-                .findActiveNotifications(event.getIntersectionID(), null, null,
-                        0, 10,
-                        false);
+                ResponseEntity<Page<Notification>> response = controller
+                                .findActiveNotifications(event.getIntersectionID(), null, null,
+                                                0, 10,
+                                                false);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getContent()).isEqualTo(events);
-        verify(activeNotificationRepo, times(1))
-                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody().getContent()).isEqualTo(events);
+                verify(activeNotificationRepo, times(1))
+                                .find(eq(event.getIntersectionID()), any(), any(), any(PageRequest.class));
+        }
 
-    @Test
-    public void testCountActiveNotificationsWithTestData() {
-        Integer intersectionID = 1;
-        boolean testData = true;
+        @Test
+        public void testCountActiveNotificationsWithTestData() {
+                Integer intersectionID = 1;
+                boolean testData = true;
 
-        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-        when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
+                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+                when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
 
-        ResponseEntity<Long> response = controller.countActiveNotifications(intersectionID,
-                null, null, testData);
+                ResponseEntity<Long> response = controller.countActiveNotifications(intersectionID,
+                                null, null, testData);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).isEqualTo(1L); // Test data should return 1L
+        }
 
-    @Test
-    public void testCountActiveNotifications() {
-        Integer intersectionID = 1;
-        String notificationType = "notification_type";
-        String key = "key";
-        Long expectedCount = 5L;
+        @Test
+        public void testCountActiveNotifications() {
+                Integer intersectionID = 1;
+                String notificationType = "notification_type";
+                String key = "key";
+                Long expectedCount = 5L;
 
-        when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
-        when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
-        when(activeNotificationRepo.count(intersectionID, notificationType, key))
-                .thenReturn(expectedCount);
+                when(permissionService.hasIntersection(intersectionID, "USER")).thenReturn(true);
+                when(permissionService.hasRole(UserRole.USER)).thenReturn(true);
+                when(activeNotificationRepo.count(intersectionID, notificationType, key))
+                                .thenReturn(expectedCount);
 
-        ResponseEntity<Long> response = controller.countActiveNotifications(intersectionID,
-                notificationType, key, false);
+                ResponseEntity<Long> response = controller.countActiveNotifications(intersectionID,
+                                notificationType, key, false);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(expectedCount);
-        verify(activeNotificationRepo, times(1)).count(intersectionID, notificationType, key);
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).isEqualTo(expectedCount);
+                verify(activeNotificationRepo, times(1)).count(intersectionID, notificationType, key);
+        }
 
-    @Test
-    public void testDeleteActiveNotifications() {
-        String key = "key";
+        @Test
+        public void testDeleteActiveNotifications() {
+                String key = "key";
 
-        when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
-        when(activeNotificationRepo.delete(key))
-                .thenReturn(1L);
+                when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
+                when(activeNotificationRepo.delete(key))
+                                .thenReturn(1L);
 
-        ResponseEntity<String> response = controller.deleteActiveNotification(key);
+                ResponseEntity<String> response = controller.deleteActiveNotification(key);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        verify(activeNotificationRepo, times(1)).delete(key);
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+                verify(activeNotificationRepo, times(1)).delete(key);
+        }
 
-    @Test
-    public void testDeleteActiveNotificationsNotFound() {
-        String key = "key";
+        @Test
+        public void testDeleteActiveNotificationsNotFound() {
+                String key = "key";
 
-        when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
-        when(activeNotificationRepo.delete(key))
-                .thenReturn(0L);
+                when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
+                when(activeNotificationRepo.delete(key))
+                                .thenReturn(0L);
 
-        ResponseEntity<String> response = controller.deleteActiveNotification(key);
+                ResponseEntity<String> response = controller.deleteActiveNotification(key);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        verify(activeNotificationRepo, times(1)).delete(key);
-    }
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+                verify(activeNotificationRepo, times(1)).delete(key);
+        }
 
-    @Test
-    public void testDeleteActiveNotificationsThrowsException() {
-        String key = "key";
-        RuntimeException repoException = new RuntimeException("repo error");
+        @Test
+        public void testDeleteActiveNotificationsThrowsException() {
+                String key = "key";
+                RuntimeException repoException = new RuntimeException("repo error");
 
-        when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
-        when(activeNotificationRepo.delete(key)).thenThrow(repoException);
+                when(permissionService.hasRole(UserRole.OPERATOR)).thenReturn(true);
+                when(activeNotificationRepo.delete(key)).thenThrow(repoException);
 
-        ResponseStatusException thrown = assertThrows(
-                ResponseStatusException.class,
-                () -> controller.deleteActiveNotification(key));
+                ResponseStatusException thrown = assertThrows(
+                                ResponseStatusException.class,
+                                () -> controller.deleteActiveNotification(key));
 
-        assertThat(thrown.getReason())
-                .isEqualTo("Failed to delete Active Notification: " + repoException.getMessage());
-        assertThat(thrown.getCause()).isEqualTo(repoException);
-        verify(activeNotificationRepo, times(1)).delete(key);
-    }
+                assertThat(thrown.getReason())
+                                .isEqualTo("Failed to delete Active Notification: " + repoException.getMessage());
+                assertThat(thrown.getCause()).isEqualTo(repoException);
+                verify(activeNotificationRepo, times(1)).delete(key);
+        }
 
 }

--- a/webapp/src/apis/intersections/notification-api.ts
+++ b/webapp/src/apis/intersections/notification-api.ts
@@ -63,7 +63,7 @@ class NotificationApi {
           method: 'DELETE',
           abortController,
           token: token,
-          body: id.toString(),
+          queryParams: { key: id.toString() },
           booleanResponse: true,
           tag: 'intersection',
         }))
@@ -73,7 +73,7 @@ class NotificationApi {
     } else {
       toast.error(`Failed to Dismiss some Notifications`)
     }
-    return true
+    return success
   }
 
   async getAllNotifications({


### PR DESCRIPTION
This PR fixes a problem where the notification deletion endpoint is improperly passed to the API endpoint as an improperly encoded request body, this results in a 500 error from the API. This issue can be replicated by trying to dismiss a notification from the intersection page of the CV-Manager GUI.  This PR fixes the issue by passing the notification ID as a url parameter instead which simplifies the procedure. Additionally this PR adjusts the return value of the api call in the front end so that it returns whether the notification deletion succeeded or failed properly. 

This PR also fixes a minor bug where the default arguments for the getIntersectionsByLocation function are booleans while the values they represent should be doubles. Since these parameters are actually required, the incorrect defaults were removed and the function arguments were marked as required.