### PR TITLE
Improved RSU Pinger Service

### DIFF
--- a/services/addons/images/rsu_status_check/README.md
+++ b/services/addons/images/rsu_status_check/README.md
@@ -52,8 +52,8 @@ To properly run the rsu_ping_fetch service the following additional services are
 
 The rsu_ping_fetch service expects the following environment variables to be set:
 
-- RSU_PING = True
 - ZABBIX = True
+- RSU_PING = False
 - ZABBIX_ENDPOINT - Zabbix API access endpoint.
 - ZABBIX_USER - Zabbix API access username.
 - ZABBIX_PASSWORD - Zabbix API access password.

--- a/services/addons/images/rsu_status_check/rsu_ping_fetch.py
+++ b/services/addons/images/rsu_status_check/rsu_ping_fetch.py
@@ -145,7 +145,7 @@ class RsuStatusFetch:
 
 if __name__ == "__main__":
     run_service = (
-        rsu_status_check_environment.RSU_PING and rsu_status_check_environment.ZABBIX
+        rsu_status_check_environment.ZABBIX and not rsu_status_check_environment.RSU_PING
     )
     if not run_service:
         logging.info("The rsu-ping-fetch service is disabled and will not run")

--- a/services/addons/images/rsu_status_check/rsu_pinger.py
+++ b/services/addons/images/rsu_status_check/rsu_pinger.py
@@ -9,7 +9,7 @@ import rsu_status_check_environment
 
 def calculate_max_workers(rsu_count):
     """
-    Scale workers with list size, but keep concurrency well below 1:1 fanout.
+    Scale workers with list size, using a minimum of 20 workers (except when rsu_count <= 0) and a maximum of 120.
     """
     if rsu_count <= 0:
         return 1

--- a/services/addons/images/rsu_status_check/rsu_pinger.py
+++ b/services/addons/images/rsu_status_check/rsu_pinger.py
@@ -29,7 +29,7 @@ def insert_ping_data(ping_data, ping_time):
 
 def ping_single_rsu(rsu, retries=2):
     """
-    Ping a single RSU with retries.
+    Ping a single RSU, retrying up to `retries` total attempts.
     Returns tuple: (rsu_id, status)
     """
 

--- a/services/addons/images/rsu_status_check/rsu_pinger.py
+++ b/services/addons/images/rsu_status_check/rsu_pinger.py
@@ -2,8 +2,18 @@ import logging
 import time
 import common.pgquery as pgquery
 from datetime import datetime
-from subprocess import Popen, DEVNULL
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import rsu_status_check_environment
+
+
+def calculate_max_workers(rsu_count):
+    """
+    Scale workers with list size, but keep concurrency well below 1:1 fanout.
+    """
+    if rsu_count <= 0:
+        return 1
+    return min(120, max(20, rsu_count // 8))
 
 
 def insert_ping_data(ping_data, ping_time):
@@ -17,30 +27,69 @@ def insert_ping_data(ping_data, ping_time):
     pgquery.write_db(query)
 
 
+def ping_single_rsu(rsu, retries=2):
+    """
+    Ping a single RSU with retries.
+    Returns tuple: (rsu_id, status)
+    """
+
+    rsu_id = rsu[0]
+    ip_address = rsu[1]
+
+    for attempt in range(retries):
+        try:
+            result = subprocess.run(
+                ["ping", "-n", "-c", "1", "-W", "2", ip_address],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=3,
+            )
+
+            if result.returncode == 0:
+                logging.debug("%s active", rsu_id)
+                return rsu_id, "1"
+
+        except subprocess.TimeoutExpired:
+            logging.debug("%s ping timeout attempt %s", rsu_id, attempt + 1)
+        except Exception as ex:
+            logging.warning(
+                "%s ping command failed on attempt %s: %s", rsu_id, attempt + 1, ex
+            )
+            return rsu_id, "0"
+
+    logging.debug("%s no response", rsu_id)
+    return rsu_id, "0"
+
+
 def ping_rsu_ips(rsu_list):
-    p = {}
-    # Start ping processes
-    for rsu in rsu_list:
-        # id: rsu_id
-        # key: process pinging the RSU's ipv4_address
-        p[rsu[0]] = Popen(["ping", "-n", "-w20", "-c1", rsu[1]], stdout=DEVNULL)
-
     ping_data = {}
-    while p:
-        for rsu_id, proc in p.items():
-            # Check if process has ended
-            if proc.poll() is not None:
-                del p[rsu_id]
+    future_to_rsu_id = {}
+    max_workers = calculate_max_workers(len(rsu_list))
 
-                if proc.returncode == 0:
-                    # Active
-                    logging.debug("%s active" % rsu_id)
-                    ping_data[rsu_id] = "1"
-                else:
-                    # Offline/Unresponsive
-                    logging.debug("%s no response" % rsu_id)
+    # Limit concurrency
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+
+        futures = [executor.submit(ping_single_rsu, rsu) for rsu in rsu_list]
+        future_to_rsu_id = {future: rsu[0] for future, rsu in zip(futures, rsu_list)}
+
+        for future in as_completed(futures):
+            rsu_id = future_to_rsu_id.get(future)
+            try:
+                result = future.result()
+                if result is None:
+                    if rsu_id is not None:
+                        logging.warning("%s returned no ping result", rsu_id)
+                        ping_data[rsu_id] = "0"
+                    continue
+                rsu_id, status = result
+            except Exception as ex:
+                if rsu_id is not None:
+                    logging.warning(
+                        "%s failed with exception in worker: %s", rsu_id, ex
+                    )
                     ping_data[rsu_id] = "0"
-                break
+                continue
+            ping_data[rsu_id] = status
 
     return ping_data
 

--- a/services/addons/images/rsu_status_check/rsu_pinger.py
+++ b/services/addons/images/rsu_status_check/rsu_pinger.py
@@ -133,7 +133,7 @@ def run_rsu_pinger():
 
 if __name__ == "__main__":
     run_service = (
-        rsu_status_check_environment.RSU_PING and rsu_status_check_environment.ZABBIX
+        rsu_status_check_environment.RSU_PING and not rsu_status_check_environment.ZABBIX
     )
     if not run_service:
         logging.info("The rsu-pinger service is disabled and will not run")

--- a/services/addons/tests/rsu_status_check/test_rsu_pinger.py
+++ b/services/addons/tests/rsu_status_check/test_rsu_pinger.py
@@ -1,5 +1,5 @@
-from mock import MagicMock, call, patch
-from subprocess import DEVNULL
+import subprocess
+from mock import MagicMock, patch
 from addons.images.rsu_status_check import rsu_pinger
 
 
@@ -21,50 +21,99 @@ def test_insert_ping_data(mock_write_db):
     mock_write_db.assert_called_with(expected_query)
 
 
-@patch("addons.images.rsu_status_check.rsu_pinger.Popen")
-def test_ping_rsu_ips_online(mock_Popen):
-    mock_p = MagicMock()
-    mock_p.poll.return_value = 1
-    mock_p.returncode = 0
-    mock_Popen.return_value = mock_p
-    rsu_list = [(1, "1.1.1.1"), (2, "2.2.2.2")]
+def test_calculate_max_workers():
+    assert rsu_pinger.calculate_max_workers(0) == 1
+    assert rsu_pinger.calculate_max_workers(1) == 20
+    assert rsu_pinger.calculate_max_workers(160) == 20
+    assert rsu_pinger.calculate_max_workers(600) == 75
+    assert rsu_pinger.calculate_max_workers(10000) == 120
 
-    # call
+
+@patch("addons.images.rsu_status_check.rsu_pinger.subprocess.run")
+def test_ping_single_rsu_online(mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+
+    result = rsu_pinger.ping_single_rsu((1, "1.1.1.1"), retries=2)
+
+    assert result == (1, "1")
+    assert mock_run.call_count == 1
+    mock_run.assert_called_with(
+        ["ping", "-n", "-c", "1", "-W", "2", "1.1.1.1"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=3,
+    )
+
+
+@patch("addons.images.rsu_status_check.rsu_pinger.subprocess.run")
+def test_ping_single_rsu_offline_after_retries(mock_run):
+    mock_run.return_value = MagicMock(returncode=1)
+
+    result = rsu_pinger.ping_single_rsu((2, "2.2.2.2"), retries=2)
+
+    assert result == (2, "0")
+    assert mock_run.call_count == 2
+
+
+@patch("addons.images.rsu_status_check.rsu_pinger.subprocess.run")
+def test_ping_single_rsu_timeout_then_success(mock_run):
+    timeout_error = subprocess.TimeoutExpired(cmd="ping", timeout=3)
+    mock_run.side_effect = [timeout_error, MagicMock(returncode=0)]
+
+    result = rsu_pinger.ping_single_rsu((3, "3.3.3.3"), retries=2)
+
+    assert result == (3, "1")
+    assert mock_run.call_count == 2
+
+
+@patch("addons.images.rsu_status_check.rsu_pinger.subprocess.run")
+def test_ping_single_rsu_generic_exception_returns_immediately(mock_run):
+    mock_run.side_effect = RuntimeError("unexpected failure")
+
+    result = rsu_pinger.ping_single_rsu((4, "4.4.4.4"), retries=2)
+
+    assert result == (4, "0")
+    assert mock_run.call_count == 1
+
+
+@patch("addons.images.rsu_status_check.rsu_pinger.calculate_max_workers")
+@patch("addons.images.rsu_status_check.rsu_pinger.ping_single_rsu")
+def test_ping_rsu_ips_uses_calculated_workers_and_collects_results(
+    mock_ping_single_rsu, mock_calculate_max_workers
+):
+    rsu_list = [(1, "1.1.1.1"), (2, "2.2.2.2")]
+    mock_calculate_max_workers.return_value = 33
+    mock_ping_single_rsu.side_effect = [(1, "1"), (2, "0")]
+
     result = rsu_pinger.ping_rsu_ips(rsu_list)
 
-    # check
-    expected_result = {1: "1", 2: "1"}
-    mock_Popen.assert_has_calls(
-        [
-            call(["ping", "-n", "-w20", "-c1", "1.1.1.1"], stdout=DEVNULL),
-            call(["ping", "-n", "-w20", "-c1", "2.2.2.2"], stdout=DEVNULL),
-        ]
-    )
-    assert mock_p.poll.call_count == len(rsu_list)  # 2
-    assert result == expected_result
+    assert result == {1: "1", 2: "0"}
+    mock_calculate_max_workers.assert_called_once_with(len(rsu_list))
 
 
-@patch("addons.images.rsu_status_check.rsu_pinger.Popen")
-def test_ping_rsu_ips_offline(mock_Popen):
-    mock_p = MagicMock()
-    mock_p.poll.return_value = 1
-    mock_p.returncode = 1
-    mock_Popen.return_value = mock_p
-    rsu_list = [(1, "1.1.1.1"), (2, "2.2.2.2")]
+@patch("addons.images.rsu_status_check.rsu_pinger.ping_single_rsu")
+def test_ping_rsu_ips_worker_exception_only_affects_failed_rsu(mock_ping_single_rsu):
+    def _side_effect(rsu):
+        if rsu[0] == 2:
+            raise ValueError("worker failure")
+        return rsu[0], "1"
 
-    # call
+    rsu_list = [(1, "1.1.1.1"), (2, "2.2.2.2"), (3, "3.3.3.3")]
+    mock_ping_single_rsu.side_effect = _side_effect
+
     result = rsu_pinger.ping_rsu_ips(rsu_list)
 
-    # check
-    expected_result = {1: "0", 2: "0"}
-    mock_Popen.assert_has_calls(
-        [
-            call(["ping", "-n", "-w20", "-c1", "1.1.1.1"], stdout=DEVNULL),
-            call(["ping", "-n", "-w20", "-c1", "2.2.2.2"], stdout=DEVNULL),
-        ]
-    )
-    assert mock_p.poll.call_count == len(rsu_list)  # 2
-    assert result == expected_result
+    assert result == {1: "1", 2: "0", 3: "1"}
+
+
+@patch("addons.images.rsu_status_check.rsu_pinger.ping_single_rsu")
+def test_ping_rsu_ips_none_result_marks_rsu_offline(mock_ping_single_rsu):
+    rsu_list = [(1, "1.1.1.1"), (2, "2.2.2.2")]
+    mock_ping_single_rsu.side_effect = [(1, "1"), None]
+
+    result = rsu_pinger.ping_rsu_ips(rsu_list)
+
+    assert result == {1: "1", 2: "0"}
 
 
 @patch("addons.images.rsu_status_check.rsu_pinger.pgquery.query_db")


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Improves the reliability of the `rsu_pinger.py` script within the `rsu_status_check` Python addon service.

Previously, the pinging was best effort and did not always allow for each ping process to properly terminate before forcing it to resolve. The Python library 'subprocess' has now been leveraged to better handle the many simultaneous processes rather than manually handling 'popen' processes. Refined timeouts and retry attempts were also added to provide better fault tolerance.

A bug has been fixed regarding the logical `run_service` boolean check. This previously only would run both the `rsu_ping_fetch` AND `rsu_pinger` if both environment variables `RSU_PING` and `ZABBIX` were set to `True`. Otherwise, any other combination of values would result in both scripts not running at all. This was never the intent of this and has been modified to properly behave as a sort of XOR between the two online status collection methods.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through unit tests and within the CDOT GCP environment with their ~600 RSUs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.